### PR TITLE
319 bug 表格单元格内多选内容删除事件没有执行

### DIFF
--- a/.changeset/tidy-trees-jog.md
+++ b/.changeset/tidy-trees-jog.md
@@ -1,0 +1,6 @@
+---
+"@wangeditor-next/editor": patch
+"@wangeditor-next/table-module": patch
+---
+
+319 bug 表格单元格内多选内容删除事件没有执行

--- a/packages/core/src/text-area/event-handlers/beforeInput.ts
+++ b/packages/core/src/text-area/event-handlers/beforeInput.ts
@@ -66,7 +66,10 @@ function handleBeforeInput(e: Event, textarea: TextArea, editor: IDomEditor) {
   if (selection && Range.isExpanded(selection) && type.startsWith('delete')) {
     const selectedElems = DomEditor.getSelectedElems(editor)
 
-    if (!(selectedElems.length > 0 && selectedElems[0].type === 'table')) {
+    const isTableSelected = selectedElems[0].type === 'table'
+    const isLastNotTableCell = selectedElems[selectedElems.length - 1].type !== 'table-cell'
+
+    if (!(isTableSelected && isLastNotTableCell)) {
       const direction = type.endsWith('Backward') ? 'backward' : 'forward'
 
       Editor.deleteFragment(editor, { direction })

--- a/packages/core/src/text-area/event-handlers/beforeInput.ts
+++ b/packages/core/src/text-area/event-handlers/beforeInput.ts
@@ -61,15 +61,19 @@ function handleBeforeInput(e: Event, textarea: TextArea, editor: IDomEditor) {
     }
   }
 
-  // COMPAT: If the selection is expanded, even if the command seems like
-  // a delete forward/backward command it should delete the selection.
-  if (selection && Range.isExpanded(selection) && type.startsWith('delete')) {
+  if (selection && Range.isExpanded(selection)) {
     const selectedElems = DomEditor.getSelectedElems(editor)
 
     const isTableSelected = selectedElems[0].type === 'table'
     const isLastNotTableCell = selectedElems[selectedElems.length - 1].type !== 'table-cell'
 
-    if (!(isTableSelected && isLastNotTableCell)) {
+    // 如果选中的是开头表格，并且最后不是 table-cell ，则不处理，防止选区包含部分 table 时误删 table 单元格
+    if (isTableSelected && isLastNotTableCell) { return }
+
+    // COMPAT: If the selection is expanded, even if the command seems like
+    // a delete forward/backward command it should delete the selection.
+    if (type.startsWith('delete')) {
+
       const direction = type.endsWith('Backward') ? 'backward' : 'forward'
 
       Editor.deleteFragment(editor, { direction })


### PR DESCRIPTION
## Changes Overview
<!-- Briefly describe your changes. -->

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue with the deletion functionality for multiple selections in table cells, ensuring correct execution.
	- Enhanced logic for handling input events in text areas to prevent unintended deletions when tables are involved.

- **Improvements**
	- Refined conditions for handling expanded selections and input types, improving overall robustness and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->