### PR TITLE
fix: safari img src not base64

### DIFF
--- a/.changeset/khaki-lions-notice.md
+++ b/.changeset/khaki-lions-notice.md
@@ -1,0 +1,5 @@
+---
+"@wangeditor-next/core": patch
+---
+
+fix: safari img src not base64

--- a/packages/core/src/editor/helper.ts
+++ b/packages/core/src/editor/helper.ts
@@ -1,0 +1,42 @@
+/**
+ * @description Processing blob url
+ * @author CodePencil
+ */
+
+/** 提取 blob URL */
+export function extractBlobUrlFromImg(html: string) {
+  const regex = /<img[^>]*src=["'](blob:[^"']+)["'][^>]*>/i
+  const match = html.match(regex)
+
+  return match ? match[1] : null
+}
+
+/** 将 blob URL 转换为 base64 */
+export async function convertBlobUrlToBase64(blobUrl: string) {
+  try {
+    const response = await fetch(blobUrl)
+
+    if (!response.ok) {
+      throw new Error('Failed to fetch blob URL')
+    }
+
+    const blob = await response.blob()
+
+    return new Promise<string | null>((resolve, reject) => {
+      const reader = new FileReader()
+
+      reader.onloadend = () => {
+        resolve(reader.result as string)
+      }
+
+      reader.onerror = () => {
+        reject(new Error('Failed to read blob as data URL'))
+      }
+
+      reader.readAsDataURL(blob)
+    })
+  } catch (error) {
+    console.error(error)
+    return null
+  }
+}

--- a/packages/core/src/editor/plugins/with-event-data.ts
+++ b/packages/core/src/editor/plugins/with-event-data.ts
@@ -132,6 +132,8 @@ export const withEventData = <T extends Editor>(editor: T) => {
 
         if (base64Data) {
           html = `<img src="${base64Data}" alt="image.png">`
+
+          URL.revokeObjectURL(blobUrl)
         }
       }
     }

--- a/packages/core/src/editor/plugins/with-event-data.ts
+++ b/packages/core/src/editor/plugins/with-event-data.ts
@@ -9,7 +9,9 @@ import {
 
 import { IDomEditor } from '../..'
 import { getPlainText, isDOMText } from '../../utils/dom'
+import { IS_SAFARI } from '../../utils/ua'
 import { DomEditor } from '../dom-editor'
+import { convertBlobUrlToBase64, extractBlobUrlFromImg } from '../helper'
 
 export const withEventData = <T extends Editor>(editor: T) => {
   const e = editor as T & IDomEditor
@@ -106,7 +108,7 @@ export const withEventData = <T extends Editor>(editor: T) => {
     return data
   }
 
-  e.insertData = (data: DataTransfer) => {
+  e.insertData = async (data: DataTransfer) => {
     const fragment = data.getData('application/x-slate-fragment')
     // 只有从编辑器中内复制的内容，才会获取 fragment，从其他地方粘贴到编辑器中，不会获取 fragment
 
@@ -119,8 +121,20 @@ export const withEventData = <T extends Editor>(editor: T) => {
     }
 
     const text = data.getData('text/plain')
-    const html = data.getData('text/html')
+    let html = data.getData('text/html')
     // const rtf = data.getData('text/rtf')
+
+    if (IS_SAFARI) {
+      const blobUrl = extractBlobUrlFromImg(html)
+
+      if (blobUrl) {
+        const base64Data = await convertBlobUrlToBase64(blobUrl)
+
+        if (base64Data) {
+          html = `<img src="${base64Data}" alt="image.png">`
+        }
+      }
+    }
 
     if (html) {
       e.dangerouslyInsertHtml(html)


### PR DESCRIPTION
## Changes Overview


## Implementation Approach

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
https://github.com/cycleccc/wangEditor-next/issues/70


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced functions for extracting blob URLs from HTML and converting them to Base64, enhancing image handling capabilities.
	- Improved paste operations for Safari users by robustly managing blob URLs and Base64-encoded images.

- **Bug Fixes**
	- Enhanced compatibility for image data handling in Safari, ensuring proper HTML insertion during paste actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->