### PR TITLE
fix(table-module/per-parse-html): 修复执行setHtml命令时，丢失td样式的问题(#665)

### DIFF
--- a/.changeset/light-bikes-type.md
+++ b/.changeset/light-bikes-type.md
@@ -1,0 +1,5 @@
+---
+"@wangeditor-next/table-module": patch
+---
+
+fix(table-module/per-parse-html): 修复执行setHtml命令时，丢失td样式的问题(#665)

--- a/packages/table-module/src/module/pre-parse-html.ts
+++ b/packages/table-module/src/module/pre-parse-html.ts
@@ -41,9 +41,6 @@ function preParse(tableElem: DOMElement): DOMElement {
 
       if (displayNoneRegex.test(styleAttr)) {
         $cell.remove()
-      } else {
-        // 删除style属性（保留单元格，只删除样式）
-        $cell.removeAttr('style')
       }
     }
     // 设置width属性为auto


### PR DESCRIPTION
## Changes Overview
fix(table-module/per-parse-html): 修复执行setHtml命令时，丢失td样式的问题

后续parse-elem-html会拦截额外多余的样式，保障后续parse-style-html的样式获取。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the style attribute for table cells unless they contain `display:none`. Styles for visible cells will now be retained as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->