### PR TITLE
feat(table): 添加行拖动和调整高度功能

### DIFF
--- a/.changeset/pretty-owls-applaud.md
+++ b/.changeset/pretty-owls-applaud.md
@@ -1,0 +1,14 @@
+---
+"@wangeditor-next/basic-modules": patch
+"@wangeditor-next/code-highlight": patch
+"@wangeditor-next/core": patch
+"@wangeditor-next/editor": patch
+"@wangeditor-next/list-module": patch
+"@wangeditor-next/table-module": patch
+"@wangeditor-next/upload-image-module": patch
+"@wangeditor-next/video-module": patch
+"@wangeditor-next/yjs-for-react": patch
+"@wangeditor-next/yjs": patch
+---
+
+feat(table): 添加行拖动和调整高度功能

--- a/packages/basic-modules/package.json
+++ b/packages/basic-modules/package.json
@@ -32,8 +32,8 @@
     "url": "git+https://github.com/wangeditor-next/wangEditor-next.git"
   },
   "scripts": {
-    "test": "jest",
-    "test-c": "jest --coverage",
+    "test": "vitest run",
+    "test-c": "vitest run --coverage",
     "dev": "cross-env NODE_ENV=development rollup -c rollup.config.js",
     "dev-watch": "cross-env NODE_ENV=development rollup -c rollup.config.js -w",
     "build": "cross-env NODE_ENV=production rollup -c rollup.config.js",

--- a/packages/code-highlight/package.json
+++ b/packages/code-highlight/package.json
@@ -32,8 +32,8 @@
     "url": "git+https://github.com/wangeditor-next/wangEditor-next.git"
   },
   "scripts": {
-    "test": "jest",
-    "test-c": "jest --coverage",
+    "test": "vitest run",
+    "test-c": "vitest run --coverage",
     "dev": "cross-env NODE_ENV=development rollup -c rollup.config.js",
     "dev-watch": "cross-env NODE_ENV=development rollup -c rollup.config.js -w",
     "build": "cross-env NODE_ENV=production rollup -c rollup.config.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,8 +32,8 @@
     "url": "git+https://github.com/wangeditor-next/wangEditor-next.git"
   },
   "scripts": {
-    "test": "jest",
-    "test-c": "jest --coverage",
+    "test": "vitest run",
+    "test-c": "vitest run --coverage",
     "dev": "cross-env NODE_ENV=development rollup -c rollup.config.js",
     "dev-watch": "cross-env NODE_ENV=development rollup -c rollup.config.js -w",
     "build": "cross-env NODE_ENV=production rollup -c rollup.config.js",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -40,8 +40,8 @@
     "url": "git+https://github.com/wangeditor-next/wangEditor-next.git"
   },
   "scripts": {
-    "test": "jest",
-    "test-c": "jest --coverage",
+    "test": "vitest run",
+    "test-c": "vitest run --coverage",
     "example": "concurrently \"pnpm dev-watch\" \"http-server -p 8881 -c-1\" ",
     "dev": "cross-env NODE_ENV=development rollup -c rollup.config.js",
     "dev-watch": "cross-env NODE_ENV=development rollup -c rollup.config.js -w",

--- a/packages/list-module/package.json
+++ b/packages/list-module/package.json
@@ -32,8 +32,8 @@
     "url": "git+https://github.com/wangeditor-next/wangEditor-next.git"
   },
   "scripts": {
-    "test": "jest",
-    "test-c": "jest --coverage",
+    "test": "vitest run",
+    "test-c": "vitest run --coverage",
     "dev": "cross-env NODE_ENV=development rollup -c rollup.config.js",
     "dev-watch": "cross-env NODE_ENV=development rollup -c rollup.config.js -w",
     "build": "cross-env NODE_ENV=production rollup -c rollup.config.js",

--- a/packages/table-module/__tests__/menu/insert-row.test.ts
+++ b/packages/table-module/__tests__/menu/insert-row.test.ts
@@ -188,4 +188,137 @@ describe('Table Module Insert Row Menu', () => {
     expect(insertRowMenu.exec(editor, '')).toBeUndefined()
     expect(insertNodesFn).not.toBeCalled()
   })
+
+  test('should create new row with default height when inserting', () => {
+    const insertRowMenu = new InsertRow()
+    const editor = createEditor()
+
+    // Mock editor config
+    vi.spyOn(editor, 'getMenuConfig').mockReturnValue({
+      minRowHeight: 35,
+    })
+
+    // Mock isDisabled to return false
+    vi.spyOn(insertRowMenu, 'isDisabled').mockReturnValue(false)
+
+    // Mock Editor.nodes to return a valid cell entry
+    const fn = function* () {
+      yield [
+        {
+          type: 'table-cell',
+          children: [{ text: '' }],
+        } as slate.Element,
+        [0, 0, 0],
+      ] as slate.NodeEntry<slate.Element>
+    }
+
+    vi.spyOn(slate.Editor, 'nodes').mockReturnValue(fn())
+
+    // Mock DomEditor.getParentNode to return a table row
+    vi.spyOn(core.DomEditor, 'getParentNode').mockImplementation(() => ({
+      type: 'table-row',
+      children: [
+        { type: 'table-cell', children: [{ text: '' }] },
+        { type: 'table-cell', children: [{ text: '' }] },
+      ],
+    }))
+
+    mockedUtils.filledMatrix.mockImplementation(() => {
+      return [
+        [
+          [
+            [{ type: 'table-cell', children: [{ text: '' }] }, [0, 0, 0]],
+            {
+              ttb: 1, btt: 1, rtl: 1, ltr: 1,
+            },
+          ],
+          [
+            [{ type: 'table-cell', children: [{ text: '' }] }, [0, 0, 1]],
+            {
+              ttb: 1, btt: 1, rtl: 1, ltr: 1,
+            },
+          ],
+        ],
+      ]
+    })
+
+    const insertNodesFn = vi.fn()
+
+    vi.spyOn(slate.Transforms, 'insertNodes').mockImplementation(insertNodesFn)
+
+    insertRowMenu.exec(editor, '')
+
+    // 验证插入的行有正确的高度属性
+    expect(insertNodesFn).toHaveBeenCalledWith(
+      editor,
+      expect.objectContaining({
+        type: 'table-row',
+        height: 35,
+        children: expect.any(Array),
+      }),
+      expect.any(Object),
+    )
+  })
+
+  test('should use default height when minRowHeight is not configured', () => {
+    const insertRowMenu = new InsertRow()
+    const editor = createEditor()
+
+    // Mock editor config without minRowHeight
+    vi.spyOn(editor, 'getMenuConfig').mockReturnValue({})
+
+    // Mock isDisabled to return false
+    vi.spyOn(insertRowMenu, 'isDisabled').mockReturnValue(false)
+
+    // Mock Editor.nodes to return a valid cell entry
+    const fn = function* () {
+      yield [
+        {
+          type: 'table-cell',
+          children: [{ text: '' }],
+        } as slate.Element,
+        [0, 0, 0],
+      ] as slate.NodeEntry<slate.Element>
+    }
+
+    vi.spyOn(slate.Editor, 'nodes').mockReturnValue(fn())
+
+    // Mock DomEditor.getParentNode to return a table row
+    vi.spyOn(core.DomEditor, 'getParentNode').mockImplementation(() => ({
+      type: 'table-row',
+      children: [
+        { type: 'table-cell', children: [{ text: '' }] },
+      ],
+    }))
+
+    mockedUtils.filledMatrix.mockImplementation(() => {
+      return [
+        [
+          [
+            [{ type: 'table-cell', children: [{ text: '' }] }, [0, 0, 0]],
+            {
+              ttb: 1, btt: 1, rtl: 1, ltr: 1,
+            },
+          ],
+        ],
+      ]
+    })
+
+    const insertNodesFn = vi.fn()
+
+    vi.spyOn(slate.Transforms, 'insertNodes').mockImplementation(insertNodesFn)
+
+    insertRowMenu.exec(editor, '')
+
+    // 验证使用默认高度 30px
+    expect(insertNodesFn).toHaveBeenCalledWith(
+      editor,
+      expect.objectContaining({
+        type: 'table-row',
+        height: 30,
+        children: expect.any(Array),
+      }),
+      expect.any(Object),
+    )
+  })
 })

