### PR TITLE
fix(table-module): 修复多选table-cell时，鼠标触发到设置cell宽度的border，会导致选中丢失的问题

### DIFF
--- a/.changeset/flat-turtles-exercise.md
+++ b/.changeset/flat-turtles-exercise.md
@@ -1,0 +1,5 @@
+---
+"@wangeditor-next/table-module": patch
+---
+
+fix(table-module): 修复多选table-cell时，鼠标触发到设置cell宽度的border，会导致选中丢失的问题

--- a/packages/table-module/src/module/render-elem/render-table.tsx
+++ b/packages/table-module/src/module/render-elem/render-table.tsx
@@ -6,7 +6,9 @@
 import { DomEditor, IDomEditor } from '@wangeditor-next/core'
 import debounce from 'lodash.debounce'
 import {
-  Editor, Element as SlateElement, Path, Point, Range,
+  Editor,
+  Element as SlateElement,
+  Path, Point, Range,
 } from 'slate'
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { h, jsx, VNode } from 'snabbdom'
@@ -133,8 +135,10 @@ function renderTable(elemNode: SlateElement, children: VNode[] | null, editor: I
         on={{
           mousemove: debounce(
             (e: MouseEvent) => {
-              handleCellBorderVisible(editor, elemNode, e, scrollWidth)
-              handleRowBorderVisible(editor, elemNode, e)
+              if (!TableCursor.hasSelected(editor)) {
+                handleCellBorderVisible(editor, elemNode, e, scrollWidth)
+                handleRowBorderVisible(editor, elemNode, e)
+              }
             },
             25,
           ),

--- a/packages/table-module/src/module/table-cursor.ts
+++ b/packages/table-module/src/module/table-cursor.ts
@@ -84,4 +84,8 @@ export const TableCursor = {
 
     return selectedElements.has(element)
   },
+
+  hasSelected(editor: Editor) {
+    return EDITOR_TO_SELECTION.has(editor)
+  },
 }


### PR DESCRIPTION
## Changes Overview
fix(table-module): 修复多选table-cell时，鼠标触发到设置cell宽度的border，会导致选中丢失的问题


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hovering around table edges no longer reveals cell/row borders when a table selection is active.
  * Reduced accidental border flicker and improved selection stability when moving the mouse near table cells, preserving multi-cell selections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->