### PR TITLE
修复在SelectLangMenu提供了selected能力，而在code-block没处理导致选中了其他语言，但是代码块代码没高亮的问题

### DIFF
--- a/.changeset/nice-buses-bathe.md
+++ b/.changeset/nice-buses-bathe.md
@@ -1,0 +1,5 @@
+---
+"@wangeditor-next/basic-modules": patch
+---
+
+修复在SelectLangMenu提供了selected能力，而在code-block没处理导致选中了其他语言，但是代码块代码没高亮的问题

--- a/packages/basic-modules/src/modules/code-block/menu/CodeBlockMenu.ts
+++ b/packages/basic-modules/src/modules/code-block/menu/CodeBlockMenu.ts
@@ -13,6 +13,8 @@ import {
 import { CODE_BLOCK_SVG } from '../../../constants/icon-svg'
 import { CodeElement } from '../custom-types'
 
+interface CodeSelectLangItem { text: string; value: string; selected?: boolean }
+
 class CodeBlockMenu implements IButtonMenu {
   readonly title = t('codeBlock.title')
 
@@ -39,7 +41,12 @@ class CodeBlockMenu implements IButtonMenu {
   getValue(editor: IDomEditor): string | boolean {
     const elem = this.getSelectCodeElem(editor)
 
-    if (elem == null) { return '' }
+    if (elem == null) {
+      const { codeLangs = [] } = editor.getMenuConfig('codeSelectLang')
+      const selectItem = (codeLangs as CodeSelectLangItem[]).find(item => item.selected)
+
+      return selectItem?.value || ''
+    }
     return elem.language || ''
   }
 

--- a/packages/core/src/create/helper.ts
+++ b/packages/core/src/create/helper.ts
@@ -111,10 +111,10 @@ export function initializeContent(editor: IDomEditor, options: { html?: string, 
   if (html != null) {
     // 传入 html ，转换为 JSON content
     editor.children = htmlToContent(editor, html)
-  }
-  if (content && content.length) {
+  } else if (content && content.length) {
     editor.children = content // 传入 JSON content
   }
+
   if (editor.children.length === 0) {
     editor.children = genDefaultContent() // 默认内容
   }


### PR DESCRIPTION
## Changes Overview
修复在SelectLangMenu提供了selected能力，而在code-block没处理，导致代码块上的tip选中了对应的语言，但是代码块的代码没高亮的问题。

例如配置：
editorConfig.MENU_CONF = {}
editorConfig.MENU_CONF.codeSelectLang = {
   codeLangs: [
     { "text": "CSS", "value": "css" }, { "text": "HTML", "value": "html" }, { "text": "XML", "value": "xml" },
     { "text": "Javascript", "value": "javascript", "**selected**": true }, { "text": "Typescript", "value": "typescript" }
   ]
}

代码块选中的语言是javascript，但是，代码高亮却是默认的。
    


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved language selection for code blocks by automatically using the configured default language when no code block is selected.

* **Bug Fixes**
  * Ensured the correct language value is returned when no code block is present in the editor.
  * Fixed an issue where the selected language in the menu was not properly reflected in the code block’s syntax highlighting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->