### PR TITLE
feat(video-module): 为视频元素添加文本对齐属性

### DIFF
--- a/packages/video-module/__tests__/parse-html.test.ts
+++ b/packages/video-module/__tests__/parse-html.test.ts
@@ -76,6 +76,7 @@ describe('video - parse html', () => {
       width: '500',
       height: '300',
       style: {},
+      textAlign: 'center',
       children: [{ text: '' }], // void 元素有一个空 text
     })
   })
@@ -99,6 +100,7 @@ describe('video - parse html', () => {
       width: 'auto',
       height: 'auto',
       style: {},
+      textAlign: 'center',
       children: [{ text: '' }], // void 元素有一个空 text
     })
   })

--- a/packages/video-module/src/module/parse-elem-html.ts
+++ b/packages/video-module/src/module/parse-elem-html.ts
@@ -16,6 +16,7 @@ function genVideoElem(
   width = 'auto',
   height = 'auto',
   style: videoStyle = {},
+  textAlign = 'center',
 ): VideoElement {
   return {
     type: 'video',
@@ -25,6 +26,7 @@ function genVideoElem(
     height,
     style,
     children: [{ text: '' }], // void 元素有一个空 text
+    textAlign,
   }
 }
 
@@ -35,7 +37,7 @@ function parseHtml(elem: DOMElement, _children: Descendant[], _editor: IDomEdito
   let width = 'auto'
   let height = 'auto'
   let style = {}
-
+  let textAlign = 'center'
   // <iframe> 形式
   const $iframe = $elem.find('iframe')
 
@@ -45,7 +47,8 @@ function parseHtml(elem: DOMElement, _children: Descendant[], _editor: IDomEdito
     style = $iframe.attr('style') || ''
     style = styleStringToObject(style)
     src = $iframe[0].outerHTML
-    return genVideoElem(src, poster, width, height, style)
+    textAlign = styleStringToObject($elem.attr('style') || '')['text-align'] || 'center'
+    return genVideoElem(src, poster, width, height, style, textAlign)
   }
 
   // <video> 形式
@@ -64,7 +67,8 @@ function parseHtml(elem: DOMElement, _children: Descendant[], _editor: IDomEdito
   poster = $video.attr('poster') || ''
   style = $video.attr('style') || ''
   style = styleStringToObject(style)
-  return genVideoElem(src, poster, width, height, style)
+  textAlign = styleStringToObject($elem.attr('style') || '')['text-align'] || 'center'
+  return genVideoElem(src, poster, width, height, style, textAlign)
 }
 
 export const parseHtmlConf = {


### PR DESCRIPTION
- 在 genVideoElem 函数中添加 textAlign 参数，默认值为 'center'
- 在 parseHtml 函数中获取父元素的 text-align 样式，并传递给 genVideoElem
- 此修改使得视频元素可以正确地继承父元素的文本对齐方式
- https://github.com/cycleccc/wangEditor-next/discussions/428

## Changes Overview
<!-- Briefly describe your changes. -->

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `textAlign` parameter for video element generation, allowing customization of text alignment.
	- Enhanced parsing of HTML elements to extract and apply text alignment from style attributes.

- **Bug Fixes**
	- Improved handling of `<iframe>` and `<video>` elements to ensure proper text alignment is applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->