### PR TITLE
fix: 宽度自适应获取当前选中的表格容器宽度，防止文档多表格时获取到其它表格容器元素和兼容高版本node.js

### DIFF
--- a/.changeset/orange-clocks-grow.md
+++ b/.changeset/orange-clocks-grow.md
@@ -1,0 +1,6 @@
+---
+"@wangeditor-next/table-module": patch
+"@wangeditor-next/editor": patch
+---
+
+fix: 宽度自适应获取当前选中的表格容器宽度，防止文档多表格时获取到其它表格容器元素和兼容高版本node.js

--- a/packages/table-module/__tests__/menu/full-width.test.ts
+++ b/packages/table-module/__tests__/menu/full-width.test.ts
@@ -111,7 +111,11 @@ describe('Table Module Full Width Menu', () => {
     setEditorSelection(editor)
 
     vi.spyOn(slate.Range, 'isCollapsed').mockImplementation(() => true)
-    vi.spyOn(core.DomEditor, 'getSelectedNodeByType').mockImplementation(() => ({}) as any)
+    vi.spyOn(core.DomEditor, 'getSelectedNodeByType').mockImplementation(() => ({
+      type: 'table',
+      children: [],
+    }) as any)
+    vi.spyOn(core.DomEditor, 'toDOMNode').mockImplementation(() => document.createElement('table'))
 
     const fn = vi.fn()
 

--- a/packages/table-module/src/module/menu/FullWidth.ts
+++ b/packages/table-module/src/module/menu/FullWidth.ts
@@ -52,12 +52,12 @@ class TableFullWidth implements IButtonMenu {
 
     const { columnWidths = [] } = tableNode
 
-    // 获取表格容器元素 - 简化逻辑
-    // 由于当前选中的表格就是我们要操作的表格，直接查找包含table的table-container
-    const containerElement = document.querySelector('.table-container')
+    // 获取当前选中的表格的DOM元素,再查找table-container容器元素，防止文档多表格时，获取到其他表格的容器元素
+    const tableDom = DomEditor.toDOMNode(editor, tableNode)
+    const containerElement = tableDom.querySelector('.table-container')
 
     if (!containerElement || columnWidths.length === 0) {
-      // 如果找不到容器或没有列宽信息，则使用原来的逻辑
+      // 如果找不到容器或没有列宽信息，则使用原来的逻辑，先使用auto预留以后实现按比例实现缩放功能
       const props: Partial<TableElement> = {
         width: 'auto',
       }

--- a/tests/setup/index.ts
+++ b/tests/setup/index.ts
@@ -6,10 +6,13 @@ import { DataTransfer } from './DataTransfer'
 import { ResizeObserver } from './ResizeObserver'
 
 // @ts-ignore
-global.crypto = {
-  getRandomValues(buffer: any) {
-    return nodeCrypto.randomFillSync(buffer)
-  },
+if (!global.crypto) {
+  // @ts-ignore
+  global.crypto = {
+    getRandomValues(buffer: any) {
+      return nodeCrypto.randomFillSync(buffer)
+    },
+  }
 }
 
 vi.spyOn(global.console, 'warn').mockImplementation(() => vi.fn())


### PR DESCRIPTION

1、修复在文档多表格时未获取当前文档表格容器宽度的问题
2、同步调整full-width.test.ts和兼容高版本node.js，高版本node.js已经提供 global.crypto，解决TypeError: Cannot set property crypto of #<Object> which has only a getter 问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table width adjustment to correctly target the container of the currently selected table, ensuring accurate behavior when multiple tables are present.

* **Tests**
  * Enhanced test setup for table full-width functionality to more realistically simulate table nodes and their DOM elements.
  * Updated global crypto assignment in test setup to avoid unnecessary overwriting if already defined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->