### PR TITLE
chore(core/upload): 修正类型

### DIFF
--- a/packages/core/src/upload/interface.ts
+++ b/packages/core/src/upload/interface.ts
@@ -37,7 +37,7 @@ interface IBaseUploadConfig {
   // 用户自定义插入视频
   customInsert?: (res: any, insertFn: InsertFn) => void
   // 用户自定义上传视频
-  customUpload?: (files: File, insertFn: InsertFn, editor?: IDomEditor) => void
+  customUpload?: (files: File, insertFn: InsertFn, editor: IDomEditor) => void
   // 自定义选择视频，如图床
   customBrowseAndUpload?: (insertFn: InsertFn) => void
   // 支持传入更多 Uppy 配置项
@@ -49,7 +49,7 @@ interface IBaseUploadConfig {
 // 有自定义上传时的配置（server可选）
 interface IUploadConfigWithCustomUpload extends IBaseUploadConfig {
   server?: string
-  customUpload: (files: File, insertFn: InsertFn, editor?: IDomEditor) => void
+  customUpload: (files: File, insertFn: InsertFn, editor: IDomEditor) => void
 }
 
 // 没有自定义上传时的配置（server必需）


### PR DESCRIPTION
## Changes Overview
在core内部调用传入的customUpload时，会传editor参数过去，因此，该类型值是存在的，而非可选态


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the upload configuration to require the editor parameter in custom upload functions, ensuring consistent behavior when handling uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->