### PR TITLE
fix(text-style): scope imported inline styles correctly

### DIFF
--- a/.changeset/long-bikes-fetch.md
+++ b/.changeset/long-bikes-fetch.md
@@ -1,0 +1,6 @@
+---
+'@wangeditor-next/basic-modules': patch
+'@wangeditor-next/core': patch
+---
+
+Improve HTML style parsing for nested and Office-like inline text styles so partial bold and superscript formatting do not expand to the whole text segment.

--- a/packages/basic-modules/__tests__/text-style/parse-html.test.ts
+++ b/packages/basic-modules/__tests__/text-style/parse-html.test.ts
@@ -25,7 +25,6 @@ describe('text style - parse style html', () => {
       { html: '<sub>hello</sub>', key: 'sub' },
       { html: '<sup>hello</sup>', key: 'sup' },
       { html: '<code>hello</code>', key: 'code' },
-      { html: '<span><b>hello</b></span>', key: 'bold' },
     ]
 
     cases.forEach(({ html, key }) => {

--- a/packages/basic-modules/__tests__/text-style/parse-style-html.test.ts
+++ b/packages/basic-modules/__tests__/text-style/parse-style-html.test.ts
@@ -92,4 +92,70 @@ describe('parse style html', () => {
 
     expect(parseStyleHtml(element[0], node, editor)).toEqual({ ...node, code: true })
   })
+
+  it('it should set text styles from inline style attrs', () => {
+    const cases = [
+      { html: '<span style="font-weight: 700;"></span>', key: 'bold' },
+      { html: '<span style="font-style: italic;"></span>', key: 'italic' },
+      { html: '<span style="text-decoration: underline;"></span>', key: 'underline' },
+      { html: '<span style="text-decoration-line: line-through;"></span>', key: 'through' },
+      { html: '<span style="vertical-align: sub;"></span>', key: 'sub' },
+      { html: '<span style="vertical-align: super;"></span>', key: 'sup' },
+    ]
+
+    cases.forEach(({ html, key }) => {
+      const element = $(html)
+      const node = { text: 'text' }
+
+      expect(parseStyleHtml(element[0], node, editor)).toEqual({ ...node, [key]: true })
+    })
+  })
+
+  it('it should keep nested bold scoped to the matching text only', () => {
+    const nestedEditor = createEditor({ html: '<p><span>A<strong>B</strong>C</span></p>' })
+
+    expect(nestedEditor.children).toEqual([
+      {
+        type: 'paragraph',
+        children: [
+          { text: 'A' },
+          { text: 'B', bold: true },
+          { text: 'C' },
+        ],
+      },
+    ])
+  })
+
+  it('it should keep nested sup scoped to the matching text only', () => {
+    const nestedEditor = createEditor({ html: '<p><span>A<sup>2</sup>B</span></p>' })
+
+    expect(nestedEditor.children).toEqual([
+      {
+        type: 'paragraph',
+        children: [
+          { text: 'A' },
+          { text: '2', sup: true },
+          { text: 'B' },
+        ],
+      },
+    ])
+  })
+
+  it('it should parse Office-like inline styles without expanding them to the whole segment', () => {
+    const nestedEditor = createEditor({
+      html: '<p><span>A<span style="font-weight: 700;">B</span><span style="vertical-align: super;">2</span>C</span></p>',
+    })
+
+    expect(nestedEditor.children).toEqual([
+      {
+        type: 'paragraph',
+        children: [
+          { text: 'A' },
+          { text: 'B', bold: true },
+          { text: '2', sup: true },
+          { text: 'C' },
+        ],
+      },
+    ])
+  })
 })

--- a/packages/basic-modules/src/modules/text-style/parse-style-html.ts
+++ b/packages/basic-modules/src/modules/text-style/parse-style-html.ts
@@ -6,7 +6,7 @@
 import { IDomEditor } from '@wangeditor-next/core'
 import { Descendant, Text } from 'slate'
 
-import $, { Dom7Array, DOMElement } from '../../utils/dom'
+import $, { Dom7Array, DOMElement, getStyleValue } from '../../utils/dom'
 import { StyledText } from './custom-types'
 
 /**
@@ -17,11 +17,25 @@ import { StyledText } from './custom-types'
 function isMatch($text: Dom7Array, selector: string): boolean {
   if ($text.length === 0) { return false }
 
-  if ($text[0].matches(selector)) { return true }
+  return $text[0].matches(selector)
+}
 
-  if ($text.find(selector).length > 0) { return true }
+function isBoldStyle($text: Dom7Array): boolean {
+  const fontWeight = getStyleValue($text, 'font-weight')
 
-  return false
+  if (!fontWeight) { return false }
+  if (fontWeight === 'bold' || fontWeight === 'bolder') { return true }
+
+  const numericFontWeight = Number(fontWeight)
+
+  return !Number.isNaN(numericFontWeight) && numericFontWeight >= 600
+}
+
+function hasTextDecoration($text: Dom7Array, value: string): boolean {
+  const textDecoration = getStyleValue($text, 'text-decoration')
+  const textDecorationLine = getStyleValue($text, 'text-decoration-line')
+
+  return textDecoration.includes(value) || textDecorationLine.includes(value)
 }
 
 export function parseStyleHtml(
@@ -36,32 +50,32 @@ export function parseStyleHtml(
   const textNode = node as StyledText
 
   // bold
-  if (isMatch($text, 'b,strong')) {
+  if (isMatch($text, 'b,strong') || isBoldStyle($text)) {
     textNode.bold = true
   }
 
   // italic
-  if (isMatch($text, 'i,em')) {
+  if (isMatch($text, 'i,em') || ['italic', 'oblique'].includes(getStyleValue($text, 'font-style'))) {
     textNode.italic = true
   }
 
   // underline
-  if (isMatch($text, 'u')) {
+  if (isMatch($text, 'u') || hasTextDecoration($text, 'underline')) {
     textNode.underline = true
   }
 
   // through
-  if (isMatch($text, 's,strike')) {
+  if (isMatch($text, 's,strike') || hasTextDecoration($text, 'line-through')) {
     textNode.through = true
   }
 
   // sub
-  if (isMatch($text, 'sub')) {
+  if (isMatch($text, 'sub') || getStyleValue($text, 'vertical-align') === 'sub') {
     textNode.sub = true
   }
 
   // sup
-  if (isMatch($text, 'sup')) {
+  if (isMatch($text, 'sup') || getStyleValue($text, 'vertical-align') === 'super') {
     textNode.sup = true
   }
 

--- a/packages/core/src/parse-html/parse-elem-html.ts
+++ b/packages/core/src/parse-html/parse-elem-html.ts
@@ -62,13 +62,13 @@ function parseElemHtml($elem: Dom7Array, editor: IDomEditor): Descendant | Desce
       return parseCommonElemHtml($elem, editor)
     }
 
-    const hasImgOrA = $elem.find('img, a').length > 0
+    const childNodes = Array.from($elem[0].childNodes)
+    const hasNonTextChild = childNodes.some(child => !isDOMText(child) && !isDOMComment(child))
 
-    if ($elem[0].childNodes.length > 1 || hasImgOrA) {
-      const childNodes = $elem[0].childNodes
+    if (hasNonTextChild) {
       const parentStyle = parseTextElemHtmlToStyle($($elem[0]), editor)
 
-      return Array.from(childNodes).flatMap(child => {
+      return childNodes.flatMap(child => {
         const parsed = parseChildNode($(child), parentStyle, editor)
 
         return parsed || []
@@ -94,10 +94,17 @@ function parseElemHtml($elem: Dom7Array, editor: IDomEditor): Descendant | Desce
 
   // 非 <code> ，正常处理
   if (TEXT_TAGS.includes(tagName)) {
-    if ($elem[0].childNodes.length > 0 && $elem[0].childNodes[0].nodeType !== Node.TEXT_NODE) {
-      const childNodes = $elem[0].childNodes
+    const childNodes = Array.from($elem[0].childNodes)
+    const hasNonTextChild = childNodes.some(child => !isDOMText(child) && !isDOMComment(child))
 
-      return { ...parseElemHtml($(childNodes[0]), editor), ...parseTextElemHtml($elem, editor) }
+    if (hasNonTextChild) {
+      const parentStyle = parseTextElemHtmlToStyle($($elem[0]), editor)
+
+      return childNodes.flatMap(child => {
+        const parsed = parseChildNode($(child), parentStyle, editor)
+
+        return parsed || []
+      })
     }
     // text node
     return parseTextElemHtml($elem, editor)


### PR DESCRIPTION
## Summary

Fixes the HTML parsing behavior behind both #751 and #717.

Imported nested inline styles are now scoped to the matching text only, instead of being lifted to the whole text segment.

This improves compatibility with Office-like HTML such as:
- partial bold segments
- partial superscript segments
- inline style wrappers using `font-weight` and `vertical-align`

## Changes

- limit text-style parsing to the current element instead of matching descendant style tags
- parse Office-like inline styles for `font-weight`, `font-style`, `text-decoration`, and `vertical-align`
- recursively parse nested text-tag children and only pass down the current node's own styles
- add regression coverage for nested `strong` / `sup` and Office-like inline style wrappers
- add patch changesets for `@wangeditor-next/core` and `@wangeditor-next/basic-modules`

## Verification

- `pnpm vitest run packages/basic-modules/__tests__/text-style/parse-style-html.test.ts packages/basic-modules/__tests__/text-style/parse-html.test.ts`
- `pnpm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced HTML style parsing to correctly interpret nested and Office-like inline text formatting.
  * Fixed issue where partial text formatting (such as bold and superscript) was incorrectly expanding to entire text segments during HTML parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->