--- a/packages/table-module/__tests__/menu/insert-table.test.ts
+++ b/packages/table-module/__tests__/menu/insert-table.test.ts
@@ -165,4 +165,93 @@ describe('Table Module Insert Table Menu', () => {
 
     expect(tdEl.className).toBe('active')
   })
+
+  test('should create table with row heights when inserting', () => {
+    const insertTableMenu = new InsertTable()
+    const editor = createEditor()
+
+    // Mock editor config
+    vi.spyOn(editor, 'getMenuConfig').mockReturnValue({
+      minWidth: 80,
+      minRowHeight: 40,
+    })
+
+    setEditorSelection(editor)
+
+    const insertNodesFn = vi.fn()
+
+    vi.spyOn(slate.Transforms, 'insertNodes').mockImplementation(insertNodesFn)
+
+    // 模拟点击创建 1x2 表格 (第一行第二列)
+    const tablePanel = insertTableMenu.getPanelContentElem(editor)
+    const tdEl = $(tablePanel).find('td')[1] // 第一行第二列，创建 1x2 表格
+
+    tdEl.dispatchEvent(
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      }),
+    )
+
+    // 验证插入的表格包含正确的行高度
+    expect(insertNodesFn).toHaveBeenCalledWith(
+      editor,
+      expect.objectContaining({
+        type: 'table',
+        children: expect.arrayContaining([
+          expect.objectContaining({
+            type: 'table-row',
+            height: 40,
+            children: expect.any(Array),
+          }),
+        ]),
+        columnWidths: [80, 80],
+      }),
+      expect.any(Object),
+    )
+  })
+
+  test('should use default row height when minRowHeight is not configured', () => {
+    const insertTableMenu = new InsertTable()
+    const editor = createEditor()
+
+    // Mock editor config without minRowHeight
+    vi.spyOn(editor, 'getMenuConfig').mockReturnValue({
+      minWidth: 60,
+    })
+
+    setEditorSelection(editor)
+
+    const insertNodesFn = vi.fn()
+
+    vi.spyOn(slate.Transforms, 'insertNodes').mockImplementation(insertNodesFn)
+
+    // 模拟点击创建 1x1 表格
+    const tablePanel = insertTableMenu.getPanelContentElem(editor)
+    const tdEl = $(tablePanel).find('td')[0]
+
+    tdEl.dispatchEvent(
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      }),
+    )
+
+    // 验证使用默认行高度 30px
+    expect(insertNodesFn).toHaveBeenCalledWith(
+      editor,
+      expect.objectContaining({
+        type: 'table',
+        children: expect.arrayContaining([
+          expect.objectContaining({
+            type: 'table-row',
+            height: 30,
+            children: expect.any(Array),
+          }),
+        ]),
+        columnWidths: [60],
+      }),
+      expect.any(Object),
+    )
+  })
 })

