### PR TITLE
fix(table-module): preserve colgroup widths on import

### DIFF
--- a/.changeset/hungry-jars-tickle.md
+++ b/.changeset/hungry-jars-tickle.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/table-module': patch
+---
+
+Preserve `colgroup` column widths when importing tables with merged cells so adjusted table widths survive `getHtml` and `setHtml` round-trips.

--- a/packages/table-module/__tests__/parse-html.test.ts
+++ b/packages/table-module/__tests__/parse-html.test.ts
@@ -370,4 +370,76 @@ describe('table - parse html', () => {
       height: 0,
     })
   })
+
+  it('table should preserve colgroup widths after merged cells change row lengths', () => {
+    const $table = $(
+      `<table style="width: auto;table-layout: fixed;height:124">
+        <colgroup contentEditable="false">
+          <col width="80"></col>
+          <col width="80"></col>
+          <col width="200"></col>
+        </colgroup>
+        <tr>
+          <th colSpan="1" rowSpan="1" width="auto">姓名</th>
+          <th colSpan="1" rowSpan="1" width="auto">学科</th>
+          <th colSpan="1" rowSpan="1" width="auto">成绩</th>
+        </tr>
+        <tr>
+          <td colSpan="1" rowSpan="1" width="auto">张三</td>
+          <td colSpan="1" rowSpan="1" width="auto">数学</td>
+          <td colSpan="1" rowSpan="1" width="auto">95</td>
+        </tr>
+        <tr>
+          <td colSpan="1" rowSpan="2" width="auto">李四</td>
+          <td colSpan="1" rowSpan="1" width="auto">英语</td>
+          <td colSpan="1" rowSpan="1" width="auto">88</td>
+        </tr>
+        <tr>
+          <td colSpan="1" rowSpan="1" width="auto">数学</td>
+          <td colSpan="1" rowSpan="1" width="auto">92</td>
+        </tr>
+      </table>`,
+    )
+    const children = [
+      {
+        type: 'table-row',
+        children: [
+          { ...TABLE_CELL_BASE_PROPS, isHeader: true, children: [{ text: '姓名' }] },
+          { ...TABLE_CELL_BASE_PROPS, isHeader: true, children: [{ text: '学科' }] },
+          { ...TABLE_CELL_BASE_PROPS, isHeader: true, children: [{ text: '成绩' }] },
+        ],
+      },
+      {
+        type: 'table-row',
+        children: [
+          { ...TABLE_CELL_BASE_PROPS, children: [{ text: '张三' }] },
+          { ...TABLE_CELL_BASE_PROPS, children: [{ text: '数学' }] },
+          { ...TABLE_CELL_BASE_PROPS, children: [{ text: '95' }] },
+        ],
+      },
+      {
+        type: 'table-row',
+        children: [
+          { ...TABLE_CELL_BASE_PROPS, rowSpan: 2, children: [{ text: '李四' }] },
+          { ...TABLE_CELL_BASE_PROPS, children: [{ text: '英语' }] },
+          { ...TABLE_CELL_BASE_PROPS, children: [{ text: '88' }] },
+        ],
+      },
+      {
+        type: 'table-row',
+        children: [
+          { ...TABLE_CELL_BASE_PROPS, children: [{ text: '数学' }] },
+          { ...TABLE_CELL_BASE_PROPS, children: [{ text: '92' }] },
+        ],
+      },
+    ]
+
+    expect(parseTableHtmlConf.parseElemHtml($table[0], children as any, editor)).toEqual({
+      type: 'table',
+      width: 'auto',
+      height: 124,
+      children,
+      columnWidths: [80, 80, 200],
+    })
+  })
 })

--- a/packages/table-module/src/module/parse-elem-html.ts
+++ b/packages/table-module/src/module/parse-elem-html.ts
@@ -114,13 +114,14 @@ function parseTableHtml(
   }
   const tdList = $elem.find('tr')[0]?.children || []
   const colgroupElments: HTMLCollection = $elem.find('colgroup')[0]?.children || null
-  // @ts-ignore
-  const colLength = children[children.length - 1].children.length
+  const colgroupWidths = colgroupElments
+    ? Array.from(colgroupElments)
+      .map((col: any) => parseInt(col.getAttribute('width'), 10))
+      .filter(width => !Number.isNaN(width))
+    : []
 
-  if (colgroupElments && colgroupElments.length === colLength) {
-    tableELement.columnWidths = Array.from(colgroupElments).map((col: any) => {
-      return parseInt(col.getAttribute('width'), 10)
-    })
+  if (colgroupWidths.length > 0) {
+    tableELement.columnWidths = colgroupWidths
   } else if (tdList.length > 0) {
     const columnWidths: number[] = []
 


### PR DESCRIPTION
## Summary

Fixes #718 by preserving `colgroup` widths when importing tables that contain merged cells.

Previously the parser only trusted `colgroup` widths when its column count matched the parsed row shape, which breaks after merged cells change the visible cell counts of later rows. In that case the parser fell back to a lossy width guess and resized columns were lost after `getHtml` / `setHtml` round-trips.

## Changes

- prefer parsed `colgroup` widths whenever valid width values are present
- keep the existing cell-width fallback only for tables without usable `colgroup` widths
- add a regression test that covers merged cells with `colgroup` widths
- add a patch changeset for `@wangeditor-next/table-module`

## Verification

- `pnpm vitest run packages/table-module/__tests__/parse-html.test.ts packages/table-module/__tests__/elem-to-html.test.ts`
- `pnpm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed table column widths preservation when importing tables with merged cells, ensuring adjusted table widths are maintained during HTML round-trips (export and import operations).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->