### PR TITLE
chore: 移除多个包中的lodash.isequal依赖

### DIFF
--- a/.changeset/neat-seahorses-exist.md
+++ b/.changeset/neat-seahorses-exist.md
@@ -1,0 +1,7 @@
+---
+"@wangeditor-next/core": patch
+"@wangeditor-next/editor": patch
+"@wangeditor-next/table-module": patch
+---
+
+chore: 移除多个包中的lodash.isequal依赖

--- a/.changeset/stupid-tomatoes-fold.md
+++ b/.changeset/stupid-tomatoes-fold.md
@@ -1,0 +1,7 @@
+---
+"@wangeditor-next/core": patch
+"@wangeditor-next/editor": patch
+"@wangeditor-next/table-module": patch
+---
+
+chore: 移除多个包中的lodash.isequal依赖

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,7 +52,6 @@
     "lodash.clonedeep": "^4.5.0",
     "lodash.debounce": "^4.0.8",
     "lodash.foreach": "^4.5.0",
-    "lodash.isequal": "^4.5.0",
     "lodash.throttle": "^4.1.1",
     "lodash.toarray": "^4.4.0",
     "nanoid": "^5.0.0",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -68,7 +68,6 @@
     "lodash.clonedeep": "^4.5.0",
     "lodash.debounce": "^4.0.8",
     "lodash.foreach": "^4.5.0",
-    "lodash.isequal": "^4.5.0",
     "lodash.throttle": "^4.1.1",
     "lodash.toarray": "^4.4.0",
     "nanoid": "^5.0.0",

--- a/packages/table-module/package.json
+++ b/packages/table-module/package.json
@@ -47,7 +47,6 @@
     "@wangeditor-next/core": "1.7.42",
     "dom7": "^3.0.0 || ^4.0.0",
     "lodash.debounce": "^4.0.8",
-    "lodash.isequal": "^4.5.0",
     "lodash.throttle": "^4.1.1",
     "nanoid": "^5.0.0",
     "slate": "^0.82.0",


### PR DESCRIPTION
https://github.com/wangeditor-next/wangEditor-next/issues/668

## Changes Overview
<!-- Briefly describe your changes. -->

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [ ] My changes do not break the library.
- [ ] I have added tests where applicable.
- [ ] I have followed the project guidelines.
- [ ] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the lodash.isequal dependency from multiple packages to streamline project maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->