--- a/packages/table-module/__tests__/render-elem.test.ts
+++ b/packages/table-module/__tests__/render-elem.test.ts
@@ -32,6 +32,26 @@ describe('table module - render elem', () => {
     expect(vnode.sel).toBe('tr')
   })
 
+  it('render table row elem with height', () => {
+    expect(renderTableRowConf.type).toBe('table-row')
+
+    const elem = { type: 'table-row', children: [], height: 50 }
+    const vnode = renderTableRowConf.renderElem(elem, null, editor)
+
+    expect(vnode.sel).toBe('tr')
+    expect(vnode.data?.style?.height).toBe('50px')
+  })
+
+  it('render table row elem without height should not set style', () => {
+    expect(renderTableRowConf.type).toBe('table-row')
+
+    const elem = { type: 'table-row', children: [] }
+    const vnode = renderTableRowConf.renderElem(elem, null, editor)
+
+    expect(vnode.sel).toBe('tr')
+    expect(vnode.data?.style?.height).toBeUndefined()
+  })
+
   it('render table elem', () => {
     expect(renderTableConf.type).toBe('table')
 
@@ -59,5 +79,93 @@ describe('table module - render elem', () => {
     const tableVnode = containerVnode.children[0] as any
 
     expect(tableVnode.data.width).toBe('100%')
+  })
+
+  it('render table with row resizer elements', () => {
+    expect(renderTableConf.type).toBe('table')
+
+    const elem = {
+      type: 'table',
+      width: 'auto',
+      columnWidths: [100, 150],
+      children: [
+        {
+          type: 'table-row',
+          height: 30,
+          children: [
+            { type: 'table-cell', children: [{ text: 'Cell 1' }] },
+            { type: 'table-cell', children: [{ text: 'Cell 2' }] },
+          ],
+        },
+        {
+          type: 'table-row',
+          height: 40,
+          children: [
+            { type: 'table-cell', children: [{ text: 'Cell 3' }] },
+            { type: 'table-cell', children: [{ text: 'Cell 4' }] },
+          ],
+        },
+      ],
+    }
+
+    const observerVnode = renderTableConf.renderElem(elem, null, editor) as any
+    const containerVnode = observerVnode.children[0] as any
+
+    // 验证容器结构
+    expect(containerVnode.sel).toBe('div')
+    expect(containerVnode.data?.className).toBe('table-container')
+
+    // 验证包含表格元素
+    const tableVnode = containerVnode.children[0] as any
+
+    expect(tableVnode.sel).toBe('table')
+
+    // 验证包含列拖动手柄
+    const columnResizer = containerVnode.children[1] as any
+
+    expect(columnResizer.sel).toBe('div')
+    expect(columnResizer.data?.className).toBe('column-resizer')
+
+    // 验证包含行拖动手柄
+    const rowResizer = containerVnode.children[2] as any
+
+    expect(rowResizer.sel).toBe('div')
+    expect(rowResizer.data?.className).toBe('row-resizer')
+
+    // 验证行拖动手柄的数量与行数一致
+    expect(rowResizer.children).toHaveLength(2)
+
+    // 验证每个行拖动手柄的高度
+    const firstRowResizer = rowResizer.children[0] as any
+
+    expect(firstRowResizer.data?.style?.minHeight).toBe('30px')
+
+    const secondRowResizer = rowResizer.children[1] as any
+
+    expect(secondRowResizer.data?.style?.minHeight).toBe('40px')
+  })
+
+  it('render table row resizer with default height when height is not specified', () => {
+    const elem = {
+      type: 'table',
+      width: 'auto',
+      columnWidths: [100],
+      children: [
+        {
+          type: 'table-row',
+          children: [
+            { type: 'table-cell', children: [{ text: 'Cell' }] },
+          ],
+        },
+      ],
+    }
+
+    const observerVnode = renderTableConf.renderElem(elem, null, editor) as any
+    const containerVnode = observerVnode.children[0] as any
+    const rowResizer = containerVnode.children[2] as any
+    const firstRowResizer = rowResizer.children[0] as any
+
+    // 验证使用默认高度 30px
+    expect(firstRowResizer.data?.style?.minHeight).toBe('30px')
   })
 })

