### PR TITLE
fix(blockquote/plugin): 修复有文字 + /n + img 的情况下，会误删 img 的问题(#709)

### DIFF
--- a/.changeset/slow-garlics-sniff.md
+++ b/.changeset/slow-garlics-sniff.md
@@ -1,0 +1,6 @@
+---
+"@wangeditor-next/basic-modules": patch
+"@wangeditor-next/editor": patch
+---
+
+fix(blockquote/plugin): 修复有文字 + /n + img 的情况下，会误删 img 的问题(#709)

--- a/packages/basic-modules/src/modules/blockquote/plugin.ts
+++ b/packages/basic-modules/src/modules/blockquote/plugin.ts
@@ -5,7 +5,8 @@
 
 import { DomEditor, IDomEditor } from '@wangeditor-next/core'
 import {
-  Editor, Node, Point, Transforms,
+  Editor, Node, Point,
+  Transforms,
 } from 'slate'
 
 function insertParagraphBeforeNewline(editor: any) {
@@ -46,8 +47,9 @@ function withBlockquote<T extends IDomEditor>(editor: T): T {
     const quoteEndLocation = Editor.end(editor, quotePath)
 
     if (Point.equals(quoteEndLocation, selection.focus)) {
+      const lastNode = Editor.last(editor, quoteEndLocation.path)
       // 光标位于 blockquote 最后
-      const str = Node.string(quoteElem)
+      const str = Node.string(lastNode[0])
 
       if (str && str.slice(-1) === '\n') {
         insertParagraphBeforeNewline(newEditor)


### PR DESCRIPTION
## Changes Overview
fix(blockquote/plugin): 修复有文字 + /n + img 的情况下，会误删 img 的问题(#709)

## Related Issues
[<!-- Link any related issues here -->](https://github.com/wangeditor-next/wangEditor-next/issues/709)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed blockquote edge case where placing the cursor at the end could remove an adjacent image; trailing content now preserves images and inserts the correct paragraph or newline based on the block’s final content, improving line-break behavior and formatting consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->