### PR TITLE
fix(core): sanitize imported html before parsing

### DIFF
--- a/.changeset/khaki-zebras-float.md
+++ b/.changeset/khaki-zebras-float.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/core': patch
+---
+
+Sanitize imported HTML by default for editor initialization, `setHtml`, and standard HTML paste flows before parsing it into editor content.

--- a/packages/core/__tests__/editor/plugins/with-content.test.ts
+++ b/packages/core/__tests__/editor/plugins/with-content.test.ts
@@ -424,5 +424,42 @@ describe('editor content API', () => {
       expect(editor.getHtml()).toBe(newHtml)
       expect(editor.isDisabled()).toBe(true)
     })
+
+    it('setHtml uses sanitizeHtml config before parsing', () => {
+      const sanitizeHtml = vi.fn().mockReturnValue('<div>safe</div>')
+      const editor = createEditor({
+        html: '<div>hello</div>',
+        config: {
+          sanitizeHtml,
+        },
+      })
+
+      editor.setHtml('<a href="javascript:alert(1)">unsafe</a>')
+
+      expect(sanitizeHtml).toHaveBeenCalledWith('<a href="javascript:alert(1)">unsafe</a>')
+      expect(editor.getHtml()).toBe('<div>safe</div>')
+    })
+  })
+
+  it('insertData sanitizes html before inserting', () => {
+    const unsafeHref = ['java', 'script:alert(1)'].join('')
+    const sanitizeHtml = vi.fn().mockReturnValue('<a href="https://example.com">safe</a>')
+    const editor = createEditor({
+      config: {
+        sanitizeHtml,
+      },
+    })
+    const insertHtmlSpy = vi.spyOn(editor, 'dangerouslyInsertHtml')
+
+    editor.select(getStartLocation(editor))
+    editor.insertData({
+      getData(type: string) {
+        if (type === 'text/html') { return `<a href="${unsafeHref}">unsafe</a>` }
+        return ''
+      },
+    } as DataTransfer)
+
+    expect(sanitizeHtml).toHaveBeenCalledWith(`<a href="${unsafeHref}">unsafe</a>`)
+    expect(insertHtmlSpy).toHaveBeenCalledWith('<a href="https://example.com">safe</a>')
   })
 })

--- a/packages/core/__tests__/utils/sanitize-html.test.ts
+++ b/packages/core/__tests__/utils/sanitize-html.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @description sanitize html test
+ * @author Codex
+ */
+
+import { defaultSanitizeHtml } from '../../src/utils/sanitize-html'
+
+describe('sanitize html', () => {
+  it('removes executable tags, attrs and urls', () => {
+    const unsafeHref = ['java', 'script:alert(1)'].join('')
+    const html = `
+      <img src="x" onerror="alert(1)" />
+      <a href="${unsafeHref}" onclick="alert(1)">bad</a>
+      <iframe src="//player.example.com/embed/1" srcdoc="<script>alert(1)</script>"></iframe>
+      <svg onload="alert(1)"><circle></circle></svg>
+    `
+    const sanitized = defaultSanitizeHtml(html)
+
+    expect(sanitized).not.toContain('onerror')
+    expect(sanitized).not.toContain('onclick')
+    expect(sanitized).not.toContain(unsafeHref)
+    expect(sanitized).not.toContain('srcdoc')
+    expect(sanitized).not.toContain('<svg')
+    expect(sanitized).toContain('<img src="x">')
+    expect(sanitized).toContain('<a>bad</a>')
+    expect(sanitized).toContain('<iframe src="//player.example.com/embed/1"></iframe>')
+  })
+
+  it('preserves editor supported attrs', () => {
+    const html = `
+      <div data-w-e-type="video" data-w-e-is-void style="text-align: center;">
+        <iframe
+          src="//player.bilibili.com/player.html?aid=1"
+          allowfullscreen="true"
+          frameborder="0"
+        ></iframe>
+      </div>
+      <div data-w-e-type="todo"><input type="checkbox" disabled checked>task</div>
+    `
+    const sanitized = defaultSanitizeHtml(html)
+
+    expect(sanitized).toContain('data-w-e-type="video"')
+    expect(sanitized).toContain('data-w-e-is-void=""')
+    expect(sanitized).toContain('style="text-align: center;"')
+    expect(sanitized).toContain('allowfullscreen="true"')
+    expect(sanitized).toContain('frameborder="0"')
+    expect(sanitized).toContain('type="checkbox"')
+    expect(sanitized).toContain('disabled=""')
+    expect(sanitized).toContain('checked=""')
+  })
+})

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -6,6 +6,7 @@
 import cloneDeep from 'lodash.clonedeep'
 import forEach from 'lodash.foreach'
 
