### PR TITLE
fix(table): If followed by a table deleteforward is disabled

### DIFF
--- a/.changeset/rotten-baboons-turn.md
+++ b/.changeset/rotten-baboons-turn.md
@@ -1,0 +1,6 @@
+---
+"@wangeditor-next/editor": patch
+"@wangeditor-next/table-module": patch
+---
+
+fix(table): If followed by a table deleteforward is disabled


### PR DESCRIPTION
## Changes Overview
<!-- Briefly describe your changes. -->

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced table editor behavior with improved deletion and insertion logic for better text manipulation within table cells.

- **Bug Fixes**
	- Fixed issues preventing deletion of the first and last cells when the cursor is positioned in adjacent paragraphs.
	- Resolved an issue where deletion actions were disabled when a table was immediately followed by another table.

- **Refactor**
	- Updated methods to improve control flow and error handling during text operations in tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->