### PR TITLE
fix(tests): fix codecov coverage upload

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,6 +10,7 @@ on:
       - 'tests/**'
       - 'build/**'
       - 'vitest.config.mts'
+  workflow_dispatch:
 
 jobs:
   test:
@@ -25,7 +26,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 18.x
+          node-version: 22.13.0
           registry-url: https://registry.npmjs.com
 
       # 安装 pnpm
@@ -42,9 +43,8 @@ jobs:
           path: |
             **/node_modules
             **/.turbo
-            /home/runner/.cache/Cypress
             ~/.pnpm-store
-          key: ${{ runner.os }}-node-18-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-node-22.13.0-${{ hashFiles('**/pnpm-lock.yaml') }}
 
       # 安装依赖
       - name: Install dependencies
@@ -63,8 +63,6 @@ jobs:
         uses: codecov/codecov-action@v5.5.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/lcov.info
+          disable_search: true
+          verbose: true

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -29,7 +29,7 @@ export default defineConfig({
     globals: true, // 如果需要全局的 vi 函数
     setupFiles: path.resolve(__dirname, 'tests/setup/index.ts'), // 对应 setup 文件
     coverage: {
-      reporter: ['text', 'json', 'html'], // 覆盖率报告格式
+      reporter: ['text', 'json', 'html', 'lcov'], // 覆盖率报告格式
       include: [
         `packages/{${modulePaths.map(p => p.split('/')[1]).join(',')}}/src/**/*.{ts,tsx}`,
       ],


### PR DESCRIPTION
## Summary
- make Vitest generate coverage/lcov.info
- make the coverage workflow upload the lcov file explicitly to Codecov
- align the coverage job Node version with the repository engine and keep it scoped to master

## Testing
- pnpm run test-c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development infrastructure and testing configuration, including Node.js toolchain version updates and enhanced code coverage reporting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->