+import { defaultSanitizeHtml } from '../utils/sanitize-html'
 import { IEditorConfig, IMenuConfig, IToolbarConfig } from './interface'
 import { GLOBAL_MENU_CONF } from './register'
 
@@ -39,6 +40,7 @@ export function genEditorConfig(userConfig: Partial<IEditorConfig> = {}): IEdito
     hoverbarKeys: {
       // 'link': { menuKeys: ['editLink', 'unLink', 'viewLink'] },
     },
+    sanitizeHtml: defaultSanitizeHtml,
     customAlert(info: string, type: string) {
       window.alert(`${type}:\n${info}`)
     },

--- a/packages/core/src/config/interface.ts
+++ b/packages/core/src/config/interface.ts
@@ -222,6 +222,11 @@ export interface IEditorConfig {
    * 自定义复制。拦截 event 添加或修改 clipboardData 数据
    */
   customCopy?: (editor: IDomEditor, e: ClipboardEvent) => void
+  /**
+   * 自定义 HTML 清洗逻辑。在 setHtml / 初始化 html / 默认粘贴 HTML 前执行。
+   * 返回值会继续进入编辑器的 HTML 解析流程。
+   */
+  sanitizeHtml?: (html: string) => string
 
   // edit state
   scroll: boolean

--- a/packages/core/src/create/helper.ts
+++ b/packages/core/src/create/helper.ts
@@ -72,6 +72,7 @@ export function genDefaultContent() {
  */
 export function htmlToContent(editor: IDomEditor, html: string = ''): Descendant[] {
   const res: Descendant[] = []
+  const { sanitizeHtml } = editor.getConfig()
 
   // 空白内容
   if (html === '') { html = '<p><br></p>' }
@@ -83,6 +84,8 @@ export function htmlToContent(editor: IDomEditor, html: string = ''): Descendant
       .map(line => `<p>${line}</p>`)
       .join('')
   }
+
+  html = sanitizeHtml ? sanitizeHtml(html) : html
 
   const $content = $(`<div>${html}</div>`)
   const list = Array.from($content.children())

--- a/packages/core/src/editor/plugins/with-event-data.ts
+++ b/packages/core/src/editor/plugins/with-event-data.ts
@@ -123,7 +123,9 @@ export const withEventData = <T extends Editor>(editor: T) => {
     // const rtf = data.getData('text/rtf')
 
     if (html) {
-      e.dangerouslyInsertHtml(html)
+      const { sanitizeHtml } = e.getConfig()
+
+      e.dangerouslyInsertHtml(sanitizeHtml ? sanitizeHtml(html) : html)
       return
     }
 

--- a/packages/core/src/utils/sanitize-html.ts
+++ b/packages/core/src/utils/sanitize-html.ts
@@ -1,0 +1,78 @@
+/**
+ * @description sanitize html before parsing/importing into editor
+ * @author Codex
+ */
+
+const BLOCKED_TAGS = new Set([
+  'base',
+  'embed',
+  'math',
+  'meta',
+  'object',
+  'script',
+  'svg',
+  'template',
+])
+
+const URL_ATTRS = new Set([
+  'href',
+  'poster',
+  'src',
+  'xlink:href',
+])
+
+const SCRIPT_SCHEME = ['java', 'script:'].join('')
+
+function normalizeAttrValue(value: string) {
+  return Array.from(value)
+    .filter(char => char > ' ')
+    .join('')
+    .toLowerCase()
+}
+
+function isSafeUrl(tagName: string, attrName: string, value: string) {
+  const normalized = normalizeAttrValue(value)
+
+  if (!normalized) { return true }
+  if (normalized.startsWith(SCRIPT_SCHEME) || normalized.startsWith('vbscript:')) { return false }
+
+  if (!normalized.startsWith('data:')) { return true }
+
+  if (attrName === 'href' || attrName === 'xlink:href') { return false }
+  if (tagName === 'img' || attrName === 'poster') { return normalized.startsWith('data:image/') }
+
+  return false
+}
+
+export function defaultSanitizeHtml(html: string = '') {
+  if (!html) { return '' }
+
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(html, 'text/html')
+  const elements = Array.from(doc.body.querySelectorAll('*'))
+
+  elements.forEach(elem => {
+    const tagName = elem.tagName.toLowerCase()
+
+    if (BLOCKED_TAGS.has(tagName)) {
+      elem.remove()
+      return
+    }
+
+    Array.from(elem.attributes).forEach(attr => {
+      const attrName = attr.name.toLowerCase()
+      const attrValue = attr.value || ''
+
+      if (attrName === 'srcdoc' || attrName.startsWith('on')) {
+        elem.removeAttribute(attr.name)
+        return
+      }
+
+      if (URL_ATTRS.has(attrName) && !isSafeUrl(tagName, attrName, attrValue)) {
+        elem.removeAttribute(attr.name)
+      }
+    })
+  })
+
+  return doc.body.innerHTML
+}

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -105,6 +105,25 @@ test.describe('Basic Editor', () => {
     await expect(page.getByTestId('editor-html')).toContainText('e2e-text')
   })
 
+  test('does not execute script when importing untrusted html', async ({ page }) => {
+    const dialogs: string[] = []
+
+    page.on('dialog', async dialog => {
+      dialogs.push(dialog.message())
+      await dialog.dismiss()
+    })
+
+    await page.goto('/examples/parse-html.html')
+    await page.locator('#text-html').fill('<img src=x onerror="alert(1)" />')
+    await page.locator('#btn-create').click()
+    await page.waitForTimeout(300)
+    await page.locator('#btn-set-html').click()
+    await page.waitForTimeout(300)
+
+    expect(dialogs).toEqual([])
+    await expect(page.locator('#editor-text-area img')).toHaveCount(1)
+  })
+
   test('applies bold and italic formatting', async ({ page }) => {
     await typeInEditor(page, 'format text')
     await selectAll(page)


### PR DESCRIPTION
## Summary

Fixes #749 by sanitizing untrusted HTML before it is parsed into editor content.

This change protects the default public HTML import paths:
- `createEditor({ html })`
- `editor.setHtml()`
- standard HTML paste flows

It intentionally does not change the semantics of `dangerouslyInsertHtml`, which remains an explicit dangerous escape hatch.

## Changes

- add a default HTML sanitizer in core
- run sanitization before parsing imported HTML into editor content
- sanitize default HTML paste input before passing it into the import pipeline
- add unit coverage for sanitizer behavior and import hooks
- add an e2e regression for malicious HTML import
- add a changeset for `@wangeditor-next/core`

## Verification

- `pnpm test`
- `pnpm exec playwright test tests/e2e/editor.spec.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to customize HTML sanitization for imported content
  * Developers can now define custom sanitization rules during editor setup

* **Bug Fixes**
  * Imported and pasted HTML content is now sanitized by default before rendering in the editor
  * Unsafe HTML attributes and script event handlers are automatically removed during the import process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->