### PR TITLE
fix(table-module): preserve cell line breaks on html import

### DIFF
--- a/.changeset/cold-bottles-watch.md
+++ b/.changeset/cold-bottles-watch.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/table-module': patch
+---
+
+Preserve line breaks when importing table cell content from Word-like HTML paragraphs.

--- a/packages/table-module/__tests__/parse-html.test.ts
+++ b/packages/table-module/__tests__/parse-html.test.ts
@@ -55,6 +55,29 @@ describe('table - pre parse html', () => {
 
     expect(res.outerHTML).toBe('<table><tr><td width="auto">hello</td></tr></table>')
   })
+
+  it('should preserve line breaks when flattening paragraphs inside cells', () => {
+    const $table = $(
+      [
+        '<table><tbody><tr><td>',
+        '<p><span style="color: rgb(255, 0, 0); background-color: rgb(255, 255, 0);">line 1</span></p>',
+        '<p><span style="color: rgb(255, 0, 0); background-color: rgb(255, 255, 0);">line 2</span></p>',
+        '</td></tr></tbody></table>',
+      ].join(''),
+    )
+
+    const res = preParseTableHtmlConf.preParseHtml($table[0])
+
+    expect(res.outerHTML).toBe(
+      [
+        '<table><tr><td width="auto">',
+        '<span style="color: rgb(255, 0, 0); background-color: rgb(255, 255, 0);">line 1</span>',
+        '<br>',
+        '<span style="color: rgb(255, 0, 0); background-color: rgb(255, 255, 0);">line 2</span>',
+        '</td></tr></table>',
+      ].join(''),
+    )
+  })
 })
 
 describe('table - parse html', () => {
@@ -94,6 +117,37 @@ describe('table - parse html', () => {
       width: 'auto',
       children,
       hidden: true,
+    })
+  })
+
+  it('table cell should keep line breaks imported from word-like paragraphs', () => {
+    const $cell = $(
+      '<td><span style="color: rgb(255, 0, 0); background-color: rgb(255, 255, 0);">line 1<br>line 2</span></td>',
+    )
+    const [cell] = parseElemHtmlFromCore($($cell[0]), editor) as any[]
+
+    expect(cell).toMatchObject({
+      ...TABLE_CELL_BASE_PROPS,
+      borderWidth: '1px',
+      borderStyle: 'solid',
+      children: [
+        {
+          text: 'line 1',
+          color: 'rgb(255, 0, 0)',
+          bgColor: 'rgb(255, 255, 0)',
+        },
+        {
+          type: 'paragraph',
+          color: 'rgb(255, 0, 0)',
+          bgColor: 'rgb(255, 255, 0)',
+          children: [{ text: '' }],
+        },
+        {
+          text: 'line 2',
+          color: 'rgb(255, 0, 0)',
+          bgColor: 'rgb(255, 255, 0)',
+        },
+      ],
     })
   })
 

--- a/packages/table-module/src/module/pre-parse-html.ts
+++ b/packages/table-module/src/module/pre-parse-html.ts
@@ -5,6 +5,53 @@
 
 import $, { DOMElement, getTagName } from '../utils/dom'
 
+function normalizeCellParagraphs(cellHtml: string): string {
+  const container = document.createElement('div')
+
+  container.innerHTML = cellHtml
+
+  const normalizedNodes = []
+  let hasMeaningfulContent = false
+
+  Array.from(container.childNodes).forEach(node => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      if ((node.textContent || '').trim()) {
+        normalizedNodes.push(node.cloneNode(true))
+        hasMeaningfulContent = true
+      }
+      return
+    }
+
+    if (!(node instanceof HTMLElement) || node.tagName.toLowerCase() !== 'p') {
+      normalizedNodes.push(node.cloneNode(true))
+      hasMeaningfulContent = true
+      return
+    }
+
+    const paragraphHtml = node.innerHTML
+    const trimmedHtml = paragraphHtml.trim()
+
+    if (!trimmedHtml || trimmedHtml === '&nbsp;') { return }
+
+    if (hasMeaningfulContent) {
+      normalizedNodes.push(document.createElement('br'))
+    }
+
+    const paragraphContainer = document.createElement('div')
+
+    paragraphContainer.innerHTML = paragraphHtml
+
+    Array.from(paragraphContainer.childNodes).forEach(childNode => {
+      normalizedNodes.push(childNode.cloneNode(true))
+    })
+    hasMeaningfulContent = true
+  })
+
+  container.replaceChildren(...normalizedNodes)
+
+  return container.innerHTML
+}
+
 /**
  * pre-prase table ，去掉 <tbody> 和处理单元格中的 <p> 标签，以及删除隐藏的单元格
  * @param table table elem
@@ -61,16 +108,7 @@ function preParse(tableElem: DOMElement): DOMElement {
     cellHtml = cellHtml.replace(/<o:p[^>]*>[\s\S]*?<\/o:p>/gi, '') // 删除 <o:p> 标签
     cellHtml = cellHtml.replace(/<\/o:p>/gi, '') // 删除可能的自闭合标签
 
-    // 一次性处理所有p标签
-    cellHtml = cellHtml.replace(/<p[^>]*>([\s\S]*?)<\/p>/gi, (match, content) => {
-      // 处理空内容或只包含空白字符的情况
-      const trimmedContent = content.trim()
-
-      if (!trimmedContent || trimmedContent === '&nbsp;') {
-        return '' // 删除空的p标签
-      }
-      return content // 返回p标签的内容
-    })
+    cellHtml = normalizeCellParagraphs(cellHtml)
 
     $cell.html(cellHtml)
   }

--- a/packages/table-module/src/module/pre-parse-html.ts
+++ b/packages/table-module/src/module/pre-parse-html.ts
@@ -10,7 +10,7 @@ function normalizeCellParagraphs(cellHtml: string): string {
 
   container.innerHTML = cellHtml
 
-  const normalizedNodes = []
+  const normalizedNodes: Node[] = []
   let hasMeaningfulContent = false
 
   Array.from(container.childNodes).forEach(node => {


### PR DESCRIPTION
## Summary
- preserve line breaks when flattening Word-like `<p>` blocks inside table cells
- keep styled cell content intact while normalizing imported HTML
- add table-module regression tests and a changeset

## Testing
- pnpm vitest run packages/table-module/__tests__/parse-html.test.ts packages/table-module/__tests__/elem-to-html.test.ts
- pnpm test

Fixes #740

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve line breaks when importing table cell content from Word-like HTML, ensuring pasted/imported tables keep original formatting.
* **Tests**
  * Added tests validating line-break preservation within table cells.
* **Chores**
  * Added a changeset entry recording this patch-level fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->