--- a/packages/table-module/__tests__/row-resize.test.ts
+++ b/packages/table-module/__tests__/row-resize.test.ts
@@ -1,0 +1,266 @@
+import * as core from '@wangeditor-next/core'
+import * as slate from 'slate'
+
+import createEditor from '../../../tests/utils/create-editor'
+import { TableElement, TableRowElement } from '../src/module/custom-types'
+import {
+  handleRowBorderHighlight,
+  handleRowBorderMouseDown,
+  handleRowBorderVisible,
+} from '../src/module/row-resize'
+
+// Mock DOM methods
+Object.defineProperty(window, 'getComputedStyle', {
+  value: () => ({
+    getPropertyValue: () => '',
+  }),
+})
+
+// Mock HTMLElement methods
+Object.defineProperty(HTMLElement.prototype, 'closest', {
+  value(selector: string) {
+    if (selector === '.table') {
+      return {
+        getBoundingClientRect: () => ({
+          x: 0,
+          y: 0,
+          top: 0,
+          left: 0,
+          width: 300,
+          height: 200,
+        }),
+      }
+    }
+    if (selector === '.row-resizer-item') {
+      return this
+    }
+    return null
+  },
+})
+
+// Mock isHTMLElememt function
+vi.mock('@wangeditor-next/core', async () => {
+  const actual = await vi.importActual('@wangeditor-next/core')
+
+  return {
+    ...actual,
+    isHTMLElememt: vi.fn(() => true),
+  }
+})
+
+function setEditorSelection(
+  editor: core.IDomEditor,
+  selection: slate.Selection = {
+    anchor: { path: [0, 0, 0], offset: 0 },
+    focus: { path: [0, 0, 0], offset: 0 },
+  },
+) {
+  editor.selection = selection
+}
+
+function createTableWithRows(rowHeights: number[]): TableElement {
+  const rows: TableRowElement[] = rowHeights.map(height => ({
+    type: 'table-row',
+    height,
+    children: [
+      {
+        type: 'table-cell',
+        children: [{ text: 'Cell content' }],
+      },
+    ],
+  }))
+
+  return {
+    type: 'table',
+    width: 'auto',
+    children: rows,
+    columnWidths: [100, 150, 200],
+  }
+}
+
+describe('Row Resize Module', () => {
+  let editor: core.IDomEditor
+
+  beforeEach(() => {
+    editor = createEditor()
+  })
+
+  describe('handleRowBorderVisible', () => {
+    test('should not process if editor is disabled', () => {
+      const table = createTableWithRows([30, 40, 50])
+      const mockEvent = {
+        clientY: 35,
+        target: document.createElement('div'),
+      } as MouseEvent
+
+      vi.spyOn(editor, 'isDisabled').mockReturnValue(true)
+      const transformsSpy = vi.spyOn(slate.Transforms, 'setNodes')
+
+      handleRowBorderVisible(editor, table, mockEvent)
+
+      expect(transformsSpy).not.toHaveBeenCalled()
+    })
+
+    test('should set hover state when mouse is on row border', () => {
+      const table = createTableWithRows([30, 40, 50])
+
+      // Create a mock target with closest method
+      const mockTarget = {
+        closest: vi.fn((selector: string) => {
+          if (selector === '.table') {
+            return {
+              getBoundingClientRect: () => ({
+                x: 0,
+                y: 0,
+                top: 0,
+                left: 0,
+                width: 300,
+                height: 120, // 30 + 40 + 50
+              }),
+            }
+          }
+          return null
+        }),
+      }
+
+      const mockEvent = {
+        clientY: 30, // 在第一行边界位置 (30px)
+        target: mockTarget,
+      } as MouseEvent
+
+      vi.spyOn(editor, 'isDisabled').mockReturnValue(false)
+      const transformsSpy = vi.spyOn(slate.Transforms, 'setNodes')
+
+      handleRowBorderVisible(editor, table, mockEvent)
+
+      expect(transformsSpy).toHaveBeenCalledWith(
+        editor,
+        { isHoverRowBorder: true, resizingRowIndex: 0 },
+        { mode: 'highest' },
+      )
+    })
+
+    test('should reset hover state when mouse moves away', () => {
+      const table: TableElement = {
+        ...createTableWithRows([30, 40, 50]),
+        isHoverRowBorder: true,
+        resizingRowIndex: 0,
+      }
+      const mockEvent = {
+        clientY: 200, // 远离边界
+        target: document.createElement('div'),
+      } as MouseEvent
+
+      vi.spyOn(editor, 'isDisabled').mockReturnValue(false)
+      const transformsSpy = vi.spyOn(slate.Transforms, 'setNodes')
+
+      handleRowBorderVisible(editor, table, mockEvent)
+
+      expect(transformsSpy).toHaveBeenCalledWith(
+        editor,
+        { isHoverRowBorder: false, resizingRowIndex: -1 },
+        { mode: 'highest' },
+      )
+    })
+  })
+
+  describe('handleRowBorderHighlight', () => {
+    test('should set resizing state on mouseenter', () => {
+      const mockEvent = { type: 'mouseenter' } as MouseEvent
+      const transformsSpy = vi.spyOn(slate.Transforms, 'setNodes')
+
+      handleRowBorderHighlight(editor, mockEvent)
+
+      expect(transformsSpy).toHaveBeenCalledWith(
+        editor,
+        { isResizingRow: true },
+        { mode: 'highest' },
+      )
+    })
+
+    test('should clear resizing state on mouseleave', () => {
+      const mockEvent = { type: 'mouseleave' } as MouseEvent
+      const transformsSpy = vi.spyOn(slate.Transforms, 'setNodes')
+
+      handleRowBorderHighlight(editor, mockEvent)
+
+      expect(transformsSpy).toHaveBeenCalledWith(
+        editor,
+        { isResizingRow: false },
+        { mode: 'highest' },
+      )
+    })
+  })
+
+  describe('handleRowBorderMouseDown', () => {
+    test('should set editor reference for row resizing', () => {
+      const table = createTableWithRows([30, 40, 50])
+
+      // 这个函数主要是设置内部状态，我们通过后续的拖动行为来验证
+      expect(() => {
+        handleRowBorderMouseDown(editor, table)
+      }).not.toThrow()
+    })
+  })
+
+  describe('Row resize integration', () => {
+    test('should handle complete row resize workflow', () => {
+      const table = createTableWithRows([30, 40, 50])
+
+      setEditorSelection(editor, {
+        anchor: { path: [0, 0, 0], offset: 0 },
+        focus: { path: [0, 0, 0], offset: 0 },
+      })
+
+      // 模拟鼠标悬停
+      const mockTarget = {
+        closest: vi.fn((selector: string) => {
+          if (selector === '.table') {
+            return {
+              getBoundingClientRect: () => ({
+                x: 0,
+                y: 0,
+                top: 0,
+                left: 0,
+                width: 300,
+                height: 120,
+              }),
+            }
+          }
+          return null
+        }),
+      }
+
+      const hoverEvent = {
+        clientY: 30, // 在第一行边界位置
+        target: mockTarget,
+      } as MouseEvent
+
+      vi.spyOn(editor, 'isDisabled').mockReturnValue(false)
+      const transformsSpy = vi.spyOn(slate.Transforms, 'setNodes')
+
+      handleRowBorderVisible(editor, table, hoverEvent)
+
+      // 验证悬停状态被设置
+      expect(transformsSpy).toHaveBeenCalledWith(
+        editor,
+        { isHoverRowBorder: true, resizingRowIndex: 0 },
+        { mode: 'highest' },
+      )
+
+      // 模拟鼠标按下
+      handleRowBorderMouseDown(editor, table)
+
+      // 模拟鼠标进入高亮状态
+      const enterEvent = { type: 'mouseenter' } as MouseEvent
+
+      handleRowBorderHighlight(editor, enterEvent)
+
+      expect(transformsSpy).toHaveBeenCalledWith(
+        editor,
+        { isResizingRow: true },
+        { mode: 'highest' },
+      )
+    })
+  })
+})

