### PR TITLE
fix(core): preserve imported underlined spaces

### DIFF
--- a/.changeset/nasty-rockets-swim.md
+++ b/.changeset/nasty-rockets-swim.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/core': patch
+---
+
+Preserve consecutive spaces when importing styled inline HTML so underlined whitespace does not collapse to a single space.

--- a/packages/basic-modules/__tests__/text-style/parse-style-html.test.ts
+++ b/packages/basic-modules/__tests__/text-style/parse-style-html.test.ts
@@ -92,4 +92,17 @@ describe('parse style html', () => {
 
     expect(parseStyleHtml(element[0], node, editor)).toEqual({ ...node, code: true })
   })
+
+  it('it should preserve consecutive spaces in underlined html imports', () => {
+    const underlinedSpaces = '        '
+    const nestedEditor = createEditor({ html: `<p><u>${underlinedSpaces}</u></p>` })
+
+    expect(nestedEditor.children).toEqual([
+      {
+        type: 'paragraph',
+        children: [{ text: underlinedSpaces, underline: true }],
+      },
+    ])
+    expect(nestedEditor.getText()).toBe(underlinedSpaces)
+  })
 })

--- a/packages/core/src/parse-html/parse-text-elem-html.ts
+++ b/packages/core/src/parse-html/parse-text-elem-html.ts
@@ -20,8 +20,9 @@ import { PARSE_STYLE_HTML_FN_LIST } from './index'
 function parseTextElemHtml($text: Dom7Array, editor: IDomEditor): Text {
   if ($text.parents('pre').length === 0) {
     // 不在 <pre> 内部
-    // 1. 替换无用空格、换行； 2. 将 <br> 替换为 `\n`
-    $text[0].innerHTML = $text[0].innerHTML.replace(/\s+/gm, ' ').replace(/<br>/g, '\n')
+    // 1. 去掉 html 格式化带来的换行和 tab；2. 将 <br> 替换为 `\n`
+    // 注意不能压缩普通空格，否则会丢失连续空格和 emsp 等宽字符
+    $text[0].innerHTML = $text[0].innerHTML.replace(/[\r\n\t]+/g, '').replace(/<br>/g, '\n')
   }
 
   // 用 textContent ，不能用 .text() 。后者无法识别 text 开头和末尾的 &nbsp;


### PR DESCRIPTION
## Summary

Fixes #742 by preserving consecutive spaces when importing styled inline HTML.

Previously `parseTextElemHtml` collapsed all whitespace inside inline text tags before reading `textContent`, which caused underlined whitespace like `<u>        </u>` to round-trip back as a single space.

## Changes

- stop collapsing ordinary consecutive spaces inside inline text html parsing
- continue normalizing `<br>` into line breaks for import
- add a regression test for imported underlined whitespace
- add a patch changeset for `@wangeditor-next/core`

## Verification

- `pnpm vitest run packages/basic-modules/__tests__/text-style/parse-style-html.test.ts packages/basic-modules/__tests__/text-style/parse-html.test.ts`
- `pnpm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve consecutive spaces when importing styled HTML so underlined whitespace no longer collapses to a single space, maintaining original formatting.

* **Tests**
  * Added a test confirming consecutive spaces inside underlined HTML are preserved on import.

* **Chores**
  * Bumped package version to include the patch fixing space preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->