### PR TITLE
feat:table echo width adaptation

### DIFF
--- a/packages/table-module/__tests__/elem-to-html.test.ts
+++ b/packages/table-module/__tests__/elem-to-html.test.ts
@@ -88,7 +88,7 @@ describe('TableModule module', () => {
       }
       const res = tableToHtmlConf.elemToHtml(element, '<tr><td>123</td></tr>')
       expect(res).toBe(
-        '<table style="width: auto;table-layout: fixed;"><tbody><tr><td>123</td></tr></tbody></table>'
+        '<table style="width: auto;table-layout: fixed;height:auto"><tbody><tr><td>123</td></tr></tbody></table>'
       )
     })
 
@@ -96,11 +96,12 @@ describe('TableModule module', () => {
       const element = {
         type: 'table',
         width: '100%',
+        height: '60px',
         children: [],
       }
       const res = tableToHtmlConf.elemToHtml(element, '<tr><td>123</td></tr>')
       expect(res).toBe(
-        '<table style="width: 100%;table-layout: fixed;"><tbody><tr><td>123</td></tr></tbody></table>'
+        '<table style="width: 100%;table-layout: fixed;height:60px"><tbody><tr><td>123</td></tr></tbody></table>'
       )
     })
   })

--- a/packages/table-module/__tests__/parse-html.test.ts
+++ b/packages/table-module/__tests__/parse-html.test.ts
@@ -98,6 +98,7 @@ describe('table - parse html', () => {
       type: 'table',
       width: '100%',
       children,
+      height: 0,
     })
   })
 })

--- a/packages/table-module/src/module/elem-to-html.ts
+++ b/packages/table-module/src/module/elem-to-html.ts
@@ -7,9 +7,16 @@ import { Element } from 'slate'
 import { TableCellElement, TableRowElement, TableElement } from './custom-types'
 
 function tableToHtml(elemNode: Element, childrenHtml: string): string {
-  const { width = 'auto' } = elemNode as TableElement
+  const { width = 'auto', columnWidths, height = 'auto' } = elemNode as TableElement
+  let cols = columnWidths
+    ?.map(width => {
+      return `<col width=${width}></col>`
+    })
+    .join('')
 
-  return `<table style="width: ${width};table-layout: fixed;"><tbody>${childrenHtml}</tbody></table>`
+  const colgroupStr = cols ? '<colgroup contentEditable="false">' + cols + '</colgroup>' : ''
+
+  return `<table style="width: ${width};table-layout: fixed;height:${height}">${colgroupStr}<tbody>${childrenHtml}</tbody></table>`
 }
 
 function tableRowToHtml(elem: Element, childrenHtml: string): string {

--- a/packages/table-module/src/module/parse-elem-html.ts
+++ b/packages/table-module/src/module/parse-elem-html.ts
@@ -77,17 +77,25 @@ function parseTableHtml(
   if (getStyleValue($elem, 'width') === '100%') width = '100%'
   if ($elem.attr('width') === '100%') width = '100%' // 兼容 v4 格式
 
+  // 计算高度
+  let height = parseInt(getStyleValue($elem, 'height') || '0')
+
   const tableELement: TableElement = {
     type: 'table',
     width,
+    height,
     // @ts-ignore
     children: children.filter(child => DomEditor.getNodeType(child) === 'table-row'),
   }
   let cellLength: number | undefined = $elem.find('tr')[0]?.children.length
-  if (cellLength > 0) {
+  let colgroupElments: HTMLCollection = $elem.find('colgroup')[0]?.children || null
+  if (colgroupElments) {
+    tableELement.columnWidths = Array.from(colgroupElments).map((col: any) => {
+      return parseInt(col.getAttribute('width'))
+    })
+  } else if (cellLength > 0) {
     tableELement.columnWidths = Array(cellLength).fill(180)
   }
-
   return tableELement
 }
 


### PR DESCRIPTION
1. 保存宽度样式
2. setHtml表格依然支持拖拽修改宽度

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced rendering capabilities for tables by introducing height specifications and improved column width handling.
	- Added support for `<colgroup>` elements to facilitate more flexible table layouts.

- **Bug Fixes**
	- Improved logic for height calculation and column widths in table parsing functions, ensuring accurate rendering of table structures.

- **Documentation**
	- Updated test cases to reflect new height and column width properties for improved clarity in table configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->