### PR TITLE
fix: issues48  setHtml table error

### DIFF
--- a/packages/table-module/__tests__/parse-html.test.ts
+++ b/packages/table-module/__tests__/parse-html.test.ts
@@ -54,9 +54,10 @@ describe('table - parse html', () => {
       rowSpan: 1,
       width: 'auto',
       children: [{ text: 'hello world' }],
+      hidden: false,
     })
 
-    const $cell2 = $('<th></th>')
+    const $cell2 = $('<th style="display:none"></th>')
     const children = [{ text: 'hello ' }, { text: 'world', bold: true }]
     expect($cell2[0].matches(parseCellHtmlConf.selector)).toBeTruthy()
     expect(parseCellHtmlConf.parseElemHtml($cell2[0], children, editor)).toEqual({
@@ -66,6 +67,7 @@ describe('table - parse html', () => {
       rowSpan: 1,
       width: 'auto',
       children,
+      hidden: true,
     })
   })
 

--- a/packages/table-module/src/module/parse-elem-html.ts
+++ b/packages/table-module/src/module/parse-elem-html.ts
@@ -28,6 +28,7 @@ function parseCellHtml(
 
   const colSpan = parseInt($elem.attr('colSpan') || '1')
   const rowSpan = parseInt($elem.attr('rowSpan') || '1')
+  const hidden = getStyleValue($elem, 'display') === 'none'
   const width = $elem.attr('width') || 'auto'
 
   return {
@@ -38,6 +39,7 @@ function parseCellHtml(
     width,
     // @ts-ignore
     children,
+    hidden,
   }
 }
 


### PR DESCRIPTION
解决合并单元格，setHTML回填，td中style="display:none"被编辑器丢掉的问题，已补充单测

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced HTML parsing for table cells, introducing a `hidden` property to manage cell visibility more effectively.

- **Bug Fixes**
	- Improved handling of cell display logic, ensuring accurate representation of hidden or visible states in table rendering.

- **Documentation**
	- Updated relevant documentation to reflect changes in cell configuration and visibility handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->