### PR TITLE
BugFix: Paste Table HTML, add columnWidths props

### DIFF
--- a/packages/table-module/__tests__/menu/delete-col.test.ts
+++ b/packages/table-module/__tests__/menu/delete-col.test.ts
@@ -8,8 +8,8 @@ import * as core from '@wangeditor-next/core'
 
 jest.mock('../../src/utils', () => ({
   filledMatrix: jest.fn(),
-}));
-const mockedUtils = utils as jest.Mocked<typeof utils>;
+}))
+const mockedUtils = utils as jest.Mocked<typeof utils>
 
 function setEditorSelection(
   editor: core.IDomEditor,
@@ -147,8 +147,29 @@ describe('Table Module Delete Col Menu', () => {
     jest.spyOn(core.DomEditor, 'findPath').mockImplementation(() => [0, 1] as slate.Path)
 
     mockedUtils.filledMatrix.mockImplementation(() => {
-      return [[[[{ "type": "table-cell", "children": [{ "text": "" }], "isHeader": false }, [0, 0, 0]], { "rtl": 1, "ltr": 1, "ttb": 1, "btt": 1 }], [[{ "type": "table-cell", "children": [{ "text": "" }], "isHeader": false }, [0, 0, 1]], { "rtl": 1, "ltr": 1, "ttb": 1, "btt": 1 }]], [[[{ "type": "table-cell", "children": [{ "text": "" }] }, [0, 1, 0]], { "rtl": 1, "ltr": 1, "ttb": 1, "btt": 1 }], [[{ "type": "table-cell", "children": [{ "text": "" }] }, [0, 1, 1]], { "rtl": 1, "ltr": 1, "ttb": 1, "btt": 1 }]]]
-    });
+      return [
+        [
+          [
+            [{ type: 'table-cell', children: [{ text: '' }], isHeader: false }, [0, 0, 0]],
+            { rtl: 1, ltr: 1, ttb: 1, btt: 1 },
+          ],
+          [
+            [{ type: 'table-cell', children: [{ text: '' }], isHeader: false }, [0, 0, 1]],
+            { rtl: 1, ltr: 1, ttb: 1, btt: 1 },
+          ],
+        ],
+        [
+          [
+            [{ type: 'table-cell', children: [{ text: '' }] }, [0, 1, 0]],
+            { rtl: 1, ltr: 1, ttb: 1, btt: 1 },
+          ],
+          [
+            [{ type: 'table-cell', children: [{ text: '' }] }, [0, 1, 1]],
+            { rtl: 1, ltr: 1, ttb: 1, btt: 1 },
+          ],
+        ],
+      ]
+    })
     const removeNodesFn = jest.fn()
     jest.spyOn(slate.Transforms, 'removeNodes').mockImplementation(removeNodesFn)
 

--- a/packages/table-module/__tests__/menu/delete-row.test.ts
+++ b/packages/table-module/__tests__/menu/delete-row.test.ts
@@ -8,8 +8,8 @@ import * as core from '@wangeditor-next/core'
 
 jest.mock('../../src/utils', () => ({
   filledMatrix: jest.fn(),
-}));
-const mockedUtils = utils as jest.Mocked<typeof utils>;
+}))
+const mockedUtils = utils as jest.Mocked<typeof utils>
 
 function setEditorSelection(
   editor: core.IDomEditor,
@@ -152,8 +152,29 @@ describe('Table Module Delete Row Menu', () => {
     }
     jest.spyOn(slate.Editor, 'nodes').mockImplementation(() => fn())
     mockedUtils.filledMatrix.mockImplementation(() => {
-      return [[[[{ "type": "table-cell", "children": [{ "text": "" }], "isHeader": false }, [0, 0, 0]], { "rtl": 1, "ltr": 1, "ttb": 1, "btt": 1 }], [[{ "type": "table-cell", "children": [{ "text": "" }], "isHeader": false }, [0, 0, 1]], { "rtl": 1, "ltr": 1, "ttb": 1, "btt": 1 }]], [[[{ "type": "table-cell", "children": [{ "text": "" }] }, [0, 1, 0]], { "rtl": 1, "ltr": 1, "ttb": 1, "btt": 1 }], [[{ "type": "table-cell", "children": [{ "text": "" }] }, [0, 1, 1]], { "rtl": 1, "ltr": 1, "ttb": 1, "btt": 1 }]]]
-    });
+      return [
+        [
+          [
+            [{ type: 'table-cell', children: [{ text: '' }], isHeader: false }, [0, 0, 0]],
+            { rtl: 1, ltr: 1, ttb: 1, btt: 1 },
+          ],
+          [
+            [{ type: 'table-cell', children: [{ text: '' }], isHeader: false }, [0, 0, 1]],
+            { rtl: 1, ltr: 1, ttb: 1, btt: 1 },
+          ],
+        ],
+        [
+          [
+            [{ type: 'table-cell', children: [{ text: '' }] }, [0, 1, 0]],
+            { rtl: 1, ltr: 1, ttb: 1, btt: 1 },
+          ],
+          [
+            [{ type: 'table-cell', children: [{ text: '' }] }, [0, 1, 1]],
+            { rtl: 1, ltr: 1, ttb: 1, btt: 1 },
+          ],
+        ],
+      ]
+    })
     const removeNodesFn = jest.fn()
     jest.spyOn(slate.Transforms, 'removeNodes').mockImplementation(removeNodesFn)
 