--- a/packages/table-module/package.json
+++ b/packages/table-module/package.json
@@ -32,8 +32,8 @@
     "url": "git+https://github.com/wangeditor-next/wangEditor-next.git"
   },
   "scripts": {
-    "test": "jest",
-    "test-c": "jest --coverage",
+    "test": "vitest run",
+    "test-c": "vitest run --coverage",
     "dev": "cross-env NODE_ENV=development rollup -c rollup.config.js",
     "dev-watch": "cross-env NODE_ENV=development rollup -c rollup.config.js -w",
     "build": "cross-env NODE_ENV=production rollup -c rollup.config.js",

--- a/packages/table-module/src/assets/index.less
+++ b/packages/table-module/src/assets/index.less
@@ -85,6 +85,47 @@
   .resizer-line-hotzone.highlight {
     opacity: 1;
   }
+/* 行拖动样式 */
+.row-resizer {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  top: 0px;
+  left: 0px;
+  width: 0;
+  height: 0;
+  z-index: 1;
+
+  .row-resizer-item {
+    position: relative;
+  }
+}
+
+.resizer-line-hotzone-horizontal {
+  cursor: row-resize;
+  position: absolute;
+  height: 6px;
+  bottom: 0px;
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity .2s ease, visibility .2s ease;
+
+  .resizer-line-horizontal {
+    width: 100%;
+    height: 2px;
+    margin-top: 5px;
+    background: rgba(20, 86, 240, 0.8);
+    user-select: none;
+  }
+}
+
+.resizer-line-hotzone-horizontal.visible {
+  visibility: visible;
+}
+
+.resizer-line-hotzone-horizontal.highlight {
+  opacity: 1;
+}
 }
 
 // --------------------------------- 分割线 ---------------------------------

