### PR TITLE
fix(core): ignore formatting newlines in nested html imports

### DIFF
--- a/.changeset/fresh-badgers-clean.md
+++ b/.changeset/fresh-badgers-clean.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/core': patch
+---
+
+Ignore formatting newlines around nested inline html imports so Word superscript content does not introduce extra line breaks.

--- a/packages/basic-modules/__tests__/text-style/parse-style-html.test.ts
+++ b/packages/basic-modules/__tests__/text-style/parse-style-html.test.ts
@@ -159,6 +159,24 @@ describe('parse style html', () => {
     ])
   })
 
+  it('it should ignore formatting newlines around nested superscript html imports', () => {
+    const nestedEditor = createEditor({
+      html: '<p><span>\nH<span style="vertical-align: super;">2</span>O\n</span></p>',
+    })
+
+    expect(nestedEditor.children).toEqual([
+      {
+        type: 'paragraph',
+        children: [
+          { text: 'H' },
+          { text: '2', sup: true },
+          { text: 'O' },
+        ],
+      },
+    ])
+    expect(nestedEditor.getText()).toBe('H2O')
+  })
+
   it('it should preserve consecutive spaces in underlined html imports', () => {
     const underlinedSpaces = '        '
     const nestedEditor = createEditor({ html: `<p><u>${underlinedSpaces}</u></p>` })

--- a/packages/core/src/parse-html/parse-elem-html.ts
+++ b/packages/core/src/parse-html/parse-elem-html.ts
@@ -11,8 +11,24 @@ import { PRE_PARSE_HTML_CONF_LIST, TEXT_TAGS } from '../index'
 import {
   getTagName, isDOMComment, isDOMElement, isDOMText,
 } from '../utils/dom'
+import { deReplaceHtmlSpecialSymbols } from '../utils/util'
+import { replaceSpace160 } from './helper'
 import parseCommonElemHtml from './parse-common-elem-html'
 import parseTextElemHtml, { parseTextElemHtmlToStyle } from './parse-text-elem-html'
+
+function normalizeTextNodeContent(text: string, childNode: Node): string {
+  const parentElem = childNode.parentElement
+
+  if (parentElem == null) { return text }
+  if (parentElem.closest('pre') == null) {
+    text = text.replace(/[\r\n\t]+/g, '')
+  }
+
+  text = deReplaceHtmlSpecialSymbols(text)
+  text = replaceSpace160(text)
+
+  return text
+}
 
 function parseChildNode($childElem, parentStyle, editor) {
   const childNode = $childElem[0]
@@ -32,7 +48,7 @@ function parseChildNode($childElem, parentStyle, editor) {
   if (isDOMComment(childNode)) { return null } // 过滤掉注释节点
 
   const text = isDOMText(childNode)
-    ? { text: childNode.textContent || '' }
+    ? { text: normalizeTextNodeContent(childNode.textContent || '', childNode) }
     : parseTextElemHtml($childElem, editor)
 
   return [{ ...parentStyle, ...text }]


### PR DESCRIPTION
## Summary
- ignore formatting `\n` and `\t` text nodes around nested inline html imports
- keep superscript marks scoped to the matching text without introducing extra line breaks
- add a core changeset for the next patch release

## Changes
- normalize mixed-content text nodes with the same newline cleanup path used for inline text parsing
- add a regression test for nested superscript html imports with formatting newlines

## Verification
- `pnpm --filter @wangeditor-next/basic-modules exec vitest run __tests__/text-style/parse-style-html.test.ts`
- `pnpm --filter @wangeditor-next/basic-modules exec vitest run __tests__/text-style/parse-html.test.ts`
- `pnpm --filter @wangeditor-next/core exec vitest run __tests__/editor/plugins/with-content.test.ts`

Refs #751


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unwanted line breaks appearing in content with superscript formatting and nested inline elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->