### PR TITLE
fix(composition):  reinput when cursor in link fornt

### DIFF
--- a/.changeset/young-crabs-wonder.md
+++ b/.changeset/young-crabs-wonder.md
@@ -1,0 +1,6 @@
+---
+"@wangeditor-next/core": patch
+"@wangeditor-next/editor": patch
+---
+
+fix(composition):  reinput when cursor in link fornt

--- a/packages/core/src/text-area/event-handlers/composition.ts
+++ b/packages/core/src/text-area/event-handlers/composition.ts
@@ -24,8 +24,8 @@ function areBothTextNodes(editor, selection) {
     const { anchor, focus } = selection
 
     if (
-      anchor.path.length === 2
-      && focus.path.length === 2
+      [2, 3].includes(anchor.path.length)
+      && [2, 3].includes(focus.path.length)
       && (anchor.offset === 0 || focus.offset === 0)
     ) {
       const nowEntry = Editor.node(editor, anchor.path)


### PR DESCRIPTION
## Changes Overview
<!-- Briefly describe your changes. -->

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved handling of text composition events, enhancing user experience, especially for Chinese input methods.
	- Expanded criteria for determining text nodes to support more scenarios.
	- Enhanced management of input length constraints during composition.
	- Addressed cursor behavior within links for better text editing experience.

- **Bug Fixes**
	- Fixed issues with fragment deletion only occurring when there is an active selection.
	- Improved cleanup of text nodes in selection blocks for better compatibility with Chrome and Firefox.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->