### PR TITLE
fix: 解决表格单元格被异常删除问题,实现编辑内容表格样式统一,对外部复制表格剔除style

### DIFF
--- a/packages/table-module/__tests__/menu/full-width.test.ts
+++ b/packages/table-module/__tests__/menu/full-width.test.ts
@@ -38,9 +38,9 @@ describe('Table Module Full Width Menu', () => {
     const editor = createEditor()
 
     vi.spyOn(core.DomEditor, 'getSelectedNodeByType').mockImplementation(
-      () => ({ width: '100%' }) as any,
+      () => ({ width: 'auto' }) as any,
     )
-    expect(fullWidthMenu.getValue(editor)).toBeTruthy()
+    expect(fullWidthMenu.getValue(editor)).toBeFalsy()
   })
 
   test('isActive should get falsy value if editor selected node is not table', () => {

--- a/packages/table-module/__tests__/parse-html.test.ts
+++ b/packages/table-module/__tests__/parse-html.test.ts
@@ -23,7 +23,7 @@ describe('table - pre parse html', () => {
     // pre parse
     const res = preParseTableHtmlConf.preParseHtml($table[0])
 
-    expect(res.outerHTML).toBe('<table><tr><td>hello</td></tr></table>')
+    expect(res.outerHTML).toBe('<table><tr><td width="auto">hello</td></tr></table>')
   })
 
   it('it should return fake element if pass fake table element', () => {
@@ -41,7 +41,7 @@ describe('table - pre parse html', () => {
     // pre parse
     const res = preParseTableHtmlConf.preParseHtml(table[0])
 
-    expect(res.outerHTML).toBe('<table><tr><td>hello</td></tr></table>')
+    expect(res.outerHTML).toBe('<table><tr><td width="auto">hello</td></tr></table>')
   })
 })
 

--- a/packages/table-module/src/module/menu/FullWidth.ts
+++ b/packages/table-module/src/module/menu/FullWidth.ts
@@ -18,15 +18,14 @@ class TableFullWidth implements IButtonMenu {
 
   readonly tag = 'button'
 
-  getValue(editor: IDomEditor): string | boolean {
-    const tableNode = DomEditor.getSelectedNodeByType(editor, 'table')
-
-    if (tableNode == null) { return false }
-    return (tableNode as TableElement).width === '100%'
+  getValue(_editor: IDomEditor): string | boolean {
+    // 每次点击都执行调整，不需要状态判断
+    return false
   }
 
-  isActive(editor: IDomEditor): boolean {
-    return !!this.getValue(editor)
+  isActive(_editor: IDomEditor): boolean {
+    // 每次点击都执行调整，不需要状态判断
+    return false
   }
 
   isDisabled(editor: IDomEditor): boolean {
@@ -44,14 +43,75 @@ class TableFullWidth implements IButtonMenu {
     return false
   }
 
-  exec(editor: IDomEditor, value: string | boolean) {
+  exec(editor: IDomEditor, _value: string | boolean) {
     if (this.isDisabled(editor)) { return }
 
-    const props: Partial<TableElement> = {
-      width: value ? 'auto' : '100%', // 切换 'auto' 和 '100%'
+    const tableNode = DomEditor.getSelectedNodeByType(editor, 'table') as TableElement
+
+    if (!tableNode) { return }
+
+    const { columnWidths = [] } = tableNode
+
+    // 获取表格容器元素 - 简化逻辑
+    // 由于当前选中的表格就是我们要操作的表格，直接查找包含table的table-container
+    const containerElement = document.querySelector('.table-container')
+
+    if (!containerElement || columnWidths.length === 0) {
+      // 如果找不到容器或没有列宽信息，则使用原来的逻辑
+      const props: Partial<TableElement> = {
+        width: 'auto',
+      }
+
+      Transforms.setNodes(editor, props, { mode: 'highest' })
+      return
     }
 
-    Transforms.setNodes(editor, props, { mode: 'highest' })
+    const containerWidth = containerElement.clientWidth
+    const currentTotalWidth = columnWidths.reduce((a, b) => a + b, 0)
+
+    // 计算等比例调整后的列宽
+    const adjustedColumnWidths = columnWidths.map(width => {
+      const ratio = width / currentTotalWidth
+
+      return Math.floor(ratio * containerWidth)
+    })
+
+    // 确保最小宽度限制（每列至少10px）
+    const minWidth = 10
+    const adjustedWithMinWidth = adjustedColumnWidths.map(width => Math.max(minWidth, width))
+
+    // 如果调整后的总宽度超过容器宽度，按比例缩小
+    const adjustedTotalWidth = adjustedWithMinWidth.reduce((a, b) => a + b, 0)
+
+    if (adjustedTotalWidth > containerWidth) {
+      const scaleFactor = containerWidth / adjustedTotalWidth
+      const finalColumnWidths = adjustedWithMinWidth.map(width => Math.max(minWidth, Math.floor(width * scaleFactor)))
+
+      // 应用新的列宽和宽度设置
+      const props: Partial<TableElement> = {
+        width: 'auto',
+        columnWidths: finalColumnWidths,
+      }
+
+      Transforms.setNodes(editor, props, { mode: 'highest' })
+    } else {
+      // 如果调整后的总宽度小于容器宽度，将剩余宽度加到最后一列
+      const finalColumnWidths = [...adjustedWithMinWidth]
+      const remainingWidth = containerWidth - adjustedTotalWidth - 1
+
+      if (remainingWidth > 0 && finalColumnWidths.length > 0) {
+        // 将剩余宽度加到最后一列
+        finalColumnWidths[finalColumnWidths.length - 1] += remainingWidth
+      }
+
+      // 应用新的列宽和宽度设置
+      const props: Partial<TableElement> = {
+        width: 'auto',
+        columnWidths: finalColumnWidths,
+      }
+
+      Transforms.setNodes(editor, props, { mode: 'highest' })
+    }
   }
 }
 

--- a/packages/table-module/src/module/plugin.ts
+++ b/packages/table-module/src/module/plugin.ts
@@ -155,6 +155,31 @@ function isTableLocation(editor: IDomEditor, location: Location): boolean {
   return hasTable
 }
 
+/**
+ * 检查当前选中的节点是否是受保护的节点类型（不应该被删除的节点）
+ * @param editor editor
+ * @returns 是否是受保护的节点
+ */
+function isProtectedNode(editor: IDomEditor): boolean {
+  // 检查是否是受保护的节点类型
+  const protectedTypes = [
+    'paragraph',
+    'header1', 'header2', 'header3', 'header4', 'header5', 'header6',
+    'blockquote',
+    'list-item',
+    'todo',
+    'divider',
+  ]
+
+  for (const type of protectedTypes) {
+    if (DomEditor.getSelectedNodeByType(editor, type)) {
+      return true
+    }
+  }
+
+  return false
+}
+
 function withTable<T extends IDomEditor>(editor: T): T {
   const {
     insertBreak,
@@ -205,7 +230,8 @@ function withTable<T extends IDomEditor>(editor: T): T {
         // 如果前面是 table, 当前是 paragraph ，则不执行删除。否则会删除 table 最后一个 cell
         // 兼容了 table 嵌套 p标签元素 selection数组五层的情况 - issues/342
 
-        if (!tableCell && isTableOnBeforeLocation && DomEditor.getSelectedNodeByType(newEditor, 'paragraph')) {
+        // 如果前面是 table, 当前是受保护的节点类型，则不执行删除
+        if (!tableCell && isTableOnBeforeLocation && isProtectedNode(newEditor)) {
           return
         }
       }
@@ -275,7 +301,8 @@ function withTable<T extends IDomEditor>(editor: T): T {
         const isTableOnAfterLocation = isTableLocation(newEditor, after) // after 是否是 table
         // 如果后面是 table, 当前是 paragraph，则不执行删除
 
-        if (!tableCell && isTableOnAfterLocation && DomEditor.getSelectedNodeByType(newEditor, 'paragraph')) {
+        // 如果后面是 table, 当前是受保护的节点类型，则不执行删除
+        if (!tableCell && isTableOnAfterLocation && isProtectedNode(newEditor)) {
           return
         }
       }

--- a/packages/table-module/src/module/pre-parse-html.ts
+++ b/packages/table-module/src/module/pre-parse-html.ts
@@ -41,8 +41,13 @@ function preParse(tableElem: DOMElement): DOMElement {
 
       if (displayNoneRegex.test(styleAttr)) {
         $cell.remove()
+      } else {
+        // 删除style属性（保留单元格，只删除样式）
+        $cell.removeAttr('style')
       }
     }
+    // 设置width属性为auto
+    $cell.attr('width', 'auto')
   }
 
   // 处理表格单元格中的 <p> 标签（通常来自Word复制）


### PR DESCRIPTION
1、修复表格单元格被异常删除的问题扩展受保护的节点类型，包括：'paragraph','header1', 'header2', 'header3', 'header4', 'header5','header6','blockquote','list-item', 'todo', 'divider'
2、确保编辑器内表格样式一致性，对外部复制表格：自动清除单元格<td>的所有style属性
3、当前编辑器表格采用table-layout: fixed模式，对Word等来源表格，若<col>已设置宽度，则将单元格<td>/<th>的宽度设为auto，使编辑器原生表格与外部复制表格的宽度渲染保持一致


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deletion handling in tables to prevent removal of protected node types (such as headers, blockquotes, lists, and dividers) in the editor.
  * Enhanced table cell processing to remove all inline styles from visible cells and standardize their width, ensuring consistent appearance.
* **New Features**
  * Updated table column width adjustment to proportionally fit the container size, improving table layout responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->