### PR TITLE
fix(core/syncSelection): 修复在code、table中回车会滚动到顶部的问题(#640)

### DIFF
--- a/.changeset/clean-paws-film.md
+++ b/.changeset/clean-paws-film.md
@@ -1,0 +1,5 @@
+---
+"@wangeditor-next/core": patch
+---
+
+fix(core/syncSelection): 修复在code、table中回车会滚动到顶部的问题(#640)


### PR DESCRIPTION
## Changes Overview
<!-- Briefly describe your changes. -->
fix(core/syncSelection): 修复在code、table中回车会滚动到顶部的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents unexpected auto-scrolling when pressing Enter on empty lines (e.g., in code blocks or tables).
  * Improves caret/selection visibility by avoiding scroll calculations when measurements are invalid.
  * Ensures reliable scrolling by falling back to the page when no parent scrolling container is available.
  * Reduces jumpy behavior during editing for a smoother typing experience.

* **Chores**
  * Added a patch release entry documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->