--- a/packages/table-module/__tests__/menu/insert-col.test.ts
+++ b/packages/table-module/__tests__/menu/insert-col.test.ts
@@ -8,8 +8,8 @@ import * as core from '@wangeditor-next/core'
 
 jest.mock('../../src/utils', () => ({
   filledMatrix: jest.fn(),
-}));
-const mockedUtils = utils as jest.Mocked<typeof utils>;
+}))
+const mockedUtils = utils as jest.Mocked<typeof utils>
 
 function setEditorSelection(
   editor: core.IDomEditor,
@@ -188,8 +188,29 @@ describe('Table Module Insert Col Menu', () => {
     const insertNodesFn = jest.fn()
     jest.spyOn(slate.Transforms, 'insertNodes').mockImplementation(insertNodesFn)
     mockedUtils.filledMatrix.mockImplementation(() => {
-      return [[[[{ "type": "table-cell", "children": [{ "text": "" }], "isHeader": false }, [0, 0, 0]], { "rtl": 1, "ltr": 1, "ttb": 1, "btt": 1 }], [[{ "type": "table-cell", "children": [{ "text": "" }], "isHeader": false }, [0, 0, 1]], { "rtl": 1, "ltr": 1, "ttb": 1, "btt": 1 }]], [[[{ "type": "table-cell", "children": [{ "text": "" }] }, [0, 1, 0]], { "rtl": 1, "ltr": 1, "ttb": 1, "btt": 1 }], [[{ "type": "table-cell", "children": [{ "text": "" }] }, [0, 1, 1]], { "rtl": 1, "ltr": 1, "ttb": 1, "btt": 1 }]]]
-    });
+      return [
+        [
+          [
+            [{ type: 'table-cell', children: [{ text: '' }], isHeader: false }, [0, 0, 0]],
+            { rtl: 1, ltr: 1, ttb: 1, btt: 1 },
+          ],
+          [
+            [{ type: 'table-cell', children: [{ text: '' }], isHeader: false }, [0, 0, 1]],
+            { rtl: 1, ltr: 1, ttb: 1, btt: 1 },
+          ],
+        ],
+        [
+          [
+            [{ type: 'table-cell', children: [{ text: '' }] }, [0, 1, 0]],
+            { rtl: 1, ltr: 1, ttb: 1, btt: 1 },
+          ],
+          [
+            [{ type: 'table-cell', children: [{ text: '' }] }, [0, 1, 1]],
+            { rtl: 1, ltr: 1, ttb: 1, btt: 1 },
+          ],
+        ],
+      ]
+    })
 
     insertColMenu.exec(editor, '')
 

--- a/packages/table-module/src/module/parse-elem-html.ts
+++ b/packages/table-module/src/module/parse-elem-html.ts
@@ -74,12 +74,15 @@ function parseTableHtml(
   let width = 'auto'
   if (getStyleValue($elem, 'width') === '100%') width = '100%'
   if ($elem.attr('width') === '100%') width = '100%' // 兼容 v4 格式
-
+  let cellLength = $elem.find('tr')[0].children.length
+  console.log($elem)
   return {
     type: 'table',
     width,
     // @ts-ignore
     children: children.filter(child => DomEditor.getNodeType(child) === 'table-row'),
+
+    columnWidths: Array(cellLength).fill(180)
   }
 }
 

--- a/packages/table-module/src/module/parse-elem-html.ts
+++ b/packages/table-module/src/module/parse-elem-html.ts
@@ -75,7 +75,7 @@ function parseTableHtml(
   if (getStyleValue($elem, 'width') === '100%') width = '100%'
   if ($elem.attr('width') === '100%') width = '100%' // 兼容 v4 格式
   let cellLength = $elem.find('tr')[0].children.length
-  console.log($elem)
+
   return {
     type: 'table',
     width,


### PR DESCRIPTION
因粘贴时，缺少列宽的宽度设置，现补上

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced table module's HTML parsing logic to determine the column length and initialize column widths more accurately.
- **Tests**
  - Improved readability and structure of mock data in test files for better test setup and data representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->