### PR TITLE
fix: 块元素高度变高在下方的 hoverbar 会盖住内容

### DIFF
--- a/packages/core/src/menus/bar/HoverBar.ts
+++ b/packages/core/src/menus/bar/HoverBar.ts
@@ -305,6 +305,7 @@ class HoverBar {
     // 获取选中的 node ，以及对应的 menu keys
     const { isShow } = this
     const { node = null, menuKeys = [] } = this.getSelectedNodeAndMenuKeys() || {}
+    const editor = this.getEditorInstance()
 
     if (node != null) {
       this.changeItemsState() // 更新菜单状态
@@ -315,9 +316,10 @@ class HoverBar {
       if (isShow) {
         // hoverbar 当前已显示
         const samePath = this.isSamePath(node, this.prevSelectedNode)
+        const isBlock = Editor.isBlock(editor, node)
 
-        if (samePath) {
-          // 和之前选中的 node path 相同 —— 满足这些条件，即终止
+        if (!isBlock && samePath) {
+          // 不是块元素且和之前选中的 node path 相同 —— 满足这些条件，即终止
           return
         }
       }


### PR DESCRIPTION
## Changes Overview
<!-- Briefly describe your changes. -->

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->

Close #514

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved hover bar state management with more precise conditions for displaying and hiding the hover bar.
	- Enhanced performance by adding a debounce mechanism to the hover bar state change method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->