### PR TITLE
fix(core/parse-html): 修复腾讯等文档复制html时，存在<span><img /></span>的不支持结构的问题(#645)

### DIFF
--- a/.changeset/giant-rockets-play.md
+++ b/.changeset/giant-rockets-play.md
@@ -1,0 +1,6 @@
+---
+"@wangeditor-next/basic-modules": patch
+"@wangeditor-next/core": patch
+---
+
+fix(core/parse-html): 修复腾讯等文档复制html时，存在<span><img /></span>的不支持结构的问题(#645)

--- a/packages/basic-modules/src/modules/paragraph/parse-elem-html.ts
+++ b/packages/basic-modules/src/modules/paragraph/parse-elem-html.ts
@@ -6,20 +6,8 @@
 import { IDomEditor } from '@wangeditor-next/core'
 import { Descendant, Text } from 'slate'
 
-import { CustomElement } from '../../../../custom-types'
 import $, { DOMElement } from '../../utils/dom'
 import { ParagraphElement } from './custom-types'
-
-function hasTypeInChildren(node: CustomElement, targetType: string) {
-  if (!node.children) { return false }
-
-  for (const child of node.children) {
-    if ('type' in child && child.type === targetType) { return true }
-    if ('children' in child && hasTypeInChildren(child as CustomElement, targetType)) { return true }
-  }
-
-  return false
-}
 
 function parseParagraphHtml(
   elem: DOMElement,
@@ -31,13 +19,6 @@ function parseParagraphHtml(
   children = children.filter(child => {
     if (Text.isText(child)) { return true }
     if (editor.isInline(child)) { return true }
-
-    // 包含 image、link、video、iframe 保留, 目前仅额外支持这四种类型
-    if (hasTypeInChildren(child, 'image')) { return true }
-    if (hasTypeInChildren(child, 'link')) { return true }
-    if (hasTypeInChildren(child, 'video')) { return true }
-    if (hasTypeInChildren(child, 'iframe')) { return true }
-
     return false
   })
 

--- a/packages/core/src/parse-html/index.ts
+++ b/packages/core/src/parse-html/index.ts
@@ -23,14 +23,6 @@ export const TEXT_TAGS = [
   'sup',
 ]
 
-// 解析 elem 时，需要特殊处理的标签
-export const SPAN_WITH_SPECIAL_TAGS = [
-  'a',
-  'img',
-  'video',
-  'iframe',
-]
-
 // ------------------------------------ pre-parse html ------------------------------------
 export type PreParseHtmlFnType = ($node: DOMElement) => DOMElement
 

--- a/packages/core/src/parse-html/parse-common-elem-html.ts
+++ b/packages/core/src/parse-html/parse-common-elem-html.ts
@@ -127,7 +127,7 @@ function genChildren($elem: Dom7Array, editor: IDomEditor): Descendant[] {
 function defaultParser(elem: DOMElement, _children: Descendant[], _editor: IDomEditor): Element {
   return {
     type: 'paragraph',
-    children: _children.length ? _children : [{ text: $(elem).text().replace(/\s+/gm, ' ') }],
+    children: [{ text: $(elem).text().replace(/\s+/gm, ' ') }],
   }
 }
 

--- a/packages/core/src/parse-html/parse-elem-html.ts
+++ b/packages/core/src/parse-html/parse-elem-html.ts
@@ -7,7 +7,7 @@ import $, { Dom7Array } from 'dom7'
 import { Descendant } from 'slate'
 
 import { IDomEditor } from '../editor/interface'
-import { PRE_PARSE_HTML_CONF_LIST, SPAN_WITH_SPECIAL_TAGS, TEXT_TAGS } from '../index'
+import { PRE_PARSE_HTML_CONF_LIST, TEXT_TAGS } from '../index'
 import {
   getTagName, isDOMComment, isDOMElement, isDOMText,
 } from '../utils/dom'
@@ -59,13 +59,6 @@ function parseElemHtml($elem: Dom7Array, editor: IDomEditor): Descendant | Desce
   // <span> 判断有没有 data-w-e-type 属性。有则是 elem ，没有则是 text
   if (tagName === 'span') {
     if ($elem.attr('data-w-e-type')) {
-      return parseCommonElemHtml($elem, editor)
-    }
-
-    // 兼容粘贴其他编辑器 html 代码时，<span> 标签包含 img、a、video、iframe 标签进行处理，其他 inline 标签暂不支持
-    const matchSpecialTag = SPAN_WITH_SPECIAL_TAGS.find(elemTag => $elem.find(elemTag).length > 0)
-
-    if (matchSpecialTag) {
       return parseCommonElemHtml($elem, editor)
     }
 

--- a/packages/core/src/parse-html/parse-elem-html.ts
+++ b/packages/core/src/parse-html/parse-elem-html.ts
@@ -62,7 +62,9 @@ function parseElemHtml($elem: Dom7Array, editor: IDomEditor): Descendant | Desce
       return parseCommonElemHtml($elem, editor)
     }
 
-    if ($elem[0].childNodes.length > 1) {
+    const hasImgOrA = $elem.find('img, a').length > 0
+
+    if ($elem[0].childNodes.length > 1 || hasImgOrA) {
       const childNodes = $elem[0].childNodes
       const parentStyle = parseTextElemHtmlToStyle($($elem[0]), editor)
 


### PR DESCRIPTION
## Changes Overview
<!-- Briefly describe your changes. -->
修复 issue https://github.com/wangeditor-next/wangEditor-next/issues/645
1. 还原之前的修复方式：https://github.com/wangeditor-next/wangEditor-next/pull/663
2. 该方式释放过多不可控，不可控核心代码：`_children.length ? _children : [{ text: $(elem).text().replace(/\s+/gm, ' ') }]`
3. 新增修复方式，继承原有解析`<span>`标签的方式，将符合期望的`<span>`的children提升到该`<span>`所在位置，删除该`<span>`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - More reliable pasting of HTML containing spans with images or links; these embedded items are now preserved and parsed consistently.

- Refactor
  - Paragraph parsing simplified to retain only text and inline elements, reducing unexpected block elements inside paragraphs.
  - Removed special-case tag handling for spans, making HTML parsing more predictable across inputs.

- Documentation
  - Updated notes to reflect the new span and paragraph parsing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->