### PR TITLE
361 wangeditor nextplugin formula katexcss没有默认导出

### DIFF
--- a/.changeset/late-cooks-sparkle.md
+++ b/.changeset/late-cooks-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/plugin-formula': patch
+---
+
+chore: delete static css import

--- a/.changeset/twenty-sheep-jam.md
+++ b/.changeset/twenty-sheep-jam.md
@@ -1,0 +1,5 @@
+---
+"@wangeditor-next/plugin-formula": patch
+---
+
+chore(plugin-formula): add esm build plugins

--- a/packages/editor-for-react/rollup.config.js
+++ b/packages/editor-for-react/rollup.config.js
@@ -1,5 +1,4 @@
 import { createRollupConfig } from '@wangeditor-next-shared/rollup-config'
-import { string } from 'rollup-plugin-string'
 
 import pkg from './package.json' assert { type: 'json' }
 
@@ -25,11 +24,6 @@ const umdConf = createRollupConfig({
     format: 'umd',
     name,
   },
-  plugins: [
-    string({
-      include: '**/*.css',
-    }),
-  ],
 })
 
 configList.push(umdConf)

--- a/packages/plugin-formula/package.json
+++ b/packages/plugin-formula/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wangeditor-next/plugin-formula",
-  "version": "0.0.7",
+  "version": "0.0.9",
   "description": "wangEditor next formula 公式",
   "author": "cycleccc <2991205548@qq.com>",
   "type": "module",
@@ -41,8 +41,7 @@
     "url": "https://github.com/cycleccc/wangEditor/issues"
   },
   "devDependencies": {
-    "katex": "^0.16.0",
-    "rollup-plugin-string": "^3.0.0"
+    "katex": "^0.16.0"
   },
   "peerDependencies": {
     "@wangeditor-next/editor": "5.6.14",

--- a/packages/plugin-formula/rollup.config.js
+++ b/packages/plugin-formula/rollup.config.js
@@ -14,6 +14,11 @@ const esmConf = createRollupConfig({
     format: 'esm',
     name,
   },
+  plugins: [
+    string({
+      include: '**/*.css',
+    }),
+  ],
 })
 
 configList.push(esmConf)

--- a/packages/plugin-formula/rollup.config.js
+++ b/packages/plugin-formula/rollup.config.js
@@ -13,11 +13,6 @@ const esmConf = createRollupConfig({
     format: 'esm',
     name,
   },
-  plugins: [
-    string({
-      include: '**/*.css',
-    }),
-  ],
 })
 
 configList.push(esmConf)

--- a/packages/plugin-formula/rollup.config.js
+++ b/packages/plugin-formula/rollup.config.js
@@ -1,5 +1,4 @@
 import { createRollupConfig } from '@wangeditor-next-shared/rollup-config'
-import { string } from 'rollup-plugin-string'
 
 import pkg from './package.json' assert { type: 'json' }
 
@@ -14,11 +13,6 @@ const esmConf = createRollupConfig({
     format: 'esm',
     name,
   },
-  plugins: [
-    string({
-      include: '**/*.css',
-    }),
-  ],
 })
 
 configList.push(esmConf)
@@ -30,11 +24,6 @@ const umdConf = createRollupConfig({
     format: 'umd',
     name,
   },
-  plugins: [
-    string({
-      include: '**/*.css',
-    }),
-  ],
 })
 
 configList.push(umdConf)

--- a/packages/plugin-formula/src/register-custom-elem/index.ts
+++ b/packages/plugin-formula/src/register-custom-elem/index.ts
@@ -6,8 +6,6 @@
 import './native-shim'
 
 import katex from 'katex'
-// @ts-ignore
-import katexStyleContent from 'katex/dist/katex.css'
 
 class WangEditorFormulaCard extends HTMLElement {
   private span: HTMLElement
@@ -22,10 +20,12 @@ class WangEditorFormulaCard extends HTMLElement {
     const shadow = this.attachShadow({ mode: 'open' })
     const document = shadow.ownerDocument
 
-    const style = document.createElement('style')
+    // 将样式通过 link 标签引入
+    const styleLink = document.createElement('link')
 
-    style.innerHTML = katexStyleContent // 加载 css 文本
-    shadow.appendChild(style)
+    styleLink.rel = 'stylesheet'
+    styleLink.href = 'https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css' // 或直接引入本地路径
+    shadow.appendChild(styleLink)
 
     const span = document.createElement('span')
 

--- a/packages/plugin-formula/src/register-custom-elem/index.ts
+++ b/packages/plugin-formula/src/register-custom-elem/index.ts
@@ -24,7 +24,9 @@ class WangEditorFormulaCard extends HTMLElement {
     const styleLink = document.createElement('link')
 
     styleLink.rel = 'stylesheet'
-    styleLink.href = 'https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css' // 或直接引入本地路径
+    styleLink.href = 'https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css'
+    styleLink.integrity = 'sha384-n8MVd4RsNIU0tAv4ct0nTaAbDJwPJzDEaqSD1odI+WdtXRGWt2kTvGFasHpSy3SV'
+    styleLink.crossOrigin = 'anonymous'
     shadow.appendChild(styleLink)
 
     const span = document.createElement('span')

--- a/yarn.lock
+++ b/yarn.lock
@@ -3741,7 +3741,6 @@ __metadata:
     dom7: "npm:^3.0.0"
     katex: "npm:^0.16.0"
     nanoid: "npm:^3.2.0"
-    rollup-plugin-string: "npm:^3.0.0"
   peerDependencies:
     "@wangeditor-next/editor": 5.6.14
     katex: ^0.16.0
@@ -11536,15 +11535,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup-plugin-string@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "rollup-plugin-string@npm:3.0.0"
-  dependencies:
-    rollup-pluginutils: "npm:^2.4.1"
-  checksum: 10c0/83bbc2230d5271bc014739d52320b66cd4071fc4f7181369533809e4a3f0269b6cb4873caa96426396b36f694023a9f68f5de7a94254e1f2764ca6bacff61995
-  languageName: node
-  linkType: hard
-
 "rollup-plugin-typescript2@npm:^0.36.0":
   version: 0.36.0
   resolution: "rollup-plugin-typescript2@npm:0.36.0"
@@ -11580,7 +11570,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup-pluginutils@npm:^2.4.1, rollup-pluginutils@npm:^2.8.2":
+"rollup-pluginutils@npm:^2.8.2":
   version: 2.8.2
   resolution: "rollup-pluginutils@npm:2.8.2"
   dependencies:


### PR DESCRIPTION
## Changes Overview
<!-- Briefly describe your changes. -->

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the `@wangeditor-next/plugin-formula` package to include a new ESM build for improved compatibility.
	- Removed unnecessary CSS dependencies to streamline the codebase.

- **Improvements**
	- Enhanced the styling process for the `WangEditorFormulaCard` by linking to an external KaTeX stylesheet, improving maintainability and performance.

- **Version Update**
	- Incremented the version of `@wangeditor-next/plugin-formula` from 0.0.8 to 0.0.9.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->