### PR TITLE
163 bug只读模式下无法复制文本内容

### DIFF
--- a/.changeset/nice-pens-kick.md
+++ b/.changeset/nice-pens-kick.md
@@ -1,0 +1,5 @@
+---
+"@wangeditor-next/core": patch
+---
+
+163 bug只读模式下无法复制文本内容

--- a/packages/core/src/text-area/event-handlers/copy.ts
+++ b/packages/core/src/text-area/event-handlers/copy.ts
@@ -11,7 +11,9 @@ function handleOnCopy(e: Event, _textarea: TextArea, editor: IDomEditor) {
   const event = e as ClipboardEvent
 
   if (!hasEditableTarget(editor, event.target)) { return }
-  event.preventDefault()
+  const { readOnly } = editor.getConfig()
+
+  if (!readOnly) { event.preventDefault() }
 
   const data = event.clipboardData
 

--- a/packages/core/src/text-area/event-handlers/copy.ts
+++ b/packages/core/src/text-area/event-handlers/copy.ts
@@ -4,18 +4,18 @@
  */
 
 import { IDomEditor } from '../../editor/interface'
-// import { DomEditor } from '../../editor/dom-editor'
-import TextArea from '../TextArea'
 import { hasEditableTarget } from '../helpers'
+import TextArea from '../TextArea'
 
-function handleOnCopy(e: Event, textarea: TextArea, editor: IDomEditor) {
+function handleOnCopy(e: Event, _textarea: TextArea, editor: IDomEditor) {
   const event = e as ClipboardEvent
 
-  if (!hasEditableTarget(editor, event.target)) return
+  if (!hasEditableTarget(editor, event.target)) { return }
   event.preventDefault()
 
   const data = event.clipboardData
-  if (data == null) return
+
+  if (data == null) { return }
   editor.setFragmentData(data)
 }
 


### PR DESCRIPTION
## Changes Overview
<!-- Briefly describe your changes. -->

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue preventing users from copying text in read-only mode within the editor.
  
- **Improvements**
	- Enhanced clarity in the copy handling functionality for better performance and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->