### PR TITLE
fix(core): optimize large plain-text paste

### DIFF
--- a/.changeset/cool-roses-think.md
+++ b/.changeset/cool-roses-think.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/core': patch
+---
+
+Improve large multi-line plain-text paste performance by inserting pasted lines as a fragment instead of splitting and inserting each line one by one.

--- a/packages/core/__tests__/editor/plugins/with-content.test.ts
+++ b/packages/core/__tests__/editor/plugins/with-content.test.ts
@@ -462,4 +462,31 @@ describe('editor content API', () => {
     expect(sanitizeHtml).toHaveBeenCalledWith(`<a href="${unsafeHref}">unsafe</a>`)
     expect(insertHtmlSpy).toHaveBeenCalledWith('<a href="https://example.com">safe</a>')
   })
+
+  it('insertData inserts multiline plain text as paragraphs', () => {
+    const editor = createEditor()
+
+    editor.select(getStartLocation(editor))
+    editor.insertData({
+      getData(type: string) {
+        if (type === 'text/plain') { return 'hello\nworld\n' }
+        return ''
+      },
+    } as DataTransfer)
+
+    expect(editor.children).toEqual([
+      {
+        type: 'paragraph',
+        children: [{ text: 'hello' }],
+      },
+      {
+        type: 'paragraph',
+        children: [{ text: 'world' }],
+      },
+      {
+        type: 'paragraph',
+        children: [{ text: '' }],
+      },
+    ])
+  })
 })

--- a/packages/core/src/editor/plugins/with-event-data.ts
+++ b/packages/core/src/editor/plugins/with-event-data.ts
@@ -4,12 +4,22 @@
  */
 
 import {
-  Editor, Node, Range, Transforms,
+  Editor, Node, Range,
 } from 'slate'
 
 import { IDomEditor } from '../..'
 import { getPlainText, isDOMText } from '../../utils/dom'
 import { DomEditor } from '../dom-editor'
+
+function createPlainTextFragment(text: string): Node[] {
+  return text
+    .replace(/\n\r|\r\n|\r/g, '\n')
+    .split('\n')
+    .map(line => ({
+      type: 'paragraph',
+      children: [{ text: line }],
+    }))
+}
 
 export const withEventData = <T extends Editor>(editor: T) => {
   const e = editor as T & IDomEditor
@@ -130,20 +140,14 @@ export const withEventData = <T extends Editor>(editor: T) => {
     }
 
     if (text) {
-      const lines = text.split(/\n\r|\r\n|\r|\n/)
-      let split = false
-
-      for (const line of lines) {
-        const leftLength = DomEditor.getLeftLengthOfMaxLength(e)
-        // 当设置了 maxLength 且剩余 length 为0时，不插入任何字符
-
-        if (split && leftLength > 0) {
-          Transforms.splitNodes(e, { always: true })
-        }
-
-        e.insertText(line)
-        split = true
+      if (!/[\r\n]/.test(text)) {
+        e.insertText(text)
+        return
       }
+
+      const textFragment = createPlainTextFragment(text)
+
+      e.insertFragment(textFragment)
 
     }
   }


### PR DESCRIPTION
## Summary

Fixes #741 by reducing the operation count of very large multi-line plain-text paste.

Previously plain-text paste split the entire text into lines and inserted each line one by one with repeated node splits. That becomes very expensive for large pasted text.

## Changes

- keep single-line plain-text paste on the fast `insertText` path
- insert multi-line plain-text paste as a single fragment of paragraphs
- add a regression test that preserves multi-line plain-text paste behavior
- add a patch changeset for `@wangeditor-next/core`

## Verification

- `pnpm vitest run packages/core/__tests__/editor/plugins/with-content.test.ts packages/core/__tests__/text-area/event-handlers/paste.test.ts`
- `pnpm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Optimized performance when pasting large blocks of multi-line plain text into the editor.

* **Tests**
  * Added test coverage to verify multi-line plain text is correctly handled as separate paragraphs during paste operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->