### PR TITLE
fix(table-module): fix the borderWidth of table copied from Safari(#146)

### DIFF
--- a/.changeset/cuddly-jokes-carry.md
+++ b/.changeset/cuddly-jokes-carry.md
@@ -1,0 +1,6 @@
+---
+"@wangeditor-next/table-module": patch
+"@wangeditor-next/editor": patch
+---
+
+fix(table-module): fix the borderWidth of table copied from Safari(#146)

--- a/packages/table-module/__tests__/parse-html.test.ts
+++ b/packages/table-module/__tests__/parse-html.test.ts
@@ -2,16 +2,28 @@
  * @description parse html test
  * @author wangfupeng
  */
-
 import { $ } from 'dom7'
 
 import createEditor from '../../../tests/utils/create-editor'
+import { registerParseElemHtmlConf } from '../../core/src/parse-html'
+import { registerParseStyleHtmlHandler } from '../../core/src/parse-html/index'
+import parseElemHtmlFromCore from '../../core/src/parse-html/parse-elem-html'
+import wangEditorTableModule from '../src/index'
 import {
   parseCellHtmlConf,
   parseRowHtmlConf,
   parseTableHtmlConf,
 } from '../src/module/parse-elem-html'
 import { preParseTableHtmlConf } from '../src/module/pre-parse-html'
+
+const TABLE_CELL_BASE_PROPS = {
+  type: 'table-cell',
+  isHeader: false,
+  colSpan: 1,
+  rowSpan: 1,
+  width: 'auto',
+  hidden: false,
+}
 
 describe('table - pre parse html', () => {
   it('pre parse', () => {
@@ -48,6 +60,13 @@ describe('table - pre parse html', () => {
 describe('table - parse html', () => {
   const editor = createEditor()
 
+  beforeEach(() => {
+    wangEditorTableModule.parseElemsHtml!.forEach(item => {
+      registerParseElemHtmlConf(item)
+    })
+    registerParseStyleHtmlHandler(wangEditorTableModule.parseStyleHtml!)
+  })
+
   it('table cell', () => {
     const $cell1 = $('<td>hello&nbsp;world</td>')
 
@@ -76,6 +95,181 @@ describe('table - parse html', () => {
       hidden: true,
     })
   })
+
+  // ============== 测试table的border相关属性 start ==============
+
+  it('table cell (TD) without border style should use default border (1px)', () => {
+    const $cell = $('<td>Cell A</td>')
+    const children = [{ text: 'Cell A' }]
+
+    expect(parseElemHtmlFromCore($($cell[0]), editor)).toEqual([
+      {
+        ...TABLE_CELL_BASE_PROPS,
+        children,
+        borderWidth: '1px',
+        borderStyle: 'solid',
+        borderColor: undefined,
+      },
+    ])
+  })
+
+  it('table cell with full border shorthand property (4px)', () => {
+    const $cell = $('<td style="border: 4px solid red;">Cell B</td>')
+    const children = [{ text: 'Cell B' }]
+
+    expect(parseElemHtmlFromCore($($cell[0]), editor)).toEqual([
+      {
+        ...TABLE_CELL_BASE_PROPS,
+        children,
+        borderWidth: '4px',
+        borderStyle: 'solid',
+        borderColor: 'red',
+      },
+    ])
+  })
+
+  it('table cell with explicit float border-width (1.5em)', () => {
+    const $cell = $(
+      '<td style="border-width: 1.5em; border-style: dotted; border-color: orange;">Cell C</td>',
+    )
+    const children = [{ text: 'Cell C' }]
+
+    expect(parseElemHtmlFromCore($($cell[0]), editor)).toEqual([
+      {
+        ...TABLE_CELL_BASE_PROPS,
+        children,
+        borderWidth: '1.5em',
+        borderStyle: 'dotted',
+        borderColor: 'orange',
+      },
+    ])
+  })
+
+  it('table cell with keyword border-width (thin) should be retained', () => {
+    const $cell = $(
+      '<td style="border-width: thin; border-style: dotted; border-color: blue;">Cell D</td>',
+    )
+    const children = [{ text: 'Cell D' }]
+
+    expect(parseElemHtmlFromCore($($cell[0]), editor)).toEqual([
+      {
+        ...TABLE_CELL_BASE_PROPS,
+        children,
+        borderWidth: 'thin',
+        borderStyle: 'dotted',
+        borderColor: 'blue',
+      },
+    ])
+  })
+
+  it('table cell with multi-value should be retained', () => {
+    const $cell = $(
+      '<td style="border-width: 2px 1em; border-style: dotted solid dashed; border-color: #ff0000 #00ff00 #0000ff rgb(250,0,255)">Cell E</td>',
+    )
+    const children = [{ text: 'Cell E' }]
+
+    expect(parseElemHtmlFromCore($($cell[0]), editor)).toEqual([
+      {
+        ...TABLE_CELL_BASE_PROPS,
+        children,
+        borderWidth: '2px 1em',
+        borderStyle: 'dotted solid dashed',
+        borderColor: '#ff0000 #00ff00 #0000ff rgb(250,0,255)',
+      },
+    ])
+  })
+
+  it('table cell with border-width using "pt" unit should convert to "px"', () => {
+    const $cell = $('<td style="border-width: 1pt; border-style: solid;">Cell G</td>')
+    const children = [{ text: 'Cell G' }]
+
+    const expectedPx = `${((1 * 4) / 3).toFixed(6)}px`
+
+    expect(parseElemHtmlFromCore($($cell[0]), editor)).toEqual([
+      {
+        ...TABLE_CELL_BASE_PROPS,
+        children,
+        borderWidth: expectedPx,
+        borderStyle: 'solid',
+        borderColor: undefined,
+      },
+    ])
+  })
+
+  it('table cell with multi-value border-width mixing keywords, pt, and px should convert correctly', () => {
+    const multiPtWidth = 'medium 1pt 0.5pt 2px'
+    const $cell = $(
+      `<td style="border-width: ${multiPtWidth}; border-style: dashed; border-color: red;">Cell H</td>`,
+    )
+    const children = [{ text: 'Cell H' }]
+
+    const expected1pt = ((1 * 4) / 3).toFixed(6)
+    const expected05pt = ((0.5 * 4) / 3).toFixed(6)
+    const expectedBorderWidth = `medium ${expected1pt}px ${expected05pt}px 2px`
+
+    expect(parseElemHtmlFromCore($($cell[0]), editor)).toEqual([
+      {
+        ...TABLE_CELL_BASE_PROPS,
+        children,
+        borderWidth: expectedBorderWidth,
+        borderStyle: 'dashed',
+        borderColor: 'red',
+      },
+    ])
+  })
+
+  it('Cell with border-width containing pt should convert width correctly', () => {
+    const $cell = $('<td style="border-width: 2.25pt;">Cell I</td>')
+    const children = [{ text: 'Cell I' }]
+
+    const expectedPx = `${((2.25 * 4) / 3).toFixed(6)}px`
+
+    expect(parseElemHtmlFromCore($($cell[0]), editor)).toEqual([
+      {
+        ...TABLE_CELL_BASE_PROPS,
+        children,
+        borderWidth: expectedPx,
+        borderStyle: 'solid',
+        borderColor: undefined,
+      },
+    ])
+  })
+
+  it('should use specific border-width/style/color over border shorthand', () => {
+    const $cell = $(
+      '<td style="border: 1px solid red; border-width: 5px; border-style: dashed; border-color: blue;">Cell I</td>',
+    )
+    const children = [{ text: 'Cell I' }]
+
+    expect(parseElemHtmlFromCore($($cell[0]), editor)).toEqual([
+      {
+        ...TABLE_CELL_BASE_PROPS,
+        children,
+        borderWidth: '5px',
+        borderStyle: 'dashed',
+        borderColor: 'blue',
+      },
+    ])
+  })
+
+  it('should use specific border-width/color over border shorthand', () => {
+    const $cell = $(
+      '<td style="border: 1px dashed red; border-width: 5px; border-color: blue;">Cell I</td>',
+    )
+    const children = [{ text: 'Cell I' }]
+
+    expect(parseElemHtmlFromCore($($cell[0]), editor)).toEqual([
+      {
+        ...TABLE_CELL_BASE_PROPS,
+        children,
+        borderWidth: '5px',
+        borderStyle: 'dashed',
+        borderColor: 'blue',
+      },
+    ])
+  })
+
+  // ============== 测试table的border相关属性 end ==============
 
   it('table row', () => {
     const $tr = $('<tr></tr>')

--- a/packages/table-module/__tests__/parse-html.test.ts
+++ b/packages/table-module/__tests__/parse-html.test.ts
@@ -183,7 +183,7 @@ describe('table - parse html', () => {
     const $cell = $('<td style="border-width: 1pt; border-style: solid;">Cell G</td>')
     const children = [{ text: 'Cell G' }]
 
-    const expectedPx = `${((1 * 4) / 3).toFixed(6)}px`
+    const expectedPx = `${((1 * 4) / 3).toFixed(2)}px`
 
     expect(parseElemHtmlFromCore($($cell[0]), editor)).toEqual([
       {
@@ -203,8 +203,8 @@ describe('table - parse html', () => {
     )
     const children = [{ text: 'Cell H' }]
 
-    const expected1pt = ((1 * 4) / 3).toFixed(6)
-    const expected05pt = ((0.5 * 4) / 3).toFixed(6)
+    const expected1pt = ((1 * 4) / 3).toFixed(2)
+    const expected05pt = ((0.5 * 4) / 3).toFixed(2)
     const expectedBorderWidth = `medium ${expected1pt}px ${expected05pt}px 2px`
 
     expect(parseElemHtmlFromCore($($cell[0]), editor)).toEqual([
@@ -222,7 +222,7 @@ describe('table - parse html', () => {
     const $cell = $('<td style="border-width: 2.25pt;">Cell I</td>')
     const children = [{ text: 'Cell I' }]
 
-    const expectedPx = `${((2.25 * 4) / 3).toFixed(6)}px`
+    const expectedPx = `${((2.25 * 4) / 3).toFixed(2)}px`
 
     expect(parseElemHtmlFromCore($($cell[0]), editor)).toEqual([
       {

--- a/packages/table-module/src/module/parse-style-html.ts
+++ b/packages/table-module/src/module/parse-style-html.ts
@@ -13,6 +13,28 @@ const DEFAULT_BORDER_COLOR = window
   ?.getComputedStyle(document.documentElement)
   ?.getPropertyValue('--w-e-textarea-border-color')
 
+/**
+ * 将 CSS 尺寸字符串中的 'pt' 转换为 'px'
+ * 转换比例: 1pt = 1.333333px (基于 W3C 推荐的 96 DPI 标准)
+ * @param cssValue 包含 pt 单位的 CSS 字符串 (如 "medium 1pt 1pt 0.5pt")
+ * @returns 转换后的 CSS 字符串 (如 "medium 1.333333px 1.333333px 0.6666665px")
+ */
+function convertPtToPx(cssValue: string): string {
+  if (!cssValue || typeof cssValue !== 'string' || !cssValue.includes('pt')) {
+    return cssValue
+  }
+
+  // 使用正则匹配所有带 'pt' 单位的值，例如 '1pt', '0.5pt', '100pt'，并进行替换
+  return cssValue.replace(/(\d+(\.\d+)?)\s*pt/g, (_, p1) => {
+    // p1 是捕获到的数字部分 (如 '1' 或 '0.5')
+    const ptValue = parseFloat(p1)
+    // 1pt ≈ 1.333333px。为了简化和保证精度，使用 4/3
+    const pxValue = ((ptValue * 4) / 3).toFixed(6)
+
+    return `${pxValue}px`
+  })
+}
+
 export function parseStyleHtml(elem: DOMElement, node: Descendant, _editor: IDomEditor): Descendant {
   if (!['TABLE', 'TD', 'TH'].includes(elem.tagName)) { return node }
 
@@ -38,7 +60,7 @@ export function parseStyleHtml(elem: DOMElement, node: Descendant, _editor: IDom
 
   borderWidth = getStyleValue($elem, 'border-width') || borderWidth // border 宽度
   if (borderWidth) {
-    tableNode.borderWidth = borderWidth.replace(/[^\d]/g, '')
+    tableNode.borderWidth = convertPtToPx(borderWidth.trim())
   }
   borderStyle = getStyleValue($elem, 'border-style') || borderStyle // border 样式
   if (borderStyle) {

--- a/packages/table-module/src/module/parse-style-html.ts
+++ b/packages/table-module/src/module/parse-style-html.ts
@@ -29,7 +29,7 @@ function convertPtToPx(cssValue: string): string {
     // p1 是捕获到的数字部分 (如 '1' 或 '0.5')
     const ptValue = parseFloat(p1)
     // 1pt ≈ 1.333333px。为了简化和保证精度，使用 4/3
-    const pxValue = ((ptValue * 4) / 3).toFixed(6)
+    const pxValue = ((ptValue * 4) / 3).toFixed(2)
 
     return `${pxValue}px`
   })

--- a/packages/table-module/src/module/render-style.ts
+++ b/packages/table-module/src/module/render-style.ts
@@ -20,7 +20,16 @@ export function renderStyle(node: Descendant, vnode: VNode): VNode {
   const props: TableCellProperty = {}
 
   if (backgroundColor) { props.backgroundColor = backgroundColor }
-  if (borderWidth) { props.borderWidth = `${borderWidth}px` }
+  if (borderWidth) {
+    const pureNumericRegex = /^\d+(\.\d+)?$/
+
+    if (pureNumericRegex.test(borderWidth)) {
+      // 增加一层校验，如果是纯数字则增加px的后缀："123"、"123.333"
+      props.borderWidth = `${borderWidth}px`
+    } else {
+      props.borderWidth = borderWidth
+    }
+  }
   if (borderStyle) { props.borderStyle = borderStyle === 'none' ? '' : borderStyle }
   if (borderColor) { props.borderColor = borderColor }
   if (textAlign) { props.textAlign = textAlign }


### PR DESCRIPTION
## Related Issues
fix [https://github.com/wangeditor-next/wangEditor-next/issues/146](https://github.com/wangeditor-next/wangEditor-next/issues/146)


## 问题发生的原因


<img width="891" height="330" alt="img" src="https://github.com/user-attachments/assets/d8f2ebf0-7504-4a05-b7e7-88bf550144ca" />

如上图所示，从`safari`复制过来的数据中出现了`border-width: medium 1pt 1pt`的数据



在`packages/table-module/src/module/parse-style-html.ts`的`parseStyleHtml`解析`border-width`，会将`medium 1pt 1pt`解析为`11`

> tableNode.borderWidth = borderWidth.replace(/[^\d]/g, '')


在`packages/table-module/src/module/render-style.ts`的拼凑style中，会拼凑解析出来的`11` + `px`构建出`border-width: 11px`的错误情况
```ts
export function renderStyle(node: Descendant, vnode: VNode): VNode {
  if (!Element.isElement(node)) { return vnode }

  const {
    backgroundColor, borderWidth, borderStyle, borderColor, textAlign,
  } = node as TableCellElement

  const props: TableCellProperty = {}

  if (backgroundColor) { props.backgroundColor = backgroundColor }
  if (borderWidth) { props.borderWidth = `${borderWidth}px` }
  if (borderStyle) { props.borderStyle = borderStyle === 'none' ? '' : borderStyle }
  if (borderColor) { props.borderColor = borderColor }
  if (textAlign) { props.textAlign = textAlign }

  const styleVnode: VNode = vnode

  if (node.type === 'table') {
    addVnodeStyle((styleVnode.children?.[0] as VNode).children?.[0] as VNode, props)
  } else {
    addVnodeStyle(styleVnode, props)
  }
  return styleVnode
}
```


## 解决方法

> https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/border-width
```css
/* Keyword values */
border-width: thin;
border-width: medium;
border-width: thick;

/* <length> values */
border-width: 4px;
border-width: 1.2rem;

/* top and bottom | left and right */
border-width: 2px 1.5em;

/* top | left and right | bottom */
border-width: 1px 2em 1.5cm;

/* top | right | bottom | left */
border-width: 1px 2em 0 4rem;

/* Global values */
border-width: inherit;
border-width: initial;
border-width: revert;
border-width: revert-layer;
border-width: unset;
```

由于`border-width`有多种格式，因此采取的方式是
- 继续保留优先级的解析：`border-width`/`border-color`/`border-style` > `border`缩写
- 保留`border-width`中的格式
  - 如果是`pt`，则按照`1pt = 4/3 px`的逻辑转化
  - 如果是非`pt`的数据，则保留原来的样式，包括`1px`、`1.5em`、`medium`等等


> 参考`https://developer.mozilla.org/zh-CN/docs/Learn_web_development/Core/Styling_basics/Values_and_units` 将`pt`转化为`px`


## 测试用例

按照
```text
由于`border-width`有多种格式，因此采取的方式是
- 继续保留优先级的解析：`border-width`/`border-color`/`border-style` > `border`缩写
- 保留`border-width`中的格式
  - 如果是`pt`，则按照`1pt = 4/3 px`的逻辑转化
  - 如果是非`pt`的数据，则保留原来的样式，包括`1px`、`1.5em`、`medium`等等
```
增加多种样式的解析


## example测试

<img width="1922" height="1708" alt="image" src="https://github.com/user-attachments/assets/7156b82a-cd4a-41dc-9eb4-7a4c0f27fcb6" />

上图是从safari复制拿到的数据，下面是修正代码后拿到的样式数据

<img width="4304" height="1350" alt="img_2" src="https://github.com/user-attachments/assets/9b270ee9-9286-4a6a-939d-178585004e3b" />

## Checklist
- [ ] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table border handling: better support for pt→px conversion, em/px units, numeric width validation, shorthand parsing and property precedence for consistent rendering (fixes Safari-copied table border issues).
* **Tests**
  * Expanded test coverage for table parsing and style handling, adding cases for varied border formats, units and precedence rules.
* **Chores**
  * Added a release changeset recording the border-width fix.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->