### PR TITLE
fix(video-module): 修复【插入视频】功能的视频超过屏幕宽度时，视频内容超过视频容器的问题

### DIFF
--- a/packages/video-module/src/assets/index.less
+++ b/packages/video-module/src/assets/index.less
@@ -7,6 +7,7 @@
   margin: 0 auto;
   margin-top: 10px;
   border-radius: 5px;
+  overflow: auto;
   background-position: 0px 0px, 10px 10px;
   background-size: 20px 20px;
   background-image: linear-gradient(45deg, #eee 25%, transparent 25%, transparent 75%, #eee 75%, #eee 100%),linear-gradient(45deg, #eee 25%, white 25%, white 75%, #eee 75%, #eee 100%);


### PR DESCRIPTION
## Changes Overview
在video-module中添加overflow: auto; 的样式，修复视频默认宽度大于屏幕宽度（editor宽度）时，视频会超出视频容器的问题。



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved video container styling by enabling automatic scrollbars when content exceeds the visible area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->