### PR TITLE
601 有序列表和无序列表输出的html不正确

### DIFF
--- a/.changeset/plenty-mayflies-dream.md
+++ b/.changeset/plenty-mayflies-dream.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/core': patch
+---
+
+抛出一个允许节点跳过缓存的配置项，默认屏蔽list不走缓存

--- a/packages/core/src/config/interface.ts
+++ b/packages/core/src/config/interface.ts
@@ -235,6 +235,9 @@ export interface IEditorConfig {
 
   // 自由扩展其他配置
   EXTEND_CONF?: any
+
+  // 跳过缓存的节点类型列表
+  skipCacheTypes?: string[]
 }
 
 /**

--- a/packages/core/src/editor/plugins/with-content.ts
+++ b/packages/core/src/editor/plugins/with-content.ts
@@ -196,10 +196,12 @@ export const withContent = <T extends Editor>(editor: T) => {
 
       // 尝试从缓存中获取
       const cached = NODE_TO_HTML.get(child)
+
       if (cached) { return cached }
 
       // 生成新的HTML并缓存
       const htmlStr = node2html(child, e)
+
       NODE_TO_HTML.set(child, htmlStr)
       return htmlStr
     }).join('')

--- a/packages/core/src/editor/plugins/with-content.ts
+++ b/packages/core/src/editor/plugins/with-content.ts
@@ -184,14 +184,22 @@ export const withContent = <T extends Editor>(editor: T) => {
   // 获取 html （去掉了格式化 2021.12.10）
   e.getHtml = (): string => {
     const { children = [] } = e
+    const { skipCacheTypes = ['list-item'] } = e.getConfig()
 
     const html = children.map(child => {
-      // 先从缓存中获取
+      const nodeType = DomEditor.getNodeType(child)
+
+      // 如果节点类型在跳过缓存列表中，不使用缓存
+      if (skipCacheTypes.includes(nodeType)) {
+        return node2html(child, e)
+      }
+
+      // 尝试从缓存中获取
       const cached = NODE_TO_HTML.get(child)
-
       if (cached) { return cached }
-      const htmlStr = node2html(child, e)
 
+      // 生成新的HTML并缓存
+      const htmlStr = node2html(child, e)
       NODE_TO_HTML.set(child, htmlStr)
       return htmlStr
     }).join('')

--- a/packages/core/src/text-area/update-view.ts
+++ b/packages/core/src/text-area/update-view.ts
@@ -4,7 +4,7 @@
  */
 
 import { h, VNode } from 'snabbdom'
-
+import { Element } from 'slate'
 import { IDomEditor } from '../editor/interface'
 import { node2Vnode } from '../render/node2Vnode'
 import $, { Dom7Array, getDefaultView, getElementById } from '../utils/dom'
@@ -95,6 +95,13 @@ function updateView(textarea: TextArea, editor: IDomEditor) {
     const vnode = node2Vnode(node, i, editor, editor)
 
     normalizeVnodeData(vnode) // 整理 vnode.data 以符合 snabbdom 的要求
+
+    const { skipCacheTypes = ['list-item'] } = editor.getConfig()
+
+    if (Element.isElement(node) && skipCacheTypes.includes(node.type)) {
+      // 如果是跳过缓存的类型，则不缓存
+      return vnode
+    }
     NODE_TO_VNODE.set(node, [i, vnode])
     return vnode
   })


### PR DESCRIPTION
## Changes Overview
<!-- Briefly describe your changes. -->

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->
本次改动新增了一个配置项 `skipCacheTypes`，用于设置哪些节点类型跳过节点缓存。默认值为`['list-item']`

```
const editorConfig = {}

editorConfig.skipCacheTypes = ['list-item', 'paragraph']

const editor = E.createEditor({
     selector: '#editor-text-area',
     config: editorConfig,
     html: '<p>hello</p>',
     mode: 'simple',
 })
```
## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->
[https://github.com/wangeditor-next/wangEditor-next/issues/601](url)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configuration option to control which node types are excluded from caching in the editor.
  - By default, list nodes are not cached, improving flexibility and performance for certain content structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->