--- a/packages/table-module/src/module/custom-types.ts
+++ b/packages/table-module/src/module/custom-types.ts
@@ -30,6 +30,7 @@ export type TableCellElement = {
 export type TableRowElement = {
   type: 'table-row'
   children: TableCellElement[]
+  height?: number // 行高度
 }
 
 export type TableElement = {
@@ -44,4 +45,9 @@ export type TableElement = {
   isResizing?: boolean | null //  用于设置 index resize-bar 的 highlight 属性
   isHoverCellBorder?: boolean // 用于设置 index resize-bar 的 visible 属性
   columnWidths?: number[]
+
+  /** row resize */
+  resizingRowIndex?: number // 用于标记正在调整的行索引
+  isResizingRow?: boolean | null // 用于设置行 resize-bar 的 highlight 属性
+  isHoverRowBorder?: boolean // 用于设置行 resize-bar 的 visible 属性
 }

--- a/packages/table-module/src/module/menu/DeleteRow.ts
+++ b/packages/table-module/src/module/menu/DeleteRow.ts
@@ -179,6 +179,8 @@ class DeleteRow implements IButtonMenu {
       // 删除当前行
       Transforms.removeNodes(editor, { at: rowPath })
 
+      // 行删除时，对应的行元素及其高度属性会自动被移除，无需额外操作
+
       // 在下一行（现在变成了当前行）的对应位置插入新单元格
       if (cellsToInsert.length > 0) {
         // 删除行后，原来的下一行会移动到rowPath的位置

--- a/packages/table-module/src/module/menu/InsertRow.ts
+++ b/packages/table-module/src/module/menu/InsertRow.ts
@@ -114,7 +114,9 @@ class InsertRow implements IButtonMenu {
       }
 
       // 拼接新的 row
-      const newRow: TableRowElement = { type: 'table-row', children: [] }
+      const { minRowHeight = 30 } = editor.getMenuConfig('insertTable') || {}
+      const defaultRowHeight = parseInt(minRowHeight.toString(), 10) || 30
+      const newRow: TableRowElement = { type: 'table-row', children: [], height: defaultRowHeight }
 
       // 只为不被合并单元格覆盖的位置创建td元素
       for (let i = 0; i < cellsLength; i += 1) {
@@ -136,6 +138,8 @@ class InsertRow implements IButtonMenu {
       const newRowPath = Path.next(rowPath)
 
       Transforms.insertNodes(editor, newRow, { at: newRowPath })
+
+      // 新插入的行已经在创建时设置了高度属性，无需额外操作
     })
   }
 }

--- a/packages/table-module/src/module/menu/InsertTable.ts
+++ b/packages/table-module/src/module/menu/InsertTable.ts
@@ -17,7 +17,9 @@ import { TableCellElement, TableElement, TableRowElement } from '../custom-types
 function genTableNode(editor: IDomEditor, rowNum: number, colNum: number): TableElement {
   // 拼接 rows
   const rows: TableRowElement[] = []
-  const { minWidth = 60, tableFullWidth, tableHeader } = editor.getMenuConfig('insertTable')
+  const {
+    minWidth = 60, minRowHeight = 30, tableFullWidth, tableHeader,
+  } = editor.getMenuConfig('insertTable')
   const columnWidths: number[] = Array(colNum).fill(parseInt(minWidth, 10) || 60)
 
   for (let i = 0; i < rowNum; i += 1) {
@@ -40,6 +42,7 @@ function genTableNode(editor: IDomEditor, rowNum: number, colNum: number): Table
     rows.push({
       type: 'table-row',
       children: cells,
+      height: parseInt(minRowHeight, 10) || 30,
     })
   }
 

--- a/packages/table-module/src/module/render-elem/render-row.tsx
+++ b/packages/table-module/src/module/render-elem/render-row.tsx
@@ -8,12 +8,20 @@ import { Element as SlateElement } from 'slate'
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { jsx, VNode } from 'snabbdom'
 
+import { TableRowElement } from '../custom-types'
+
 function renderTableRow(
-  _elemNode: SlateElement,
+  elemNode: SlateElement,
   children: VNode[] | null,
   _editor: IDomEditor,
 ): VNode {
-  const vnode = <tr>{children}</tr>
+  const { height } = elemNode as TableRowElement
+
+  const vnode = (
+    <tr style={{ height: height ? `${height}px` : undefined }}>
+      {children}
+    </tr>
+  )
 
   return vnode
 }

--- a/packages/table-module/src/module/row-resize.ts
+++ b/packages/table-module/src/module/row-resize.ts
@@ -1,0 +1,260 @@
+import { DomEditor, IDomEditor, isHTMLElememt } from '@wangeditor-next/core'
+import throttle from 'lodash.throttle'
+import { Editor, Element as SlateElement, Transforms } from 'slate'
+
+import { isOfType } from '../utils'
+import $ from '../utils/dom'
+import { TableElement, TableRowElement } from './custom-types'
+
+/**
+ * 计算行高度的比例
+ */
+export function getRowHeightRatios(rowHeights: number[]) {
+  const rowHeightRatios: number[] = []
+  const totalHeight = rowHeights.reduce((a, b) => a + b, 0)
+
+  for (const height of rowHeights) {
+    rowHeightRatios.push(height / totalHeight)
+  }
+
+  return rowHeightRatios
+}
+
+/**
+ * 计算累积行高度
+ */
+function getCumulativeHeights(rowHeights: number[]) {
+  const cumulativeHeights: number[] = []
+  let totalHeight = 0
+
+  for (const height of rowHeights) {
+    totalHeight += height
+    cumulativeHeights.push(totalHeight)
+  }
+
+  return cumulativeHeights
+}
+
+// 行拖拽相关状态
+let isMouseDownForRowResize = false
+let clientYWhenMouseDown = 0
+let editorWhenMouseDownForRow: IDomEditor | null = null
+const $window = $(window)
+
+/**
+ * 计算行高度调整
+ */
+function calculateRowHeights(rowHeights: number[], resizingRowIndex: number, heightChange: number, editor: IDomEditor): number[] {
+  const newHeights = [...rowHeights]
+
+  // 获取最小高度配置
+  const { minRowHeight = 30 } = editor.getMenuConfig('insertTable') || {}
+  const minHeight = parseInt(minRowHeight.toString(), 10) || 30
+
+  // 直接增加当前行的高度，其他行保持不变
+  const currentHeight = newHeights[resizingRowIndex]
+  const newHeight = Math.max(minHeight, currentHeight + heightChange)
+
+  newHeights[resizingRowIndex] = Math.floor(newHeight * 100) / 100
+
+  return newHeights
+}
+
+/**
+ * 根据鼠标位置计算行高度
+ */
+function calculateRowHeightsByBorderPosition(
+  rowHeights: number[],
+  resizingRowIndex: number,
+  mousePositionInTable: number,
+  cumulativeHeights: number[],
+  editor: IDomEditor,
+): number[] {
+  const newHeights = [...rowHeights]
+
+  // 检查边界范围
+  if (resizingRowIndex < 0 || resizingRowIndex >= rowHeights.length) {
+    return newHeights
+  }
+
+  // 获取最小高度配置
+  const { minRowHeight = 30 } = editor.getMenuConfig('insertTable') || {}
+  const minHeight = parseInt(minRowHeight.toString(), 10) || 30
+
+  // 计算当前边界的上边界位置
+  const topBoundary = resizingRowIndex === 0 ? 0 : cumulativeHeights[resizingRowIndex - 1]
+
+  // 计算鼠标位置相对于当前行上边界的偏移
+  const mouseOffset = mousePositionInTable - topBoundary
+
+  // 确保不小于最小高度
+  const newHeight = Math.max(minHeight, mouseOffset)
+
+  // 直接设置当前行的高度，其他行保持不变
+  newHeights[resizingRowIndex] = Math.floor(newHeight * 100) / 100
+
+  return newHeights
+}
+
+function onMouseMoveForRowHandler(event: Event) {
+  if (!isMouseDownForRowResize) { return }
+  if (editorWhenMouseDownForRow === null) { return }
+  event.preventDefault()
+
+  const { clientY } = event as MouseEvent
+  const heightChange = clientY - clientYWhenMouseDown
+
+  const [[elemNode]] = Editor.nodes(editorWhenMouseDownForRow, {
+    match: isOfType(editorWhenMouseDownForRow, 'table'),
+  })
+  const { children: tableRows, resizingRowIndex = -1 } = elemNode as TableElement
+
+  // 从实际行元素获取高度
+  const rowHeights = tableRows.map(row => (row as TableRowElement).height || 30)
+
+  let adjustRowHeights: number[]
+  const tableNode = DomEditor.getSelectedNodeByType(editorWhenMouseDownForRow, 'table') as TableElement
+  const tableDom = DomEditor.toDOMNode(editorWhenMouseDownForRow, tableNode)
+
+  const tableElement = tableDom.querySelector('.table')
+
+  if (tableElement) {
+    const tableRect = tableElement.getBoundingClientRect()
+    const mousePositionInTable = clientY - tableRect.top
+
+    // 计算边界的新位置
+    const cumulativeHeights = getCumulativeHeights(rowHeights)
+    const newBorderPosition = mousePositionInTable
+
+    // 根据新的边界位置计算行高度
+    adjustRowHeights = calculateRowHeightsByBorderPosition(rowHeights, resizingRowIndex, newBorderPosition, cumulativeHeights, editorWhenMouseDownForRow)
+  } else {
+    // 如果找不到表格元素，则使用简单的高度变化逻辑
+    adjustRowHeights = calculateRowHeights(rowHeights, resizingRowIndex, heightChange, editorWhenMouseDownForRow)
+  }
+
+  // 直接更新对应行元素的高度
+  const currentTableNode = DomEditor.getSelectedNodeByType(editorWhenMouseDownForRow, 'table') as TableElement
+
+  if (currentTableNode && resizingRowIndex >= 0 && resizingRowIndex < adjustRowHeights.length) {
+    const tablePath = DomEditor.findPath(editorWhenMouseDownForRow, currentTableNode)
+    const rowPath = [...tablePath, resizingRowIndex]
+
+    try {
+      Transforms.setNodes(
+        editorWhenMouseDownForRow,
+        { height: adjustRowHeights[resizingRowIndex] } as TableRowElement,
+        { at: rowPath },
+      )
+    } catch (error) {
+      // 如果路径不存在，忽略错误
+      console.warn('更新行高度失败:', error)
+    }
+  }
+}
+
+const onMouseMoveForRowThrottled = throttle(onMouseMoveForRowHandler, 100)
+
+function onMouseUpForRow(_event: Event) {
+  isMouseDownForRowResize = false
+  editorWhenMouseDownForRow = null
+  document.body.style.cursor = ''
+
+  // 解绑事件
+  $window.off('mousemove', onMouseMoveForRowThrottled)
+  $window.off('mouseup', onMouseUpForRow)
+}
+
+/**
+ * 鼠标移动时，判断在哪个行边界上
+ */
+export function handleRowBorderVisible(
+  editor: IDomEditor,
+  elemNode: SlateElement,
+  e: MouseEvent,
+) {
+  if (editor.isDisabled()) { return }
+  if (isMouseDownForRowResize) { return }
+
+  const {
+    children: tableRows,
+    isHoverRowBorder,
+    resizingRowIndex,
+  } = elemNode as TableElement
+
+  const { target } = e
+
+  if (isHTMLElememt(target)) {
+    const parent = target.closest('.table')
+
+    if (parent) {
+      const { clientY: mouseY } = e
+      const rect = parent.getBoundingClientRect()
+
+      // 从实际行元素获取高度
+      const actualRowHeights = tableRows.map(row => (row as TableRowElement).height || 30)
+      const cumulativeHeights = getCumulativeHeights(actualRowHeights)
+
+      // 鼠标移动时，计算当前鼠标位置，判断在哪个行边界上
+      for (let i = 0; i < cumulativeHeights.length; i += 1) {
+        if (
+          mouseY - rect.y >= cumulativeHeights[i] - 5
+          && mouseY - rect.y < cumulativeHeights[i] + 5
+        ) {
+          // 节流，防止多次引起Transforms.setNodes重绘
+          if (resizingRowIndex === i) { return }
+          Transforms.setNodes(
+            editor,
+            { isHoverRowBorder: true, resizingRowIndex: i } as TableElement,
+            { mode: 'highest' },
+          )
+          return
+        }
+      }
+    }
+  }
+
+  // 鼠标移出时，重置
+  if (isHoverRowBorder === true) {
+    Transforms.setNodes(editor, { isHoverRowBorder: false, resizingRowIndex: -1 } as TableElement, {
+      mode: 'highest',
+    })
+  }
+}
+
+/**
+ * 设置行拖拽高亮
+ */
+export function handleRowBorderHighlight(editor: IDomEditor, e: MouseEvent) {
+  if (e.type === 'mouseenter') {
+    Transforms.setNodes(editor, { isResizingRow: true } as TableElement, { mode: 'highest' })
+  } else {
+    Transforms.setNodes(editor, { isResizingRow: false } as TableElement, { mode: 'highest' })
+  }
+}
+
+export function handleRowBorderMouseDown(editor: IDomEditor, _elemNode: SlateElement) {
+  if (isMouseDownForRowResize) { return }
+  editorWhenMouseDownForRow = editor
+}
+
+function onMouseDownForRow(event: Event) {
+  const elem = event.target as HTMLElement
+
+  if (elem.tagName === 'DIV' && elem.closest('.row-resizer-item')) {
+    if (editorWhenMouseDownForRow === null) { return }
+
+    // 记录必要信息
+    isMouseDownForRowResize = true
+    const { clientY } = event as MouseEvent
+
+    clientYWhenMouseDown = clientY
+    document.body.style.cursor = 'row-resize'
+    event.preventDefault()
+  }
+
+  $window.on('mousemove', onMouseMoveForRowThrottled)
+  $window.on('mouseup', onMouseUpForRow)
+}
+
+$window.on('mousedown', onMouseDownForRow)

--- a/packages/upload-image-module/package.json
+++ b/packages/upload-image-module/package.json
@@ -32,8 +32,8 @@
     "url": "git+https://github.com/wangeditor-next/wangEditor-next.git"
   },
   "scripts": {
-    "test": "jest",
-    "test-c": "jest --coverage",
+    "test": "vitest run",
+    "test-c": "vitest run --coverage",
     "dev": "cross-env NODE_ENV=development rollup -c rollup.config.js",
     "dev-watch": "cross-env NODE_ENV=development rollup -c rollup.config.js -w",
     "build": "cross-env NODE_ENV=production rollup -c rollup.config.js",

--- a/packages/video-module/package.json
+++ b/packages/video-module/package.json
@@ -32,8 +32,8 @@
     "url": "git+https://github.com/wangeditor-next/wangEditor-next.git"
   },
   "scripts": {
-    "test": "jest",
-    "test-c": "jest --coverage",
+    "test": "vitest run",
+    "test-c": "vitest run --coverage",
     "dev": "cross-env NODE_ENV=development rollup -c rollup.config.js",
     "dev-watch": "cross-env NODE_ENV=development rollup -c rollup.config.js -w",
     "build": "cross-env NODE_ENV=production rollup -c rollup.config.js",

--- a/packages/yjs-for-react/package.json
+++ b/packages/yjs-for-react/package.json
@@ -39,8 +39,8 @@
     "url": "git+https://github.com/wangeditor-next/wangEditor-next.git"
   },
   "scripts": {
-    "test": "jest",
-    "test-c": "jest --coverage",
+    "test": "vitest run",
+    "test-c": "vitest run --coverage",
     "dev": "cross-env NODE_ENV=development rollup -c rollup.config.js",
     "dev-watch": "cross-env NODE_ENV=development rollup -c rollup.config.js -w",
     "build": "cross-env NODE_ENV=production rollup -c rollup.config.js",

--- a/packages/yjs/package.json
+++ b/packages/yjs/package.json
@@ -39,8 +39,8 @@
     "url": "git+https://github.com/wangeditor-next/wangEditor-next.git"
   },
   "scripts": {
-    "test": "jest",
-    "test-c": "jest --coverage",
+    "test": "vitest run",
+    "test-c": "vitest run --coverage",
     "dev": "cross-env NODE_ENV=development rollup -c rollup.config.js",
     "dev-watch": "cross-env NODE_ENV=development rollup -c rollup.config.js -w",
     "build": "cross-env NODE_ENV=production rollup -c rollup.config.js",


### PR DESCRIPTION
- 在样式文件中新增行拖动相关样式。
- 扩展自定义类型，增加行高度属性。
- 实现行高度调整的逻辑，包括鼠标拖动时的高度计算。
- 更新表格渲染逻辑，支持动态设置行高度。
- 增加行边界高亮和可见性处理。

## Changes Overview
<!-- Briefly describe your changes. -->

## Implementation Approach
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done
<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps
<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes
<!-- Add any other notes or screenshots about the PR here. -->

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
<!-- Link any related issues here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Drag-to-resize table row heights with hover, highlight feedback and visible row handles.
  - Rows render with explicit per-row heights so resizers align correctly.
  - New/inserted tables and rows use a configurable default row height (minRowHeight).

- **Tests**
  - Added unit tests for row insertion heights, row rendering, resizer UI structure, and row-resize interactions.

- **Chores**
  - Switched package test runner from Jest to Vitest across multiple packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->