### PR TITLE
fix(core): stop default text paste for custom handlers

### DIFF
--- a/.changeset/early-lobsters-trade.md
+++ b/.changeset/early-lobsters-trade.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/core': patch
+---
+
+Prevent the default browser paste when `customPaste` returns `false`, including plain-text paste flows.

--- a/packages/core/__tests__/text-area/event-handlers/paste.test.ts
+++ b/packages/core/__tests__/text-area/event-handlers/paste.test.ts
@@ -44,7 +44,7 @@ describe('handleOnPaste', () => {
     handleOnPaste(event, {} as any, editor)
 
     expect(EDITOR_TO_CAN_PASTE.get(editor)).toBe(false)
-    expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(event.preventDefault).toHaveBeenCalled()
     expect(editor.insertData).not.toHaveBeenCalled()
     EDITOR_TO_CAN_PASTE.delete(editor)
   })

--- a/packages/core/src/text-area/event-handlers/paste.ts
+++ b/packages/core/src/text-area/event-handlers/paste.ts
@@ -27,6 +27,7 @@ function handleOnPaste(e: Event, textarea: TextArea, editor: IDomEditor) {
     if (res === false) {
       // 自行实现粘贴，不执行默认粘贴
       EDITOR_TO_CAN_PASTE.set(editor, false) // 标记为：不可执行默认粘贴
+      event.preventDefault()
       return
     }
   }


### PR DESCRIPTION
## Summary

Fixes #710 by stopping the browser default paste when `customPaste` returns `false`.

This makes custom paste handlers reliably block plain-text paste flows as well, instead of letting browser default insertion slip through.

## Changes

- call `preventDefault()` when `customPaste` returns `false`
- keep the existing `EDITOR_TO_CAN_PASTE` guard for beforeinput paste flows
- add a regression test for the blocked paste path
- add a patch changeset for `@wangeditor-next/core`

## Verification

- `pnpm vitest run packages/core/__tests__/text-area/event-handlers/paste.test.ts packages/core/__tests__/text-area/event-handlers/before-input.test.ts`
- `pnpm test`
- manual verification in `examples/default-mode.html`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed paste behavior: when custom paste handlers return false, the browser's default paste action is now properly prevented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->