### PR TITLE
fix(core): upgrade Slate to 0.123 and realign DOM bridge

### DIFF
--- a/.changeset/slate-upgrade-audit.md
+++ b/.changeset/slate-upgrade-audit.md
@@ -1,0 +1,20 @@
+---
+'@wangeditor-next/core': patch
+'@wangeditor-next/editor': patch
+'@wangeditor-next/basic-modules': patch
+'@wangeditor-next/list-module': patch
+'@wangeditor-next/table-module': patch
+'@wangeditor-next/code-highlight': patch
+'@wangeditor-next/video-module': patch
+'@wangeditor-next/upload-image-module': patch
+'@wangeditor-next/plugin-markdown': patch
+'@wangeditor-next/plugin-link-card': patch
+'@wangeditor-next/plugin-float-image': patch
+'@wangeditor-next/yjs': patch
+'@wangeditor-next/yjs-for-react': patch
+'@wangeditor-next/yjs-for-vue': patch
+---
+
+Upgrade the Slate dependency line to `slate@^0.123.0` and `slate-history@^0.115.0`, and realign wangEditor's DOM bridge, selection sync, and composition handling with current Slate behavior.
+
+This release also fixes regressions around full-document delete normalization, selectionchange handling in `Document | ShadowRoot`, and related list / paste / image / code-block flows covered by the workspace E2E suite.

--- a/docs/slate-upgrade-audit.md
+++ b/docs/slate-upgrade-audit.md
@@ -1,0 +1,280 @@
+# Slate Upgrade Audit
+
+## Baseline
+
+- Audit branch: `chore/core/slate-upgrade-audit`
+- Audit worktree: `/home/cycleccc/workspace/wangEditor-next-slate-upgrade-20260316`
+- Base commit: `origin/master@b54e4873`
+- Upstream Slate clone for comparison: `/tmp/slate-upstream`
+- Upstream Slate head used in this audit: `91321bd`
+
+## Current Dependency State
+
+- Current local `slate`: `^0.82.0` in `packages/core`, `packages/editor`, `packages/basic-modules`, `packages/list-module`, `packages/table-module`, `packages/video-module`, `packages/upload-image-module`, `packages/plugin-*`, `packages/yjs*`
+- Current lockfile-resolved `slate`: `0.82.1`
+- Current local `slate-history`: `^0.109.0` in `packages/core`
+- Upstream comparison baseline:
+  - `slate@0.123.0`
+  - `slate-dom@0.123.1`
+  - `slate-react@0.123.0`
+  - `slate-history@0.115.0`
+
+## Recommendation
+
+- Upgrade `slate` and `slate-history` as a dedicated effort.
+- Use `slate-dom` and `slate-react` as source references, not as direct runtime dependencies of `@wangeditor-next/core`.
+- Do not try to solve this by a version bump alone. The local DOM bridge and selection/composition pipeline must be realigned with upstream behavior.
+- Prefer targeting the current upstream line directly instead of stepping through every intermediate beta version.
+
+## Progress
+
+- Environment aligned to `Node 22.13.0` for audit and validation work.
+- Workspace dependencies bumped:
+  - `slate` moved to `^0.123.0` across `packages/core`, `packages/editor`, built-in modules, plugins, and `yjs*`.
+  - `slate-history` moved to `^0.115.0` in `packages/core`.
+- Completed in local `dom-editor`:
+  - `toSlateRange` now forwards search direction into `toSlatePoint`.
+  - `toSlatePoint` now searches across `contenteditable="false"` neighbors.
+  - `toSlatePoint(..., { suppressThrow: true })` no longer crashes on stale `findPath`.
+- Completed in local selection sync:
+  - `selectionchange` now uses `suppressThrow: true` and skips `Transforms.select` when range resolution fails.
+  - `selectionchange` listener now binds to the actual editor root (`Document | ShadowRoot`), not only `window.document`.
+  - `selectionchange` now matches upstream target classification more closely: anchor uses `hasSelectableTarget`, focus only needs to remain inside the editor.
+  - `selectionchange` ignores native `input` and `textarea` sources before entering the sync pipeline.
+- Completed in local `beforeinput` / composition flow:
+  - pending DOM selection sync is flushed before handling `beforeinput`.
+  - `insertFromComposition` is handled explicitly.
+  - `compositionend` skips duplicate insertion when the commit was already applied through `beforeinput`.
+  - selection changes that happen while composing are now stored as pending selection and can be applied at `compositionend`.
+- Regression coverage added for:
+  - stale path resolution in `dom-editor`
+  - non-editable neighbor point resolution
+  - `selectionchange` null-range safety
+  - `beforeinput` selection flush
+  - duplicate composition commit prevention
+  - `TextArea` root-level `selectionchange` binding
+- Slate 0.123 API compatibility fixes landed:
+  - local render pipeline now consumes `Text.decorations()` as `{ leaf, position }[]`
+  - selection helpers now wrap original editor methods instead of recursing through `Transforms.select` / `Transforms.move` / `Transforms.deselect`
+  - local `IDomEditor.move` typing now supports both legacy `move(distance, reverse?)` and upstream `move(options?)`
+  - workspace packages using `Editor.isVoid` / `Editor.isBlock` now guard with `Element.isElement(...)` where Slate tightened types
+- Validation completed on this branch:
+  - `pnpm --filter @wangeditor-next/core test`
+  - `pnpm --filter @wangeditor-next/basic-modules test -- __tests__/color/color-menus.test.ts __tests__/emotion/emotion-menu.test.ts __tests__/font-size-family/menu/font-size-menu.test.ts __tests__/font-size-family/menu/font-family-menu.test.ts __tests__/image/helper.test.ts __tests__/justify/menus.test.ts __tests__/text-style/menu/menus.test.ts`
+  - `pnpm build`
+  - full workspace `pnpm test`
+  - `pnpm e2e`
+- Validation still pending:
+  - manual browser verification for IME, ShadowRoot, table selection, and Android/WebView paths
+
+## Why This Needs a Dedicated Track
+
+- The issue tracker shows repeated failures in the same areas:
+  - IME / Android / WebView / Sogou / composition:
+    - `#12`, `#254`, `#298`, `#733`
+  - DOM point / selection mapping crashes:
+    - `#614`, `#714`, `#733`
+  - Shadow DOM / micro-frontend cursor drift:
+    - `#409`
+  - Non-editable or custom element cursor behavior:
+    - `#249`, `#568`
+  - Mobile selection / keyboard re-open behavior:
+    - `#750`
+- The current local implementations are exactly where upstream Slate has kept patching:
+  - `packages/core/src/editor/dom-editor.ts`
+  - `packages/core/src/text-area/syncSelection.ts`
+  - `packages/core/src/text-area/TextArea.ts`
+  - `packages/core/src/text-area/event-handlers/composition.ts`
+  - `packages/core/src/text-area/event-handlers/beforeInput.ts`
+  - `packages/core/src/text-area/helpers.ts`
+
+## Do Not Adopt Blindly
+
+- Do not import `slate-react` into non-React packages.
+- Do not replace the current editor event system wholesale with React `Editable`.
+- Do not assume upstream fixes will automatically solve table-module logic bugs. Some failures are local overrides, not upstream Slate bugs.
+
+## Upstream Signals Worth Porting
+
+- `slate-dom@0.123.1`
+  - `findPath` should not throw during `toSlatePoint(..., { suppressThrow: true })` after unmount or stale node references.
+  - File: `/tmp/slate-upstream/packages/slate-dom/CHANGELOG.md`
+  - File: `/tmp/slate-upstream/packages/slate-dom/src/plugin/dom-editor.ts`
+- `slate-dom@0.119.0`
+  - Shadow DOM Android typing crash fix.
+- `slate-dom@0.118.1`
+  - Search backward and forward for leaf nodes in non-contenteditable elements inside `toSlatePoint`.
+- `slate-react`
+  - Ignore `selectionchange` events coming from native `input` and `textarea`.
+  - Keep `isComposing` state accurate on `compositionend`.
+  - Flush pending `selectionchange` work before `beforeinput`.
+  - Restore selection after applying `beforeinput` target ranges.
+  - Android-specific pending diff handling around `beforeinput` and selection updates.
+
+## Local To Upstream Mapping
+
+| Local area | Local files | Upstream reference |
+| --- | --- | --- |
+| DOM node/point/range conversion | `packages/core/src/editor/dom-editor.ts` | `/tmp/slate-upstream/packages/slate-dom/src/plugin/dom-editor.ts` |
+| DOM-specific editor plugin behavior | `packages/core/src/editor/plugins/with-dom.ts` | `/tmp/slate-upstream/packages/slate-dom/src/plugin/with-dom.ts` |
+| Selection sync loop | `packages/core/src/text-area/syncSelection.ts` | `/tmp/slate-upstream/packages/slate-react/src/components/editable.tsx` |
+| Selectionchange wiring | `packages/core/src/text-area/TextArea.ts` | `/tmp/slate-upstream/packages/slate-react/src/components/editable.tsx` |
+| IME/composition handling | `packages/core/src/text-area/event-handlers/composition.ts` | `/tmp/slate-upstream/packages/slate-react/src/components/editable.tsx` |
+| Beforeinput handling | `packages/core/src/text-area/event-handlers/beforeInput.ts` | `/tmp/slate-upstream/packages/slate-react/src/components/editable.tsx` |
+| Target classification helpers | `packages/core/src/text-area/helpers.ts` | `/tmp/slate-upstream/packages/slate-dom/src/plugin/dom-editor.ts` |
+| Android-specific deferred input behavior | none today | `/tmp/slate-upstream/packages/slate-react/src/hooks/android-input-manager/android-input-manager.ts` |
+
+## Mandatory Checklist
+
+### 1. Freeze Regression Coverage Before Bumping Versions
+
+- Add characterization tests for the currently reported bug shapes before changing behavior.
+- Minimum regression cases:
+  - Android / IME autocorrect replacement
+  - Chinese IME after `Ctrl+A` then `Enter`
+  - Cursor crossing mark/plain-text boundary
+  - Selection inside table then `Enter`
+  - Selection inside ShadowRoot / micro-frontend host
+  - Non-editable inline or void node cursor movement
+  - Readonly selection behavior
+  - DOM node unmount while selectionchange is still in flight
+- Add unit tests where possible under `packages/core/__tests__/text-area` and `packages/core/__tests__/editor`.
+- Add at least one browser-level regression in `tests/e2e` for IME-adjacent and table selection behavior.
+
+### 2. Realign Target Classification APIs
+
+- Add a local equivalent of `hasSelectableTarget`.
+- Re-audit `hasEditableTarget`, `hasTarget`, and `isTargetInsideNonReadonlyVoid`.
+- Ensure readonly mode still allows valid selection detection without treating random external nodes as selectable.
+- Review local code paths still assuming "editable" and "selectable" mean the same thing.
+- Expected local touch points:
+  - `packages/core/src/text-area/helpers.ts`
+  - `packages/core/src/text-area/syncSelection.ts`
+  - `packages/core/src/text-area/event-handlers/*`
+
+### 3. Rewrite `toSlatePoint` to Match Current Upstream Behavior
+
+- Port the non-contenteditable branch search logic.
+- Port nested editor / nested void safety checks.
+- Port `searchDirection` handling.
+- Port Android zero-width composition adjustments.
+- Wrap stale `findPath` resolution in `try/catch` when `suppressThrow` is enabled.
+- Expected local touch point:
+  - `packages/core/src/editor/dom-editor.ts`
+
+### 4. Rewrite `toSlateRange` to Match Current Upstream Behavior
+
+- Port `focusBeforeAnchor` search direction handling.
+- Review ShadowRoot `isCollapsed` compatibility logic.
+- Review Firefox-specific table range handling.
+- Keep `suppressThrow: true` on selectionchange and readonly safety paths.
+- Expected local touch point:
+  - `packages/core/src/editor/dom-editor.ts`
+
+### 5. Rebuild the Selectionchange Pipeline
+
+- Re-check the current throttle-only approach in `TextArea.onDOMSelectionChange`.
+- Add upstream-style guards for:
+  - composing state
+  - internal drag state
+  - updating-selection state
+  - Android pending changes
+  - dirty node map / stale DOM mapping
+  - events originating from native `input` and `textarea`
+- Revisit deselect behavior in readonly mode.
+- Expected local touch points:
+  - `packages/core/src/text-area/TextArea.ts`
+  - `packages/core/src/text-area/syncSelection.ts`
+
+### 6. Rebuild `beforeinput` / composition Coordination
+
+- Flush pending selection synchronization before handling `beforeinput`.
+- Re-check whether target ranges should update selection before applying edits.
+- Review whether the current composition pipeline should still do manual DOM repair after upstream-aligned selection handling is introduced.
+- Preserve wangEditor-specific handling only where upstream behavior does not cover custom rendering constraints.
+- Expected local touch points:
+  - `packages/core/src/text-area/event-handlers/beforeInput.ts`
+  - `packages/core/src/text-area/event-handlers/composition.ts`
+
+### 7. Decide How Much Android Input Manager Logic to Borrow
+
+- Do not port the whole upstream Android input manager blindly.
+- Do evaluate whether the current local implementation needs:
+  - pending diff buffering
+  - deferred flush after non-contenteditable deletion
+  - user selection handoff while composing
+- This is the main area connected to:
+  - `#12`
+  - `#254`
+  - `#298`
+  - `#750`
+
+### 8. Audit Local Overrides That Can Still Break After Upstream Alignment
+
+- Review editor overrides in modules that mutate selection or `insertBreak`.
+- Highest risk modules:
+  - `packages/table-module/src/module/plugin.ts`
+  - `packages/list-module/src/module/plugin.ts`
+  - `packages/plugin-markdown/src/module/plugin.ts`
+  - `packages/basic-modules/src/modules/link/helper.ts`
+- Confirm these still behave correctly after `slate` API and selection semantics shift.
+
+### 9. Upgrade Dependencies
+
+- Update workspace packages from `slate@^0.82.0` to the target range.
+- Update `slate-history` in `packages/core`.
+- Re-run install and rebuild lockfile.
+- Fix compile-time breakages package by package.
+- Rebuild all affected packages after `packages/core` changes.
+
+### 10. Re-run Full Validation
+
+- `pnpm install`
+- `pnpm build`
+- `pnpm test`
+- `pnpm e2e`
+- Manual validation in:
+  - Chrome desktop
+  - Firefox desktop
+  - Safari desktop if available
+  - Android Chrome / WebView
+  - Shadow DOM or micro-frontend host
+
+## Suggested Execution Order
+
+1. Add regression tests first.
+2. Align local DOM bridge behavior with upstream `slate-dom`.
+3. Align selectionchange / beforeinput / composition flow with upstream `slate-react`.
+4. Upgrade `slate` and `slate-history`.
+5. Fix compile and behavior regressions in `table-module`, `list-module`, markdown, and link handling.
+6. Run full build and cross-browser validation.
+
+## High-Risk Local Files
+
+- `packages/core/src/editor/dom-editor.ts`
+- `packages/core/src/text-area/syncSelection.ts`
+- `packages/core/src/text-area/TextArea.ts`
+- `packages/core/src/text-area/event-handlers/composition.ts`
+- `packages/core/src/text-area/event-handlers/beforeInput.ts`
+- `packages/table-module/src/module/plugin.ts`
+- `packages/list-module/src/module/plugin.ts`
+- `packages/basic-modules/src/modules/link/helper.ts`
+- `packages/plugin-markdown/src/module/plugin.ts`
+
+## Compare Commands
+
+- Compare local DOM bridge against upstream:
+  - `git diff --no-index packages/core/src/editor/dom-editor.ts /tmp/slate-upstream/packages/slate-dom/src/plugin/dom-editor.ts`
+- Compare local selection sync against upstream editable handling:
+  - `git diff --no-index packages/core/src/text-area/syncSelection.ts /tmp/slate-upstream/packages/slate-react/src/components/editable.tsx`
+- Search all local Slate integration points:
+  - `rg -n "from 'slate'|from 'slate-history'|selectionchange|beforeinput|composition|contenteditable|data-slate" packages -g '!**/dist/**'`
+
+## Deliverable Definition
+
+- The upgrade effort is not done when the code compiles.
+- The effort is done when:
+  - the dependency bump lands,
+  - the issue clusters above have regression coverage,
+  - cursor / IME / readonly / table / shadow-root behavior is revalidated,
+  - and the local DOM bridge no longer diverges from upstream in the known failure areas without an explicit reason.

--- a/packages/basic-modules/package.json
+++ b/packages/basic-modules/package.json
@@ -48,7 +48,7 @@
     "dom7": "^3.0.0 || ^4.0.0",
     "lodash.throttle": "^4.1.1",
     "nanoid": "^5.0.0",
-    "slate": "^0.82.0",
+    "slate": "^0.123.0",
     "snabbdom": "^3.6.0"
   },
   "dependencies": {

--- a/packages/basic-modules/src/modules/color/menu/BaseMenu.ts
+++ b/packages/basic-modules/src/modules/color/menu/BaseMenu.ts
@@ -6,7 +6,7 @@
 import {
   DomEditor, IDomEditor, IDropPanelMenu, t,
 } from '@wangeditor-next/core'
-import { Editor } from 'slate'
+import { Editor, Element } from 'slate'
 
 import { CLEAN_SVG } from '../../../constants/icon-svg'
 import $, { Dom7Array, DOMElement } from '../../../utils/dom'
@@ -52,7 +52,7 @@ abstract class BaseMenu implements IDropPanelMenu {
         const type = DomEditor.getNodeType(n)
 
         if (type === 'pre') { return true } // 代码块
-        if (Editor.isVoid(editor, n)) { return true } // void node
+        if (Element.isElement(n) && Editor.isVoid(editor, n)) { return true } // void node
 
         return false
       },

--- a/packages/basic-modules/src/modules/emotion/menu/EmotionMenu.ts
+++ b/packages/basic-modules/src/modules/emotion/menu/EmotionMenu.ts
@@ -6,7 +6,7 @@
 import {
   DomEditor, IDomEditor, IDropPanelMenu, t,
 } from '@wangeditor-next/core'
-import { Editor } from 'slate'
+import { Editor, Element } from 'slate'
 
 import { EMOTION_SVG } from '../../../constants/icon-svg'
 import $, { Dom7Array, DOMElement } from '../../../utils/dom'
@@ -45,7 +45,7 @@ class EmotionMenu implements IDropPanelMenu {
         const type = DomEditor.getNodeType(n)
 
         if (type === 'pre') { return true } // 代码块
-        if (Editor.isVoid(editor, n)) { return true } // void node
+        if (Element.isElement(n) && Editor.isVoid(editor, n)) { return true } // void node
 
         return false
       },

--- a/packages/basic-modules/src/modules/font-size-family/menu/BaseMenu.ts
+++ b/packages/basic-modules/src/modules/font-size-family/menu/BaseMenu.ts
@@ -6,7 +6,7 @@
 import {
   DomEditor, IDomEditor, IOption, ISelectMenu,
 } from '@wangeditor-next/core'
-import { Editor } from 'slate'
+import { Editor, Element } from 'slate'
 
 abstract class BaseMenu implements ISelectMenu {
   abstract readonly title: string
@@ -43,7 +43,7 @@ abstract class BaseMenu implements ISelectMenu {
         const type = DomEditor.getNodeType(n)
 
         if (type === 'pre') { return true } // 代码块
-        if (Editor.isVoid(editor, n)) { return true } // void node
+        if (Element.isElement(n) && Editor.isVoid(editor, n)) { return true } // void node
 
         return false
       },

--- a/packages/basic-modules/src/modules/image/helper.ts
+++ b/packages/basic-modules/src/modules/image/helper.ts
@@ -4,7 +4,9 @@
  */
 
 import { DomEditor, IDomEditor } from '@wangeditor-next/core'
-import { Editor, Range, Transforms } from 'slate'
+import {
+  Editor, Element, Range, Transforms,
+} from 'slate'
 
 import { replaceSymbols } from '../../utils/util'
 import { ImageElement, ImageStyle } from './custom-types'
@@ -29,7 +31,7 @@ export function isInsertImageMenuDisabled(editor: IDomEditor): boolean {
       if (type === 'list-item') { return true } // list
       if (type.startsWith('header')) { return true } // 标题
       if (type === 'blockquote') { return true } // 引用
-      if (Editor.isVoid(editor, n)) { return true } // void
+      if (Element.isElement(n) && Editor.isVoid(editor, n)) { return true } // void
 
       return false
     },

--- a/packages/basic-modules/src/modules/justify/menu/BaseMenu.ts
+++ b/packages/basic-modules/src/modules/justify/menu/BaseMenu.ts
@@ -4,7 +4,7 @@
  */
 
 import { DomEditor, IButtonMenu, IDomEditor } from '@wangeditor-next/core'
-import { Editor, Element, Node } from 'slate'
+import { Editor, Element } from 'slate'
 
 abstract class BaseMenu implements IButtonMenu {
   abstract readonly title: string
@@ -27,8 +27,8 @@ abstract class BaseMenu implements IButtonMenu {
     if (editor.selection == null) { return true }
 
     const selectedElems = DomEditor.getSelectedElems(editor)
-    const notMatch = selectedElems.some((elem: Node) => {
-      const { type } = elem as unknown as Element
+    const notMatch = selectedElems.some((elem: Element) => {
+      const { type } = elem
 
       if (Editor.isVoid(editor, elem) && Editor.isBlock(editor, elem) && type !== 'video') { return true }
 

--- a/packages/basic-modules/src/modules/text-style/helper.ts
+++ b/packages/basic-modules/src/modules/text-style/helper.ts
@@ -4,7 +4,7 @@
  */
 
 import { DomEditor, IDomEditor } from '@wangeditor-next/core'
-import { Editor, Node } from 'slate'
+import { Editor, Element, Node } from 'slate'
 
 export function isMenuDisabled(editor: IDomEditor, _mark?: string): boolean {
   if (editor.selection == null) { return true }
@@ -14,7 +14,7 @@ export function isMenuDisabled(editor: IDomEditor, _mark?: string): boolean {
       const type = DomEditor.getNodeType(n)
 
       if (type === 'pre') { return true } // 代码块
-      if (Editor.isVoid(editor, n)) { return true } // void node
+      if (Element.isElement(n) && Editor.isVoid(editor, n)) { return true } // void node
 
       return false
     },

--- a/packages/code-highlight/package.json
+++ b/packages/code-highlight/package.json
@@ -46,7 +46,7 @@
   "peerDependencies": {
     "@wangeditor-next/core": "1.7.46",
     "dom7": "^3.0.0 || ^4.0.0",
-    "slate": "^0.82.0",
+    "slate": "^0.123.0",
     "snabbdom": "^3.6.0"
   },
   "dependencies": {

--- a/packages/core/__tests__/editor/dom-editor.test.ts
+++ b/packages/core/__tests__/editor/dom-editor.test.ts
@@ -169,6 +169,18 @@ describe('Core DomEditor', () => {
     expect(res).toBeTruthy()
   })
 
+  test('hasDOMNode treats readonly editor descendants as editable targets', async () => {
+    editor.insertText('x')
+    await flushPromises()
+
+    const editorElement = DomEditor.toDOMNode(editor, editor)
+    const textNode = editorElement.querySelector('[data-slate-string]')?.firstChild as Node
+
+    editorElement.setAttribute('contenteditable', 'false')
+
+    expect(DomEditor.hasDOMNode(editor, textNode, { editable: true })).toBe(true)
+  })
+
   test('toDOMRange', async () => {
     editor.insertText('hello')
     await flushPromises()
@@ -263,6 +275,69 @@ describe('Core DomEditor', () => {
     })
 
     expect(slatePoint).toEqual(point)
+  })
+
+  test('toSlatePoint returns null when suppressThrow is enabled and path lookup is stale', async () => {
+    editor.insertText('hello')
+    await flushPromises()
+
+    const point = { path: [0, 0], offset: 3 }
+    const domPoint = DomEditor.toDOMPoint(editor, point)
+
+    vi.spyOn(DomEditor, 'findPath').mockImplementationOnce(() => {
+      throw new Error('stale path')
+    })
+
+    const slatePoint = DomEditor.toSlatePoint(editor, domPoint, {
+      exactMatch: false,
+      suppressThrow: true,
+    })
+
+    expect(slatePoint).toBeNull()
+  })
+
+  test('toSlatePoint finds the next selectable leaf when selection lands inside a non-editable node', async () => {
+    editor.insertText('hello')
+    await flushPromises()
+
+    const paragraph = DomEditor.toDOMNode(editor, editor.children[0] as CustomElement)
+    const textNodeWrapper = paragraph.querySelector('[data-slate-node="text"]') as HTMLElement
+    const leaf = paragraph.querySelector('[data-slate-leaf]') as HTMLElement
+    const nonEditable = document.createElement('span')
+
+    nonEditable.setAttribute('contenteditable', 'false')
+    nonEditable.textContent = 'x'
+    textNodeWrapper.insertBefore(nonEditable, leaf)
+
+    const slatePoint = DomEditor.toSlatePoint(editor, [nonEditable.firstChild as Node, 0], {
+      exactMatch: false,
+      suppressThrow: false,
+      searchDirection: 'forward',
+    })
+
+    expect(slatePoint).toEqual({ path: [0, 0], offset: 0 })
+  })
+
+  test('toSlatePoint finds the previous selectable leaf when selection lands after a non-editable node', async () => {
+    editor.insertText('hello')
+    await flushPromises()
+
+    const paragraph = DomEditor.toDOMNode(editor, editor.children[0] as CustomElement)
+    const textNodeWrapper = paragraph.querySelector('[data-slate-node="text"]') as HTMLElement
+    const leaf = paragraph.querySelector('[data-slate-leaf]') as HTMLElement
+    const nonEditable = document.createElement('span')
+
+    nonEditable.setAttribute('contenteditable', 'false')
+    nonEditable.textContent = 'x'
+    textNodeWrapper.insertBefore(nonEditable, leaf.nextSibling)
+
+    const slatePoint = DomEditor.toSlatePoint(editor, [nonEditable.firstChild as Node, 1], {
+      exactMatch: false,
+      suppressThrow: false,
+      searchDirection: 'backward',
+    })
+
+    expect(slatePoint).toEqual({ path: [0, 0], offset: 5 })
   })
 
   test('hasRange', () => {

--- a/packages/core/__tests__/editor/plugins/with-content.test.ts
+++ b/packages/core/__tests__/editor/plugins/with-content.test.ts
@@ -257,6 +257,23 @@ describe('editor content API', () => {
     expect(editor.getText()).toBe('lo')
   })
 
+  it('deleteFragment resets a full-document selection to an empty paragraph', () => {
+    const editor = createEditor({
+      content: [
+        {
+          type: 'header1',
+          textAlign: 'center',
+          children: [{ text: 'hello' }],
+        } as any,
+      ],
+    })
+
+    editor.select([])
+    editor.deleteFragment()
+
+    expect(editor.children).toEqual([{ type: 'paragraph', children: [{ text: '' }] }])
+  })
+
   it('insertBreak', () => {
     const editor = createEditor()
 

--- a/packages/core/__tests__/editor/plugins/with-content.test.ts
+++ b/packages/core/__tests__/editor/plugins/with-content.test.ts
@@ -272,6 +272,10 @@ describe('editor content API', () => {
     editor.deleteFragment()
 
     expect(editor.children).toEqual([{ type: 'paragraph', children: [{ text: '' }] }])
+    expect(editor.selection).toEqual({
+      anchor: { path: [0, 0], offset: 0 },
+      focus: { path: [0, 0], offset: 0 },
+    })
   })
 
   it('insertBreak', () => {

--- a/packages/core/__tests__/text-area/TextArea.test.ts
+++ b/packages/core/__tests__/text-area/TextArea.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @description TextArea test
+ */
+
+import {
+  afterEach, describe, expect, it, vi,
+} from 'vitest'
+
+import flushPromises from '../../../../tests/utils/flush-promises'
+import { EditorEvents } from '../../src/config/interface'
+import { DomEditor } from '../../src/editor/dom-editor'
+import * as syncSelection from '../../src/text-area/syncSelection'
+import TextArea from '../../src/text-area/TextArea'
+import { TEXTAREA_TO_EDITOR } from '../../src/utils/weak-maps'
+
+afterEach(() => {
+  document.body.innerHTML = ''
+  vi.restoreAllMocks()
+})
+
+describe('TextArea', () => {
+  it('binds selectionchange to the editor root', async () => {
+    document.body.innerHTML = '<div id="box"></div>'
+    const root = {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    } as any
+    const editor = {
+      on: vi.fn(),
+      getConfig: () => ({ scroll: true }),
+      hidePanelOrModal: vi.fn(),
+      selection: null,
+    } as any
+
+    vi.spyOn(DomEditor, 'findDocumentOrShadowRoot').mockReturnValue(root)
+
+    const textarea = new TextArea('#box')
+
+    TEXTAREA_TO_EDITOR.set(textarea, editor)
+    await flushPromises()
+
+    const selectionChangeHandler = root.addEventListener.mock.calls[0][1]
+    const destroyedHandler = editor.on.mock.calls.find(
+      ([eventType]) => eventType === EditorEvents.DESTROYED,
+    )?.[1]
+
+    expect(root.addEventListener).toHaveBeenCalledWith(
+      'selectionchange',
+      expect.any(Function),
+    )
+    expect(destroyedHandler).toEqual(expect.any(Function))
+
+    destroyedHandler()
+
+    expect(root.removeEventListener).toHaveBeenCalledWith(
+      'selectionchange',
+      selectionChangeHandler,
+    )
+  })
+
+  it('ignores selectionchange events originating from input and textarea', async () => {
+    document.body.innerHTML = '<div id="box"></div>'
+    const root = {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    } as any
+    const editor = {
+      on: vi.fn(),
+      getConfig: () => ({ scroll: true }),
+      hidePanelOrModal: vi.fn(),
+      selection: null,
+    } as any
+
+    vi.spyOn(DomEditor, 'findDocumentOrShadowRoot').mockReturnValue(root)
+    const syncSpy = vi.spyOn(syncSelection, 'DOMSelectionToEditor').mockImplementation(() => {})
+
+    const textarea = new TextArea('#box')
+
+    TEXTAREA_TO_EDITOR.set(textarea, editor)
+    await flushPromises()
+
+    const selectionChangeHandler = root.addEventListener.mock.calls[0][1]
+    const input = document.createElement('input')
+    const textareaElem = document.createElement('textarea')
+    const div = document.createElement('div')
+
+    selectionChangeHandler({ target: input })
+    selectionChangeHandler({ target: textareaElem })
+    selectionChangeHandler.flush()
+
+    expect(syncSpy).not.toHaveBeenCalled()
+
+    selectionChangeHandler({ target: div })
+    selectionChangeHandler.flush()
+
+    expect(syncSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core/__tests__/text-area/event-handlers/before-input.test.ts
+++ b/packages/core/__tests__/text-area/event-handlers/before-input.test.ts
@@ -10,7 +10,10 @@ import {
 import { DomEditor } from '../../../src/editor/dom-editor'
 import handleBeforeInput from '../../../src/text-area/event-handlers/beforeInput'
 import * as helpers from '../../../src/text-area/helpers'
-import { EDITOR_TO_CAN_PASTE } from '../../../src/utils/weak-maps'
+import {
+  EDITOR_TO_CAN_PASTE,
+  EDITOR_TO_PENDING_COMPOSITION_END,
+} from '../../../src/utils/weak-maps'
 
 vi.mock('../../../src/utils/ua', () => ({
   HAS_BEFORE_INPUT_SUPPORT: true,
@@ -49,6 +52,33 @@ describe('handleBeforeInput', () => {
 
     expect(Editor.insertText).toHaveBeenCalledWith(editor, 'hello')
     expect(event.preventDefault).toHaveBeenCalled()
+  })
+
+  it('flushes DOM selection sync before handling input', () => {
+    const editor = {
+      selection: createSelection(false),
+      getConfig: () => ({ readOnly: false }),
+      insertData: vi.fn(),
+    } as any
+    const textarea = {
+      flushDOMSelectionChange: vi.fn(),
+    } as any
+    const event = {
+      inputType: 'insertText',
+      data: 'hello',
+      dataTransfer: null,
+      isComposing: false,
+      target: {},
+      preventDefault: vi.fn(),
+      getTargetRanges: () => [],
+    } as any
+
+    vi.spyOn(helpers, 'hasEditableTarget').mockReturnValue(true)
+    vi.spyOn(Editor, 'insertText').mockImplementation(() => {})
+
+    handleBeforeInput(event, textarea, editor)
+
+    expect(textarea.flushDOMSelectionChange).toHaveBeenCalledTimes(1)
   })
 
   it('deletes backward for deleteContentBackward', () => {
@@ -123,5 +153,37 @@ describe('handleBeforeInput', () => {
 
     expect(Editor.insertText).not.toHaveBeenCalled()
     EDITOR_TO_CAN_PASTE.delete(editor)
+  })
+
+  it('marks insertFromComposition as already handled', () => {
+    const editor = {
+      selection: createSelection(false),
+      getConfig: () => ({ readOnly: false }),
+      insertData: vi.fn(),
+    } as any
+    const textarea = {
+      flushDOMSelectionChange: vi.fn(),
+      isComposing: true,
+    } as any
+    const event = {
+      inputType: 'insertFromComposition',
+      data: '拼',
+      dataTransfer: null,
+      isComposing: true,
+      target: {},
+      preventDefault: vi.fn(),
+      getTargetRanges: () => [],
+    } as any
+
+    vi.spyOn(helpers, 'hasEditableTarget').mockReturnValue(true)
+    vi.spyOn(Editor, 'insertText').mockImplementation(() => {})
+
+    handleBeforeInput(event, textarea, editor)
+
+    expect(Editor.insertText).toHaveBeenCalledWith(editor, '拼')
+    expect(textarea.isComposing).toBe(false)
+    expect(EDITOR_TO_PENDING_COMPOSITION_END.get(editor)).toBe(true)
+
+    EDITOR_TO_PENDING_COMPOSITION_END.delete(editor)
   })
 })

--- a/packages/core/__tests__/text-area/event-handlers/click.test.ts
+++ b/packages/core/__tests__/text-area/event-handlers/click.test.ts
@@ -21,6 +21,7 @@ describe('handleOnClick', () => {
   it('selects void node range', () => {
     const editor = {
       getConfig: () => ({ readOnly: false }),
+      range: vi.fn((at: any, to = at) => ({ anchor: at, focus: to })),
     } as any
     const target = document.createElement('div')
     const event = { target } as any

--- a/packages/core/__tests__/text-area/event-handlers/composition.test.ts
+++ b/packages/core/__tests__/text-area/event-handlers/composition.test.ts
@@ -2,7 +2,7 @@
  * @description composition handlers test
  */
 
-import { Editor } from 'slate'
+import { Editor, Transforms } from 'slate'
 import {
   afterEach, describe, expect, it, vi,
 } from 'vitest'
@@ -17,6 +17,10 @@ import {
 import * as helpers from '../../../src/text-area/helpers'
 import { hidePlaceholder } from '../../../src/text-area/place-holder'
 import { editorSelectionToDOM } from '../../../src/text-area/syncSelection'
+import {
+  EDITOR_TO_PENDING_COMPOSITION_END,
+  EDITOR_TO_PENDING_SELECTION,
+} from '../../../src/utils/weak-maps'
 
 vi.mock('../../../src/utils/ua', () => ({
   IS_CHROME: true,
@@ -105,5 +109,69 @@ describe('composition handlers', () => {
     expect(DomEditor.setNewKey).toHaveBeenCalledWith(paragraph)
     expect(Editor.insertText).toHaveBeenCalledWith(editor, 'a')
     expect(textarea.changeViewState).toHaveBeenCalled()
+  })
+
+  it('skips duplicate insert when beforeinput already handled composition commit', () => {
+    const paragraph = { type: 'paragraph', children: [{ text: 'x' }] }
+    const editor = {
+      selection: createSelection(false),
+      getConfig: () => ({ maxLength: 0 }),
+    } as any
+    const textarea = { changeViewState: vi.fn() } as any
+    const event = { target: {}, data: '拼' } as any
+
+    vi.spyOn(helpers, 'hasEditableTarget').mockReturnValue(true)
+    vi.spyOn(DomEditor, 'cleanExposedTexNodeInSelectionBlock').mockImplementation(() => {})
+    vi.spyOn(DomEditor, 'findDocumentOrShadowRoot').mockReturnValue({ getSelection: () => null } as any)
+    vi.spyOn(Editor, 'node').mockImplementation((_ed, path) => {
+      if (path.length === 1) {
+        return [paragraph, path] as any
+      }
+
+      return [{ text: 'x' }, path] as any
+    })
+    vi.spyOn(Editor, 'insertText').mockImplementation(() => {})
+    EDITOR_TO_PENDING_COMPOSITION_END.set(editor, true)
+
+    handleCompositionEnd(event, textarea, editor)
+
+    expect(DomEditor.cleanExposedTexNodeInSelectionBlock).toHaveBeenCalledWith(editor)
+    expect(Editor.insertText).not.toHaveBeenCalled()
+    expect(EDITOR_TO_PENDING_COMPOSITION_END.has(editor)).toBe(false)
+  })
+
+  it('applies pending selection before inserting committed composition text', () => {
+    const paragraph = { type: 'paragraph', children: [{ text: 'x' }] }
+    const pendingSelection = {
+      anchor: { path: [0, 0], offset: 1 },
+      focus: { path: [0, 0], offset: 1 },
+    }
+    const editor = {
+      selection: createSelection(false),
+      getConfig: () => ({ maxLength: 0 }),
+    } as any
+    const textarea = { changeViewState: vi.fn() } as any
+    const event = { target: {}, data: '拼' } as any
+
+    vi.spyOn(helpers, 'hasEditableTarget').mockReturnValue(true)
+    vi.spyOn(DomEditor, 'cleanExposedTexNodeInSelectionBlock').mockImplementation(() => {})
+    vi.spyOn(DomEditor, 'findDocumentOrShadowRoot').mockReturnValue({ getSelection: () => null } as any)
+    vi.spyOn(Editor, 'node').mockImplementation((_ed, path) => {
+      if (path.length === 1) {
+        return [paragraph, path] as any
+      }
+
+      return [{ text: 'x' }, path] as any
+    })
+    vi.spyOn(Editor, 'insertText').mockImplementation(() => {})
+    const selectSpy = vi.spyOn(Transforms, 'select').mockImplementation(() => {})
+
+    EDITOR_TO_PENDING_SELECTION.set(editor, pendingSelection as any)
+
+    handleCompositionEnd(event, textarea, editor)
+
+    expect(selectSpy).toHaveBeenCalledWith(editor, pendingSelection)
+    expect(Editor.insertText).toHaveBeenCalledWith(editor, '拼')
+    expect(EDITOR_TO_PENDING_SELECTION.has(editor)).toBe(false)
   })
 })

--- a/packages/core/__tests__/text-area/event-handlers/cut.test.ts
+++ b/packages/core/__tests__/text-area/event-handlers/cut.test.ts
@@ -45,6 +45,7 @@ describe('handleOnCut', () => {
 
   it('deletes void node for collapsed selection', () => {
     const clipboardData = { setData: vi.fn() }
+    const voidNode = { type: 'void', children: [{ text: '' }] }
     const editor = {
       selection: createSelection(false),
       getConfig: () => ({ readOnly: false }),
@@ -57,7 +58,7 @@ describe('handleOnCut', () => {
     } as any
 
     vi.spyOn(helpers, 'hasEditableTarget').mockReturnValue(true)
-    vi.spyOn(Node, 'parent').mockReturnValue({ type: 'void' } as any)
+    vi.spyOn(Node, 'parent').mockReturnValue(voidNode as any)
     vi.spyOn(Editor, 'isVoid').mockReturnValue(true)
     vi.spyOn(Transforms, 'delete').mockImplementation(() => {})
 

--- a/packages/core/__tests__/text-area/helpers.test.ts
+++ b/packages/core/__tests__/text-area/helpers.test.ts
@@ -10,6 +10,7 @@ import {
 import { DomEditor } from '../../src/editor/dom-editor'
 import {
   hasEditableTarget,
+  hasSelectableTarget,
   hasTarget,
   isDOMEventHandled,
   isRangeEqual,
@@ -85,10 +86,32 @@ describe('text-area helpers', () => {
     const target = { nodeType: 1 } as any
 
     vi.spyOn(DomEditor, 'hasDOMNode').mockReturnValue(true)
-    vi.spyOn(DomEditor, 'toSlateNode').mockReturnValue({ type: 'void' } as any)
+    vi.spyOn(DomEditor, 'toSlateNode').mockReturnValue({ type: 'void', children: [] } as any)
     vi.spyOn(Editor, 'isVoid').mockReturnValue(true)
 
     expect(isTargetInsideNonReadonlyVoid(editor, target)).toBe(true)
+  })
+
+  it('treats editable targets as selectable', () => {
+    const editor = {} as any
+    const target = { nodeType: 1 } as any
+
+    vi.spyOn(DomEditor, 'hasDOMNode').mockImplementation((_editor, _target, options) => {
+      return Boolean(options?.editable)
+    })
+
+    expect(hasSelectableTarget(editor, target)).toBe(true)
+  })
+
+  it('treats void targets as selectable even when not editable', () => {
+    const editor = { getConfig: () => ({ readOnly: false }) } as any
+    const target = { nodeType: 1 } as any
+
+    vi.spyOn(DomEditor, 'hasDOMNode').mockReturnValue(true)
+    vi.spyOn(DomEditor, 'toSlateNode').mockReturnValue({ type: 'void', children: [] } as any)
+    vi.spyOn(Editor, 'isVoid').mockReturnValue(true)
+
+    expect(hasSelectableTarget(editor, target)).toBe(true)
   })
 
   it('returns false when editor is readonly', () => {

--- a/packages/core/__tests__/text-area/syncSelection.test.ts
+++ b/packages/core/__tests__/text-area/syncSelection.test.ts
@@ -11,7 +11,11 @@ import {
 import { DomEditor } from '../../src/editor/dom-editor'
 import * as helpers from '../../src/text-area/helpers'
 import { DOMSelectionToEditor, editorSelectionToDOM } from '../../src/text-area/syncSelection'
-import { EDITOR_TO_ELEMENT, IS_FOCUSED } from '../../src/utils/weak-maps'
+import {
+  EDITOR_TO_ELEMENT,
+  EDITOR_TO_PENDING_SELECTION,
+  IS_FOCUSED,
+} from '../../src/utils/weak-maps'
 
 vi.mock('scroll-into-view-if-needed', () => ({
   default: vi.fn(),
@@ -22,8 +26,8 @@ vi.mock('../../src/utils/ua', () => ({
 }))
 
 vi.mock('../../src/text-area/helpers', () => ({
-  hasEditableTarget: vi.fn(),
-  isTargetInsideNonReadonlyVoid: vi.fn(),
+  hasSelectableTarget: vi.fn(),
+  hasTarget: vi.fn(),
 }))
 
 const createSelection = (backward = false) => ({
@@ -280,15 +284,63 @@ describe('editorSelectionToDOM', () => {
 })
 
 describe('DOMSelectionToEditor', () => {
-  it('returns early when editor is readonly', () => {
+  it('selects range when editor is readonly and dom selection stays in editor', () => {
     const editor = { getConfig: () => ({ readOnly: true }) } as any
     const textarea = { isComposing: false, isUpdatingSelection: false, isDraggingInternally: false } as any
 
-    const deselectSpy = vi.spyOn(Transforms, 'deselect')
+    const editorElement = document.createElement('div')
+    const domSelection = createDomSelection({
+      anchorNode: document.createTextNode('a'),
+      focusNode: document.createTextNode('b'),
+    })
+    const root = { activeElement: editorElement, getSelection: () => domSelection }
+    const range = createSelection()
+
+    vi.spyOn(DomEditor, 'findDocumentOrShadowRoot').mockReturnValue(root as any)
+    vi.spyOn(DomEditor, 'toDOMNode').mockReturnValue(editorElement as any)
+    vi.spyOn(DomEditor, 'toSlateRange').mockReturnValue(range as any)
+
+    const hasSelectableTarget = helpers.hasSelectableTarget as unknown as vi.Mock
+    const hasTarget = helpers.hasTarget as unknown as vi.Mock
+
+    hasSelectableTarget.mockReturnValue(true)
+    hasTarget.mockReturnValue(true)
+
+    const selectSpy = vi.spyOn(Transforms, 'select').mockImplementation(() => {})
+    const deselectSpy = vi.spyOn(Transforms, 'deselect').mockImplementation(() => {})
 
     DOMSelectionToEditor(textarea, editor)
 
+    expect(selectSpy).toHaveBeenCalledWith(editor, range)
     expect(deselectSpy).not.toHaveBeenCalled()
+  })
+
+  it('deselects when readonly selection leaves the editor', () => {
+    const editor = {
+      deselect: vi.fn(),
+      getConfig: () => ({ readOnly: true }),
+    } as any
+    const textarea = { isComposing: false, isUpdatingSelection: false, isDraggingInternally: false } as any
+
+    const editorElement = document.createElement('div')
+    const domSelection = createDomSelection({
+      anchorNode: document.createTextNode('a'),
+      focusNode: document.createTextNode('b'),
+    })
+    const root = { activeElement: editorElement, getSelection: () => domSelection }
+
+    vi.spyOn(DomEditor, 'findDocumentOrShadowRoot').mockReturnValue(root as any)
+    vi.spyOn(DomEditor, 'toDOMNode').mockReturnValue(editorElement as any)
+
+    const hasSelectableTarget = helpers.hasSelectableTarget as unknown as vi.Mock
+    const hasTarget = helpers.hasTarget as unknown as vi.Mock
+
+    hasSelectableTarget.mockReturnValue(false)
+    hasTarget.mockReturnValue(false)
+
+    DOMSelectionToEditor(textarea, editor)
+
+    expect(editor.deselect).toHaveBeenCalled()
   })
 
   it('deselects when editor is not active element', () => {
@@ -341,18 +393,80 @@ describe('DOMSelectionToEditor', () => {
     vi.spyOn(DomEditor, 'toDOMNode').mockReturnValue(editorElement as any)
     vi.spyOn(DomEditor, 'toSlateRange').mockReturnValue(range as any)
 
-    const hasEditableTarget = helpers.hasEditableTarget as unknown as vi.Mock
-    const isTargetInsideNonReadonlyVoid = helpers.isTargetInsideNonReadonlyVoid as unknown as vi.Mock
+    const hasSelectableTarget = helpers.hasSelectableTarget as unknown as vi.Mock
+    const hasTarget = helpers.hasTarget as unknown as vi.Mock
 
-    hasEditableTarget.mockReturnValue(true)
-    isTargetInsideNonReadonlyVoid.mockReturnValue(false)
+    hasSelectableTarget.mockReturnValue(true)
+    hasTarget.mockReturnValue(true)
 
     const selectSpy = vi.spyOn(Transforms, 'select').mockImplementation(() => {})
 
     DOMSelectionToEditor(textarea, editor)
 
     expect(selectSpy).toHaveBeenCalledWith(editor, range)
+    expect(DomEditor.toSlateRange).toHaveBeenCalledWith(editor, domSelection, {
+      exactMatch: false,
+      suppressThrow: true,
+    })
     expect(Range.isCollapsed(range)).toBe(false)
+  })
+
+  it('stores a pending selection instead of selecting while composing', () => {
+    const editor = { getConfig: () => ({ readOnly: false }) } as any
+    const textarea = { isComposing: true, isUpdatingSelection: false, isDraggingInternally: false } as any
+
+    const editorElement = document.createElement('div')
+    const domSelection = createDomSelection({
+      anchorNode: document.createTextNode('a'),
+      focusNode: document.createTextNode('b'),
+    })
+    const root = { activeElement: editorElement, getSelection: () => domSelection }
+    const range = createSelection()
+
+    vi.spyOn(DomEditor, 'findDocumentOrShadowRoot').mockReturnValue(root as any)
+    vi.spyOn(DomEditor, 'toDOMNode').mockReturnValue(editorElement as any)
+    vi.spyOn(DomEditor, 'toSlateRange').mockReturnValue(range as any)
+
+    const hasSelectableTarget = helpers.hasSelectableTarget as unknown as vi.Mock
+    const hasTarget = helpers.hasTarget as unknown as vi.Mock
+
+    hasSelectableTarget.mockReturnValue(true)
+    hasTarget.mockReturnValue(true)
+
+    const selectSpy = vi.spyOn(Transforms, 'select').mockImplementation(() => {})
+
+    DOMSelectionToEditor(textarea, editor)
+
+    expect(selectSpy).not.toHaveBeenCalled()
+    expect(EDITOR_TO_PENDING_SELECTION.get(editor)).toEqual(range)
+  })
+
+  it('skips selection when slate range cannot be resolved during selectionchange', () => {
+    const editor = { getConfig: () => ({ readOnly: false }) } as any
+    const textarea = { isComposing: false, isUpdatingSelection: false, isDraggingInternally: false } as any
+
+    const editorElement = document.createElement('div')
+    const domSelection = createDomSelection({
+      anchorNode: document.createTextNode('a'),
+      focusNode: document.createTextNode('b'),
+    })
+    const root = { activeElement: editorElement, getSelection: () => domSelection }
+
+    vi.spyOn(DomEditor, 'findDocumentOrShadowRoot').mockReturnValue(root as any)
+    vi.spyOn(DomEditor, 'toDOMNode').mockReturnValue(editorElement as any)
+    vi.spyOn(DomEditor, 'toSlateRange').mockReturnValue(null as any)
+
+    const hasSelectableTarget = helpers.hasSelectableTarget as unknown as vi.Mock
+    const hasTarget = helpers.hasTarget as unknown as vi.Mock
+
+    hasSelectableTarget.mockReturnValue(true)
+    hasTarget.mockReturnValue(true)
+
+    const selectSpy = vi.spyOn(Transforms, 'select').mockImplementation(() => {})
+
+    DOMSelectionToEditor(textarea, editor)
+
+    expect(selectSpy).not.toHaveBeenCalled()
   })
 
   it('skips selection when nodes are not selectable', () => {
@@ -369,11 +483,38 @@ describe('DOMSelectionToEditor', () => {
     vi.spyOn(DomEditor, 'findDocumentOrShadowRoot').mockReturnValue(root as any)
     vi.spyOn(DomEditor, 'toDOMNode').mockReturnValue(editorElement as any)
 
-    const hasEditableTarget = helpers.hasEditableTarget as unknown as vi.Mock
-    const isTargetInsideNonReadonlyVoid = helpers.isTargetInsideNonReadonlyVoid as unknown as vi.Mock
+    const hasSelectableTarget = helpers.hasSelectableTarget as unknown as vi.Mock
+    const hasTarget = helpers.hasTarget as unknown as vi.Mock
 
-    hasEditableTarget.mockReturnValue(false)
-    isTargetInsideNonReadonlyVoid.mockReturnValue(false)
+    hasSelectableTarget.mockReturnValue(false)
+    hasTarget.mockReturnValue(false)
+
+    const selectSpy = vi.spyOn(Transforms, 'select').mockImplementation(() => {})
+
+    DOMSelectionToEditor(textarea, editor)
+
+    expect(selectSpy).not.toHaveBeenCalled()
+  })
+
+  it('skips selection when focus node is outside editor even if anchor is selectable', () => {
+    const editor = { getConfig: () => ({ readOnly: false }) } as any
+    const textarea = { isComposing: false, isUpdatingSelection: false, isDraggingInternally: false } as any
+
+    const editorElement = document.createElement('div')
+    const domSelection = createDomSelection({
+      anchorNode: document.createTextNode('a'),
+      focusNode: document.createTextNode('b'),
+    })
+    const root = { activeElement: editorElement, getSelection: () => domSelection }
+
+    vi.spyOn(DomEditor, 'findDocumentOrShadowRoot').mockReturnValue(root as any)
+    vi.spyOn(DomEditor, 'toDOMNode').mockReturnValue(editorElement as any)
+
+    const hasSelectableTarget = helpers.hasSelectableTarget as unknown as vi.Mock
+    const hasTarget = helpers.hasTarget as unknown as vi.Mock
+
+    hasSelectableTarget.mockReturnValue(true)
+    hasTarget.mockReturnValue(false)
 
     const selectSpy = vi.spyOn(Transforms, 'select').mockImplementation(() => {})
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,7 @@
     "lodash.throttle": "^4.1.1",
     "lodash.toarray": "^4.4.0",
     "nanoid": "^5.0.0",
-    "slate": "^0.82.0",
+    "slate": "^0.123.0",
     "snabbdom": "^3.6.0"
   },
   "dependencies": {
@@ -64,7 +64,7 @@
     "html-void-elements": "^3.0.0",
     "i18next": "^23.0.0",
     "scroll-into-view-if-needed": "^3.0.0",
-    "slate-history": "^0.109.0"
+    "slate-history": "^0.115.0"
   },
   "devDependencies": {
     "@types/is-hotkey": "^0.1.2",

--- a/packages/core/src/editor/dom-editor.ts
+++ b/packages/core/src/editor/dom-editor.ts
@@ -43,6 +43,17 @@ import {
 } from '../utils/weak-maps'
 import type { IDomEditor } from './interface'
 
+const isBefore = (node: DOMNode, otherNode: DOMNode): boolean => {
+  // compareDocumentPosition returns bit flags; we only care about relative order.
+  // eslint-disable-next-line no-bitwise
+  return Boolean(node.compareDocumentPosition(otherNode) & DOMNode.DOCUMENT_POSITION_PRECEDING)
+}
+
+const isAfter = (node: DOMNode, otherNode: DOMNode): boolean => {
+  // eslint-disable-next-line no-bitwise
+  return Boolean(node.compareDocumentPosition(otherNode) & DOMNode.DOCUMENT_POSITION_FOLLOWING)
+}
+
 /**
  * 自定义全局 command
  */
@@ -236,6 +247,7 @@ export const DomEditor = {
         // （data-slate-zero-width、data-slate-string）判断一起出现，唯独此处欠缺，补全
         && (!editable
           || targetEl.isContentEditable
+          || targetEl.closest('[contenteditable="false"]') === editorEl
           || !!targetEl.getAttribute('data-slate-zero-width')))
       || !!targetEl.getAttribute('data-slate-string')
     )
@@ -364,7 +376,7 @@ export const DomEditor = {
     // If the drop target is inside a void node, move it into either the
     // next or previous node, depending on which side the `x` and `y`
     // coordinates are closest to.
-    if (Editor.isVoid(editor, node)) {
+    if (Element.isElement(node) && Editor.isVoid(editor, node)) {
       const rect = target.getBoundingClientRect()
       const isPrev = editor.isInline(node)
         ? x - rect.left < rect.left + rect.width - x
@@ -471,7 +483,16 @@ export const DomEditor = {
 
     const focus = isCollapsed
       ? anchor
-      : DomEditor.toSlatePoint(editor, [focusNode, focusOffset], { exactMatch, suppressThrow })
+      : DomEditor.toSlatePoint(editor, [focusNode, focusOffset], {
+        exactMatch,
+        suppressThrow,
+        searchDirection: (
+          isBefore(anchorNode as DOMNode, focusNode as DOMNode)
+          || (anchorNode === focusNode && focusOffset < anchorOffset)
+        )
+          ? 'forward'
+          : 'backward',
+      })
 
     if (!focus) {
       return null as T extends true ? Range | null : Range
@@ -506,16 +527,26 @@ export const DomEditor = {
     options: {
       exactMatch: T
       suppressThrow: T
+      searchDirection?: 'forward' | 'backward'
     },
   ): T extends true ? Point | null : Point {
     const { exactMatch, suppressThrow } = options
     const [nearestNode, nearestOffset] = exactMatch ? domPoint : normalizeDOMPoint(domPoint)
     const parentNode = nearestNode.parentNode as DOMElement
+    let searchDirection = options.searchDirection
     let textNode: DOMElement | null = null
     let offset = 0
 
     if (parentNode) {
-      const voidNode = parentNode.closest('[data-slate-void="true"]')
+      const editorEl = DomEditor.toDOMNode(editor, editor)
+      const potentialVoidNode = parentNode.closest('[data-slate-void="true"]')
+      const voidNode = potentialVoidNode && editorEl.contains(potentialVoidNode)
+        ? potentialVoidNode
+        : null
+      const potentialNonEditableNode = parentNode.closest('[contenteditable="false"]')
+      const nonEditableNode = potentialNonEditableNode && editorEl.contains(potentialNonEditableNode)
+        ? potentialNonEditableNode
+        : null
       let leafNode = parentNode.closest('[data-slate-leaf]')
       let domNode: DOMElement | null = null
 
@@ -550,7 +581,8 @@ export const DomEditor = {
       } else if (voidNode) {
         // For void nodes, the element with the offset key will be a cousin, not an
         // ancestor, so find it by going down from the nearest void parent.
-        leafNode = voidNode.querySelector('[data-slate-leaf]')!
+        leafNode = Array.from(voidNode.querySelectorAll('[data-slate-leaf]'))
+          .find(leaf => DomEditor.hasDOMNode(editor, leaf)) || null
 
         // COMPAT: In read-only editors the leaf is not rendered.
         if (!leafNode) {
@@ -562,6 +594,60 @@ export const DomEditor = {
           domNode.querySelectorAll('[data-slate-zero-width]').forEach(el => {
             offset -= el.textContent!.length
           })
+        }
+      } else if (nonEditableNode) {
+        const getLeafNodes = (node: DOMElement | null | undefined) => {
+          return node
+            ? Array.from(node.querySelectorAll('[data-slate-leaf]'))
+              .filter(leaf => DomEditor.hasDOMNode(editor, leaf))
+            : []
+        }
+        const elementNode = nonEditableNode.closest('[data-slate-node="element"]')
+
+        if (searchDirection === 'backward' || !searchDirection) {
+          const leafNodes = [
+            ...getLeafNodes(elementNode?.previousElementSibling as DOMElement | null),
+            ...getLeafNodes(elementNode),
+          ]
+
+          for (let i = leafNodes.length - 1; i >= 0; i -= 1) {
+            const currentLeaf = leafNodes[i]
+
+            if (isBefore(nonEditableNode, currentLeaf)) {
+              leafNode = currentLeaf
+              searchDirection = 'backward'
+              break
+            }
+          }
+        }
+
+        if (!leafNode && (searchDirection === 'forward' || !searchDirection)) {
+          const leafNodes = [
+            ...getLeafNodes(elementNode),
+            ...getLeafNodes(elementNode?.nextElementSibling as DOMElement | null),
+          ]
+
+          for (const currentLeaf of leafNodes) {
+            if (isAfter(nonEditableNode, currentLeaf)) {
+              leafNode = currentLeaf
+              searchDirection = 'forward'
+              break
+            }
+          }
+        }
+
+        if (leafNode) {
+          textNode = leafNode.closest('[data-slate-node="text"]')!
+          domNode = leafNode
+
+          if (searchDirection === 'forward') {
+            offset = 0
+          } else {
+            offset = domNode.textContent!.length
+            domNode.querySelectorAll('[data-slate-zero-width]').forEach(el => {
+              offset -= el.textContent!.length
+            })
+          }
         }
       }
 
@@ -594,7 +680,16 @@ export const DomEditor = {
     // the select event fires twice, once for the old editor's `element`
     // first, and then afterwards for the correct `element`. (2017/03/03)
     const slateNode = DomEditor.toSlateNode(editor, textNode!)
-    const path = DomEditor.findPath(editor, slateNode)
+    let path: Path
+
+    try {
+      path = DomEditor.findPath(editor, slateNode)
+    } catch (e) {
+      if (suppressThrow) {
+        return null as T extends true ? Point | null : Point
+      }
+      throw e
+    }
 
     return { path, offset } as T extends true ? Point | null : Point
   },

--- a/packages/core/src/editor/interface.ts
+++ b/packages/core/src/editor/interface.ts
@@ -16,6 +16,7 @@ import { IPositionStyle } from '../menus/interface'
 import { DOMElement } from '../utils/dom'
 
 export type ElementWithId = Element & { id: string }
+type MoveOptions = Parameters<Editor['move']>[0]
 
 export type getMenuConfigReturnType<K> = K extends keyof IMenuConfig ? IMenuConfig[K] : ISingleMenuConfig
 
@@ -69,7 +70,8 @@ export interface IDomEditor extends Editor {
   // selection 相关
   select: (at: Location) => void
   deselect: () => void
-  move: (distance: number, reverse?: boolean) => void
+  move(options?: MoveOptions): void
+  move(distance: number, reverse?: boolean): void
   moveReverse: (distance: number) => void
   restoreSelection: () => void
   getTableSelection?: () => NodeEntryWithContext[][] | null

--- a/packages/core/src/editor/plugins/with-content.ts
+++ b/packages/core/src/editor/plugins/with-content.ts
@@ -4,7 +4,7 @@
  */
 
 import {
-  Editor, Element, Node, Operation, Path, Range, Text, Transforms,
+  Editor, Element, Node, Operation, Path, Point, Range, Text, Transforms,
 } from 'slate'
 
 import { IDomEditor } from '../..'
@@ -56,10 +56,42 @@ function insertElemToEditor(editor: IDomEditor, elem: Element) {
   }
 }
 
+function isSelectedAll(editor: IDomEditor): boolean {
+  const { selection } = editor
+
+  if (selection == null || Range.isCollapsed(selection)) { return false }
+
+  const [start, end] = Range.edges(selection)
+  const [editorStart, editorEnd] = Editor.edges(editor, [])
+
+  return Point.equals(start, editorStart) && Point.equals(end, editorEnd)
+}
+
+function ensureEmptyParagraph(editor: IDomEditor) {
+  const firstNode = editor.children[0]
+
+  if (editor.children.length !== 1) { return }
+  if (!Element.isElement(firstNode)) { return }
+  if (firstNode.type === 'paragraph' && Node.string(firstNode) === '') { return }
+  if (Node.string(firstNode) !== '') { return }
+
+  const initialEditorValue: Node[] = [
+    {
+      type: 'paragraph',
+      children: [{ text: '' }],
+    },
+  ]
+
+  Editor.withoutNormalizing(editor, () => {
+    Transforms.removeNodes(editor, { at: [0] })
+    Transforms.insertNodes(editor, initialEditorValue, { at: [0] })
+  })
+}
+
 export const withContent = <T extends Editor>(editor: T) => {
   const e = editor as T & IDomEditor
   const {
-    onChange, insertText, apply, deleteBackward,
+    onChange, insertText, apply, deleteBackward, deleteFragment,
   } = e
 
   e.insertText = (text: string) => {
@@ -141,7 +173,7 @@ export const withContent = <T extends Editor>(editor: T) => {
 
     if (editor.selection && Range.isCollapsed(editor.selection)) {
       const parentBlockEntry = Editor.above(editor, {
-        match: n => Editor.isBlock(editor, n),
+        match: n => Element.isElement(n) && Editor.isBlock(editor, n),
         at: editor.selection,
       })
 
@@ -159,6 +191,16 @@ export const withContent = <T extends Editor>(editor: T) => {
           Transforms.delete(editor, { at: currentLineRange })
         }
       }
+    }
+  }
+
+  e.deleteFragment = options => {
+    const shouldResetToParagraph = isSelectedAll(e)
+
+    deleteFragment(options)
+
+    if (shouldResetToParagraph) {
+      ensureEmptyParagraph(e)
     }
   }
 
@@ -304,7 +346,10 @@ export const withContent = <T extends Editor>(editor: T) => {
 
     if (e.children.length === 0) {
       Transforms.insertNodes(e, initialEditorValue)
+      return
     }
+
+    ensureEmptyParagraph(e)
   }
 
   e.getParentNode = (node: Node) => {

--- a/packages/core/src/editor/plugins/with-content.ts
+++ b/packages/core/src/editor/plugins/with-content.ts
@@ -201,6 +201,12 @@ export const withContent = <T extends Editor>(editor: T) => {
 
     if (shouldResetToParagraph) {
       ensureEmptyParagraph(e)
+
+      // ensureEmptyParagraph uses withoutNormalizing to replace non-paragraph
+      // empty nodes, which can leave the selection null. Restore it to start.
+      if (e.selection == null && e.children.length > 0) {
+        Transforms.select(e, Editor.start(e, []))
+      }
     }
   }
 

--- a/packages/core/src/editor/plugins/with-selection.ts
+++ b/packages/core/src/editor/plugins/with-selection.ts
@@ -3,18 +3,25 @@
  * @author wangfupeng
  */
 
-import { Editor, Transforms, Location, Node, Range, Point } from 'slate'
-import { IDomEditor } from '../interface'
-import { DomEditor } from '../dom-editor'
+import {
+  Editor, Location, Node, Point,
+  Range,
+} from 'slate'
+
 import { getPositionByNode, getPositionBySelection } from '../../menus/helpers/position'
 import { EDITOR_TO_SELECTION } from '../../utils/weak-maps'
+import { DomEditor } from '../dom-editor'
+import { IDomEditor } from '../interface'
 
 export const withSelection = <T extends Editor>(editor: T) => {
   const e = editor as T & IDomEditor
+  const { select, deselect, move } = e
+
+  type MoveOptions = Parameters<Editor['move']>[0]
 
   // 选中
   e.select = (at: Location) => {
-    Transforms.select(e, at)
+    select(at)
   }
 
   // 取消选中
@@ -28,17 +35,22 @@ export const withSelection = <T extends Editor>(editor: T) => {
     }
 
     if (selection) {
-      Transforms.deselect(editor)
+      deselect()
     }
   }
 
   // 移动光标
-  e.move = (distance: number, reverse = false) => {
-    if (!distance) return
-    if (distance < 0) return
+  e.move = (distanceOrOptions?: number | MoveOptions, reverse = false) => {
+    if (typeof distanceOrOptions !== 'number') {
+      move(distanceOrOptions)
+      return
+    }
 
-    Transforms.move(editor, {
-      distance,
+    if (!distanceOrOptions) { return }
+    if (distanceOrOptions < 0) { return }
+
+    move({
+      distance: distanceOrOptions,
       unit: 'character',
       reverse,
     })
@@ -54,10 +66,11 @@ export const withSelection = <T extends Editor>(editor: T) => {
    */
   e.restoreSelection = () => {
     const selection = EDITOR_TO_SELECTION.get(e)
-    if (selection == null) return
+
+    if (selection == null) { return }
 
     e.focus()
-    Transforms.select(e, selection)
+    select(selection)
   }
 
   /**
@@ -79,7 +92,8 @@ export const withSelection = <T extends Editor>(editor: T) => {
    */
   e.isSelectedAll = () => {
     const { selection } = e
-    if (selection == null) return false
+
+    if (selection == null) { return false }
 
     const [start1, end1] = Range.edges(selection) // 获取当前选取的开始、结束 point
     const [start2, end2] = Editor.edges(e, []) // 获取编辑器全部的开始、结束 point
@@ -97,7 +111,7 @@ export const withSelection = <T extends Editor>(editor: T) => {
     const start = Editor.start(e, [])
     const end = Editor.end(e, [])
 
-    Transforms.select(e, {
+    select({
       anchor: start,
       focus: end,
     })

--- a/packages/core/src/render/text/renderText.tsx
+++ b/packages/core/src/render/text/renderText.tsx
@@ -3,35 +3,40 @@
  * @author wangfupeng
  */
 
-import { Text as SlateText, Ancestor } from 'slate'
-import { jsx, VNode } from 'snabbdom'
+import {
+  Ancestor, LeafPosition,
+  Text as SlateText,
+} from 'slate'
+import { VNode } from 'snabbdom'
+
 import { DomEditor } from '../../editor/dom-editor'
 import { IDomEditor } from '../../editor/interface'
-import { KEY_TO_ELEMENT, NODE_TO_ELEMENT, ELEMENT_TO_NODE } from '../../utils/weak-maps'
+import { getElementById } from '../../utils/dom'
+import { promiseResolveThen } from '../../utils/util'
+import { ELEMENT_TO_NODE, KEY_TO_ELEMENT, NODE_TO_ELEMENT } from '../../utils/weak-maps'
+import { genTextId } from '../helper'
 import genTextVnode from './genVnode'
 import addTextVnodeStyle from './renderStyle'
-import { promiseResolveThen } from '../../utils/util'
-import { genTextId } from '../helper'
-import { getElementById } from '../../utils/dom'
 
 function renderText(textNode: SlateText, parent: Ancestor, editor: IDomEditor): VNode {
-  if (textNode.text == null)
-    throw new Error(`Current node is not slate Text ${JSON.stringify(textNode)}`)
+  if (textNode.text == null) { throw new Error(`Current node is not slate Text ${JSON.stringify(textNode)}`) }
   const key = DomEditor.findKey(editor, textNode)
 
   // 根据 decorate 将 text 拆分为多个叶子节点 text[]
   const { decorate } = editor.getConfig()
-  if (decorate == null) throw new Error(`Can not get config.decorate`)
+
+  if (decorate == null) { throw new Error('Can not get config.decorate') }
   const path = DomEditor.findPath(editor, textNode)
   const ds = decorate([textNode, path])
   const leaves = SlateText.decorations(textNode, ds)
 
   // 生成 leaves vnode
-  const leavesVnode = leaves.map((leafNode, index) => {
+  const leavesVnode = leaves.map(({ leaf, position }: { leaf: SlateText; position?: LeafPosition }) => {
     // 文字和样式
-    const isLast = index === leaves.length - 1
-    let strVnode = genTextVnode(leafNode, isLast, textNode, parent, editor)
-    strVnode = addTextVnodeStyle(leafNode, strVnode)
+    const isLast = position?.isLast ?? leaves.length === 1
+    let strVnode = genTextVnode(leaf, isLast, textNode, parent, editor)
+
+    strVnode = addTextVnodeStyle(leaf, strVnode)
     // 生成每一个 leaf 节点
     return <span data-slate-leaf>{strVnode}</span>
   })
@@ -48,7 +53,8 @@ function renderText(textNode: SlateText, parent: Ancestor, editor: IDomEditor): 
   promiseResolveThen(() => {
     // 异步，否则拿不到 DOM
     const dom = getElementById(textId)
-    if (dom == null) return
+
+    if (dom == null) { return }
     KEY_TO_ELEMENT.set(key, dom)
     NODE_TO_ELEMENT.set(textNode, dom)
     ELEMENT_TO_NODE.set(dom, textNode)

--- a/packages/core/src/render/text/renderText.tsx
+++ b/packages/core/src/render/text/renderText.tsx
@@ -7,7 +7,8 @@ import {
   Ancestor, LeafPosition,
   Text as SlateText,
 } from 'slate'
-import { VNode } from 'snabbdom'
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { jsx, VNode } from 'snabbdom'
 
 import { DomEditor } from '../../editor/dom-editor'
 import { IDomEditor } from '../../editor/interface'

--- a/packages/core/src/text-area/TextArea.ts
+++ b/packages/core/src/text-area/TextArea.ts
@@ -10,7 +10,9 @@ import { Range } from 'slate'
 import { EditorEvents } from '../config/interface'
 import { DomEditor } from '../editor/dom-editor'
 import { IDomEditor } from '../editor/interface'
-import $, { Dom7Array, DOMElement } from '../utils/dom'
+import $, {
+  Dom7Array, DOMElement, isDOMElement,
+} from '../utils/dom'
 import { promiseResolveThen } from '../utils/util'
 import { TEXTAREA_TO_EDITOR } from '../utils/weak-maps'
 import eventHandlerConf from './event-handlers/index'
@@ -21,6 +23,8 @@ import updateView from './update-view'
 let ID = 1
 
 class TextArea {
+  private selectionChangeRoot: Document | ShadowRoot | null = null
+
   // eslint-disable-next-line
   readonly id = ID++
 
@@ -72,14 +76,8 @@ class TextArea {
     // 异步，否则获取不到 editor 和 DOM
     promiseResolveThen(() => {
       const editor = this.editorInstance
-      const window = DomEditor.getWindow(editor)
 
-      // 监听 selection change
-      window.document.addEventListener('selectionchange', this.onDOMSelectionChange)
-      // editor 销毁时，解绑 selection change
-      editor.on(EditorEvents.DESTROYED, () => {
-        window.document.removeEventListener('selectionchange', this.onDOMSelectionChange)
-      })
+      this.bindSelectionChange(editor)
 
       // 点击编辑区域，关闭 panel
       $container.on('click', () => editor.hidePanelOrModal())
@@ -117,11 +115,44 @@ class TextArea {
     return editor
   }
 
-  private onDOMSelectionChange = throttle(() => {
+  private bindSelectionChange(editor: IDomEditor, retries = 5) {
+    if (this.selectionChangeRoot != null || editor.isDestroyed) { return }
+
+    try {
+      const root = DomEditor.findDocumentOrShadowRoot(editor)
+
+      root.addEventListener('selectionchange', this.onDOMSelectionChange)
+      this.selectionChangeRoot = root
+    } catch (ex) {
+      if (retries > 0) {
+        setTimeout(() => this.bindSelectionChange(editor, retries - 1), 0)
+        return
+      }
+
+      window.document.addEventListener('selectionchange', this.onDOMSelectionChange)
+      this.selectionChangeRoot = window.document
+    }
+
+    editor.on(EditorEvents.DESTROYED, () => {
+      this.selectionChangeRoot?.removeEventListener('selectionchange', this.onDOMSelectionChange)
+      this.selectionChangeRoot = null
+    })
+  }
+
+  private onDOMSelectionChange = throttle((event?: Event) => {
+    const targetElement = isDOMElement(event?.target) ? event.target : null
+    const targetTagName = targetElement?.tagName
+
+    if (targetTagName === 'INPUT' || targetTagName === 'TEXTAREA') { return }
+
     const editor = this.editorInstance
 
     DOMSelectionToEditor(this, editor)
   }, 100)
+
+  flushDOMSelectionChange() {
+    this.onDOMSelectionChange.flush()
+  }
 
   /**
    * 绑定事件，如 beforeinput onblur onfocus keydown click copy/paste drag/drop 等

--- a/packages/core/src/text-area/event-handlers/beforeInput.ts
+++ b/packages/core/src/text-area/event-handlers/beforeInput.ts
@@ -9,7 +9,10 @@ import { DomEditor } from '../../editor/dom-editor'
 import { IDomEditor } from '../../editor/interface'
 import { DOMStaticRange, isDataTransfer } from '../../utils/dom'
 import { HAS_BEFORE_INPUT_SUPPORT } from '../../utils/ua'
-import { EDITOR_TO_CAN_PASTE } from '../../utils/weak-maps'
+import {
+  EDITOR_TO_CAN_PASTE,
+  EDITOR_TO_PENDING_COMPOSITION_END,
+} from '../../utils/weak-maps'
 import { hasEditableTarget } from '../helpers'
 import TextArea from '../TextArea'
 
@@ -29,6 +32,9 @@ function handleBeforeInput(e: Event, textarea: TextArea, editor: IDomEditor) {
   if (!HAS_BEFORE_INPUT_SUPPORT) { return } // 有些浏览器完全不支持 beforeInput ，会用 keypress 和 keydown 兼容
   if (readOnly) { return }
   if (!hasEditableTarget(editor, event.target)) { return }
+
+  // 一些输入法和浏览器扩展会先改 DOM 选区，再触发 beforeinput
+  textarea.flushDOMSelectionChange?.()
 
   const { selection } = editor
   const { inputType: type } = event
@@ -144,10 +150,16 @@ function handleBeforeInput(e: Event, textarea: TextArea, editor: IDomEditor) {
     }
 
     case 'insertFromDrop':
+    case 'insertFromComposition':
     case 'insertFromPaste':
     case 'insertFromYank':
     case 'insertReplacementText':
     case 'insertText': {
+      if (type === 'insertFromComposition') {
+        textarea.isComposing = false
+        EDITOR_TO_PENDING_COMPOSITION_END.set(editor, true)
+      }
+
       if (type === 'insertFromPaste') {
         if (!EDITOR_TO_CAN_PASTE.get(editor)) { break } // 不可默认粘贴
       }

--- a/packages/core/src/text-area/event-handlers/composition.ts
+++ b/packages/core/src/text-area/event-handlers/composition.ts
@@ -4,13 +4,17 @@
  */
 
 import {
-  Editor, Element, Range, Text,
+  Editor, Element, Range, Text, Transforms,
 } from 'slate'
 
 import { DomEditor } from '../../editor/dom-editor'
 import { IDomEditor } from '../../editor/interface'
 import { DOMNode } from '../../utils/dom'
 import { IS_CHROME, IS_FIREFOX, IS_SAFARI } from '../../utils/ua'
+import {
+  EDITOR_TO_PENDING_COMPOSITION_END,
+  EDITOR_TO_PENDING_SELECTION,
+} from '../../utils/weak-maps'
 import { hasEditableTarget } from '../helpers'
 import { hidePlaceholder } from '../place-holder'
 import { editorSelectionToDOM } from '../syncSelection'
@@ -54,6 +58,7 @@ export function handleCompositionStart(e: Event, textarea: TextArea, editor: IDo
   const event = e as CompositionEvent
 
   if (!hasEditableTarget(editor, event.target)) { return }
+  EDITOR_TO_PENDING_SELECTION.delete(editor)
 
   const { selection } = editor
 
@@ -109,6 +114,23 @@ export function handleCompositionEnd(e: Event, textarea: TextArea, editor: IDomE
 
   if (!hasEditableTarget(editor, event.target)) { return }
   textarea.isComposing = false
+  const shouldSkipInsertion = EDITOR_TO_PENDING_COMPOSITION_END.get(editor) === true
+
+  if (shouldSkipInsertion) {
+    EDITOR_TO_PENDING_COMPOSITION_END.delete(editor)
+    EDITOR_TO_PENDING_SELECTION.delete(editor)
+  } else {
+    const pendingSelection = EDITOR_TO_PENDING_SELECTION.get(editor)
+
+    EDITOR_TO_PENDING_SELECTION.delete(editor)
+
+    if (
+      pendingSelection
+      && (!editor.selection || !Range.equals(editor.selection, pendingSelection))
+    ) {
+      Transforms.select(editor, pendingSelection)
+    }
+  }
 
   const { selection } = editor
 
@@ -141,6 +163,7 @@ export function handleCompositionEnd(e: Event, textarea: TextArea, editor: IDomE
   const { data } = event
 
   if (!data) { return }
+  if (shouldSkipInsertion) { return }
 
   // 检查 maxLength -【注意】这里只处理拼音输入的 maxLength 限制。其他限制，在插件 with-max-length.ts 中处理
   const { maxLength } = editor.getConfig()

--- a/packages/core/src/text-area/event-handlers/cut.ts
+++ b/packages/core/src/text-area/event-handlers/cut.ts
@@ -4,7 +4,7 @@
  */
 
 import {
-  Editor, Node, Range, Transforms,
+  Editor, Element, Node, Range, Transforms,
 } from 'slate'
 
 import { IDomEditor } from '../../editor/interface'
@@ -31,7 +31,7 @@ function handleOnCut(e: Event, textarea: TextArea, editor: IDomEditor) {
     } else {
       const node = Node.parent(editor, selection.anchor.path)
 
-      if (Editor.isVoid(editor, node)) {
+      if (Element.isElement(node) && Editor.isVoid(editor, node)) {
         Transforms.delete(editor)
       }
     }

--- a/packages/core/src/text-area/event-handlers/drag.ts
+++ b/packages/core/src/text-area/event-handlers/drag.ts
@@ -3,7 +3,7 @@
  * @author wangfupeng
  */
 
-import { Editor, Transforms } from 'slate'
+import { Editor, Element, Transforms } from 'slate'
 
 import { DomEditor } from '../../editor/dom-editor'
 import { IDomEditor } from '../../editor/interface'
@@ -21,7 +21,8 @@ export function handleOnDragstart(e: Event, textarea: TextArea, editor: IDomEdit
 
   const node = DomEditor.toSlateNode(editor, event.target)
   const path = DomEditor.findPath(editor, node)
-  const voidMatch = Editor.isVoid(editor, node) || Editor.void(editor, { at: path, voids: true })
+  const voidMatch = (Element.isElement(node) && Editor.isVoid(editor, node))
+    || Editor.void(editor, { at: path, voids: true })
 
   // If starting a drag on a void node, make sure it is selected
   // so that it shows up in the selection's fragment.
@@ -52,7 +53,7 @@ export function handleOnDragover(event: Event, textarea: TextArea, editor: IDomE
   // default, and calling `preventDefault` hides the cursor.
   const node = DomEditor.toSlateNode(editor, event.target)
 
-  if (Editor.isVoid(editor, node)) {
+  if (Element.isElement(node) && Editor.isVoid(editor, node)) {
     event.preventDefault()
   }
 }

--- a/packages/core/src/text-area/helpers.ts
+++ b/packages/core/src/text-area/helpers.ts
@@ -3,24 +3,25 @@
  * @author wangfupeng
  */
 
-import { Editor } from 'slate'
-import { DOMRange, DOMNode, isDOMNode } from '../utils/dom'
-import { IDomEditor } from '../editor/interface'
+import { Editor, Element } from 'slate'
+
 import { DomEditor } from '../editor/dom-editor'
+import { IDomEditor } from '../editor/interface'
+import { DOMNode, DOMRange, isDOMNode } from '../utils/dom'
 
 /**
  * Check if two DOM range objects are equal.
  */
 export const isRangeEqual = (a: DOMRange, b: DOMRange) => {
   return (
-    (a.startContainer === b.startContainer &&
-      a.startOffset === b.startOffset &&
-      a.endContainer === b.endContainer &&
-      a.endOffset === b.endOffset) ||
-    (a.startContainer === b.endContainer &&
-      a.startOffset === b.endOffset &&
-      a.endContainer === b.startContainer &&
-      a.endOffset === b.startOffset)
+    (a.startContainer === b.startContainer
+      && a.startOffset === b.startOffset
+      && a.endContainer === b.endContainer
+      && a.endOffset === b.endOffset)
+    || (a.startContainer === b.endContainer
+      && a.startOffset === b.endOffset
+      && a.endContainer === b.startContainer
+      && a.endOffset === b.startOffset)
   )
 }
 
@@ -29,23 +30,9 @@ export const isRangeEqual = (a: DOMRange, b: DOMRange) => {
  */
 export function hasEditableTarget(
   editor: IDomEditor,
-  target: EventTarget | null
+  target: EventTarget | null,
 ): target is DOMNode {
   return isDOMNode(target) && DomEditor.hasDOMNode(editor, target, { editable: true })
-}
-
-/**
- * Check if the target is inside void and in an non-readonly editor.
- */
-export function isTargetInsideNonReadonlyVoid(
-  editor: IDomEditor,
-  target: EventTarget | null
-): boolean {
-  const { readOnly } = editor.getConfig()
-  if (readOnly) return false
-
-  const slateNode = hasTarget(editor, target) && DomEditor.toSlateNode(editor, target)
-  return Editor.isVoid(editor, slateNode)
 }
 
 /**
@@ -53,6 +40,29 @@ export function isTargetInsideNonReadonlyVoid(
  */
 export function hasTarget(editor: IDomEditor, target: EventTarget | null): target is DOMNode {
   return isDOMNode(target) && DomEditor.hasDOMNode(editor, target)
+}
+
+/**
+ * Check if the target is inside void and in an non-readonly editor.
+ */
+export function isTargetInsideNonReadonlyVoid(
+  editor: IDomEditor,
+  target: EventTarget | null,
+): boolean {
+  const { readOnly } = editor.getConfig()
+
+  if (readOnly) { return false }
+
+  const slateNode = hasTarget(editor, target) && DomEditor.toSlateNode(editor, target)
+
+  return !!slateNode && Element.isElement(slateNode) && Editor.isVoid(editor, slateNode)
+}
+
+/**
+ * Check if the target can participate in editor selection.
+ */
+export function hasSelectableTarget(editor: IDomEditor, target: EventTarget | null): boolean {
+  return hasEditableTarget(editor, target) || isTargetInsideNonReadonlyVoid(editor, target)
 }
 
 /**

--- a/packages/core/src/text-area/syncSelection.ts
+++ b/packages/core/src/text-area/syncSelection.ts
@@ -10,8 +10,12 @@ import { DomEditor } from '../editor/dom-editor'
 import { IDomEditor } from '../editor/interface'
 import { DOMElement } from '../utils/dom'
 import { IS_FIREFOX } from '../utils/ua'
-import { EDITOR_TO_ELEMENT, IS_FOCUSED } from '../utils/weak-maps'
-import { hasEditableTarget, isTargetInsideNonReadonlyVoid } from './helpers'
+import {
+  EDITOR_TO_ELEMENT,
+  EDITOR_TO_PENDING_SELECTION,
+  IS_FOCUSED,
+} from '../utils/weak-maps'
+import { hasSelectableTarget, hasTarget } from './helpers'
 import TextArea from './TextArea'
 
 /**
@@ -172,8 +176,6 @@ export function DOMSelectionToEditor(textarea: TextArea, editor: IDomEditor) {
   const { isComposing, isUpdatingSelection, isDraggingInternally } = textarea
   const config = editor.getConfig()
 
-  if (config.readOnly) { return }
-  if (isComposing) { return }
   if (isUpdatingSelection) { return }
   if (isDraggingInternally) { return }
 
@@ -197,16 +199,33 @@ export function DOMSelectionToEditor(textarea: TextArea, editor: IDomEditor) {
 
   const { anchorNode, focusNode } = domSelection
 
-  const anchorNodeSelectable = hasEditableTarget(editor, anchorNode) || isTargetInsideNonReadonlyVoid(editor, anchorNode)
-  const focusNodeSelectable = hasEditableTarget(editor, focusNode) || isTargetInsideNonReadonlyVoid(editor, focusNode)
+  const anchorNodeSelectable = hasSelectableTarget(editor, anchorNode)
+  const focusNodeInEditor = hasTarget(editor, focusNode)
 
-  if (anchorNodeSelectable && focusNodeSelectable) {
+  if (isComposing) {
+    if (anchorNodeSelectable && focusNodeInEditor) {
+      const range = DomEditor.toSlateRange(editor, domSelection, {
+        exactMatch: false,
+        suppressThrow: true,
+      })
+
+      EDITOR_TO_PENDING_SELECTION.set(editor, range)
+    }
+
+    return
+  }
+
+  if (anchorNodeSelectable && focusNodeInEditor) {
     const range = DomEditor.toSlateRange(editor, domSelection, {
       exactMatch: false,
-      suppressThrow: false,
+      suppressThrow: true,
     })
 
-    Transforms.select(editor, range)
+    if (range) {
+      Transforms.select(editor, range)
+    }
+  } else if (config.readOnly) {
+    Transforms.deselect(editor)
   } else {
     // 禁用此行，让光标选区继续生效
     // Transforms.deselect(editor)

--- a/packages/core/src/utils/weak-maps.ts
+++ b/packages/core/src/utils/weak-maps.ts
@@ -84,3 +84,9 @@ export const EDITOR_TO_EMITTER: WeakMap<Editor, Emitter> = new WeakMap()
 
 // editor 是否可执行粘贴
 export const EDITOR_TO_CAN_PASTE: WeakMap<Editor, boolean> = new WeakMap()
+
+// beforeinput 已处理 composition 提交，compositionend 需跳过重复插入
+export const EDITOR_TO_PENDING_COMPOSITION_END: WeakMap<Editor, boolean> = new WeakMap()
+
+// composing 期间暂存用户选区，composition 提交后再决定是否应用
+export const EDITOR_TO_PENDING_SELECTION: WeakMap<Editor, Range | null> = new WeakMap()

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -71,7 +71,7 @@
     "lodash.throttle": "^4.1.1",
     "lodash.toarray": "^4.4.0",
     "nanoid": "^5.0.0",
-    "slate": "^0.82.0",
+    "slate": "^0.123.0",
     "snabbdom": "^3.6.0"
   },
   "devDependencies": {

--- a/packages/list-module/__tests__/plugin.test.ts
+++ b/packages/list-module/__tests__/plugin.test.ts
@@ -69,7 +69,7 @@ describe('list plugin test', () => {
     editor.handleTab() // tab
     const children = editor.children
 
-    expect(children).toEqual([{ children: [{ text: '    ' }], type: 'list-item' }])
+    expect(children).toEqual([{ children: [{ text: '    ' }], type: 'paragraph' }])
   })
 
   it('insert tab - select all and multi list', () => {

--- a/packages/list-module/package.json
+++ b/packages/list-module/package.json
@@ -46,7 +46,7 @@
   "peerDependencies": {
     "@wangeditor-next/core": "1.7.46",
     "dom7": "^3.0.0 || ^4.0.0",
-    "slate": "^0.82.0",
+    "slate": "^0.123.0",
     "snabbdom": "^3.6.0"
   },
   "devDependencies": {

--- a/packages/plugin-float-image/package.json
+++ b/packages/plugin-float-image/package.json
@@ -43,7 +43,7 @@
   "peerDependencies": {
     "@wangeditor-next/editor": "5.6.50",
     "dom7": "^3.0.0 || ^4.0.0",
-    "slate": "^0.82.0",
+    "slate": "^0.123.0",
     "snabbdom": "^3.6.0"
   },
   "devDependencies": {

--- a/packages/plugin-link-card/package.json
+++ b/packages/plugin-link-card/package.json
@@ -43,7 +43,7 @@
   "peerDependencies": {
     "@wangeditor-next/editor": "5.6.50",
     "dom7": "^3.0.0 || ^4.0.0",
-    "slate": "^0.82.0",
+    "slate": "^0.123.0",
     "snabbdom": "^3.6.0"
   },
   "devDependencies": {

--- a/packages/plugin-markdown/package.json
+++ b/packages/plugin-markdown/package.json
@@ -43,7 +43,7 @@
   "peerDependencies": {
     "@wangeditor-next/editor": "5.6.50",
     "dom7": "^3.0.0 || ^4.0.0",
-    "slate": "^0.82.0",
+    "slate": "^0.123.0",
     "snabbdom": "^3.6.0"
   },
   "devDependencies": {

--- a/packages/plugin-markdown/src/module/plugin.ts
+++ b/packages/plugin-markdown/src/module/plugin.ts
@@ -48,7 +48,7 @@ function getBeforeText(editor: IDomEditor): { beforeText: string; range: SlateRa
   const { anchor } = selection
   // 找到当前文本上面的 block 元素，如 header1 paragraph
   const block = SlateEditor.above(editor, {
-    match: n => SlateEditor.isBlock(editor, n),
+    match: n => SlateElement.isElement(n) && SlateEditor.isBlock(editor, n),
   })
 
   if (block == null) {
@@ -105,7 +105,7 @@ function withMarkdown<T extends IDomEditor>(editor: T) {
     }
 
     SlateTransforms.setNodes<SlateElement>(editor, props, {
-      match: n => SlateEditor.isBlock(editor, n),
+      match: n => SlateElement.isElement(n) && SlateEditor.isBlock(editor, n),
     })
 
     // 如果是 list-item ，则包裹一层 bulleted-list
@@ -210,7 +210,7 @@ function withMarkdown<T extends IDomEditor>(editor: T) {
     }
 
     SlateTransforms.setNodes<SlateElement>(editor, props, {
-      match: n => SlateEditor.isBlock(editor, n),
+      match: n => SlateElement.isElement(n) && SlateEditor.isBlock(editor, n),
     })
   }
 

--- a/packages/table-module/package.json
+++ b/packages/table-module/package.json
@@ -49,7 +49,7 @@
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",
     "nanoid": "^5.0.0",
-    "slate": "^0.82.0",
+    "slate": "^0.123.0",
     "snabbdom": "^3.6.0"
   },
   "devDependencies": {

--- a/packages/upload-image-module/package.json
+++ b/packages/upload-image-module/package.json
@@ -50,7 +50,7 @@
     "@wangeditor-next/core": "1.7.46",
     "dom7": "^3.0.0 || ^4.0.0",
     "lodash.foreach": "^4.5.0",
-    "slate": "^0.82.0",
+    "slate": "^0.123.0",
     "snabbdom": "^3.6.0"
   },
   "devDependencies": {

--- a/packages/video-module/package.json
+++ b/packages/video-module/package.json
@@ -49,7 +49,7 @@
     "@wangeditor-next/core": "1.7.46",
     "dom7": "^3.0.0 || ^4.0.0",
     "nanoid": "^5.0.0",
-    "slate": "^0.82.0",
+    "slate": "^0.123.0",
     "snabbdom": "^3.6.0"
   },
   "devDependencies": {

--- a/packages/yjs-for-react/package.json
+++ b/packages/yjs-for-react/package.json
@@ -62,7 +62,7 @@
     "@wangeditor-next/editor": "5.6.50",
     "@wangeditor-next/yjs": "^0.1.44",
     "react": ">=17.0.2",
-    "slate": "^0.82.0",
+    "slate": "^0.123.0",
     "yjs": "^13.5.29"
   }
 }

--- a/packages/yjs-for-vue/package.json
+++ b/packages/yjs-for-vue/package.json
@@ -60,7 +60,7 @@
     "@wangeditor-next/editor": "5.6.50",
     "@wangeditor-next/yjs": "^0.1.44",
     "vue": ">=3.5.18",
-    "slate": "^0.82.0",
+    "slate": "^0.123.0",
     "yjs": "^13.5.29"
   }
 }

--- a/packages/yjs/package.json
+++ b/packages/yjs/package.json
@@ -49,7 +49,7 @@
   },
   "peerDependencies": {
     "@wangeditor-next/core": "1.7.46",
-    "slate": "^0.82.0",
+    "slate": "^0.123.0",
     "yjs": "^13.5.29"
   },
   "bugs": {
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@wangeditor-next-shared/rollup-config": "workspace:^",
-    "slate": "^0.82.0",
+    "slate": "^0.123.0",
     "typescript": "^5.0.0",
     "yjs": "^13.5.29"
   }

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -36,23 +36,12 @@ const waitForMenuEnabled = async (page: Page, menuKey: string) => {
 
 const pasteText = async (page: Page, text: string) => {
   await clearEditor(page)
-  const editable = getEditable(page)
-
-  await editable.evaluate(
-    (node: HTMLElement, value: string) => {
-      const data = new DataTransfer()
-
-      data.setData('text/plain', value)
-      const event = new ClipboardEvent('paste', {
-        clipboardData: data,
-        bubbles: true,
-        cancelable: true,
-      })
-
-      node.dispatchEvent(event)
-    },
-    text,
-  )
+  await page.context().grantPermissions(['clipboard-read', 'clipboard-write'])
+  await page.evaluate(async value => {
+    await navigator.clipboard.writeText(value)
+  }, text)
+  await focusEditor(page)
+  await page.keyboard.press('Control+V')
 }
 
 const dropImage = async (page: Page) => {


### PR DESCRIPTION
## Changes Overview
- Upgrade the workspace Slate dependency line to `slate@^0.123.0` and `slate-history@^0.115.0`.
- Realign wangEditor's local DOM bridge, selection sync, `beforeinput`, and composition handling with current Slate behavior.
- Fix follow-up regressions in full-document delete normalization, list flows, paste, image upload/drag-drop, and code-block E2E coverage.
- Add an audit document and changeset for the upgrade track.

## Implementation Approach
- Port the highest-value behavior from upstream `slate-dom` / `slate-react` into `packages/core` instead of adding them as runtime dependencies.
- Update `dom-editor`, `syncSelection`, `TextArea`, `beforeInput`, and `composition` to better match upstream selection and IME handling.
- Adapt the render pipeline and editor method wrappers to Slate 0.123 APIs.
- Tighten dependent module code where Slate now requires `Element` guards for `Editor.isVoid` / `Editor.isBlock`.
- Normalize full-document delete back to an empty paragraph so toolbar state and block-type behavior stay stable after `Ctrl+A` + delete.

## Testing Done
- `pnpm build`
- `pnpm test`
- `pnpm e2e`
- Focused validation while iterating:
  - `pnpm --filter @wangeditor-next/core test`
  - `pnpm --filter @wangeditor-next/basic-modules test -- __tests__/color/color-menus.test.ts __tests__/emotion/emotion-menu.test.ts __tests__/font-size-family/menu/font-size-menu.test.ts __tests__/font-size-family/menu/font-family-menu.test.ts __tests__/image/helper.test.ts __tests__/justify/menus.test.ts __tests__/text-style/menu/menus.test.ts`
  - `pnpm --filter @wangeditor-next/plugin-markdown exec vitest run __tests__/module.test.ts __tests__/plugin.test.ts`

## Verification Steps
1. Check the three commits independently:
   - `fix(core): align slate integration with 0.123`
   - `fix(workspace): update slate consumers and e2e flows`
   - `docs(core): add slate upgrade audit`
2. Run `pnpm build`, `pnpm test`, and `pnpm e2e` on Node `22.13.0`.
3. Open `packages/editor/examples/default-mode.html` and verify list, image upload/drag-drop, paste, code block, and table flows.
4. Review [docs/slate-upgrade-audit.md](docs/slate-upgrade-audit.md) for the upstream mapping and remaining manual validation scope.

## Additional Notes
- The branch includes explicit regression coverage for stale DOM mapping, non-editable targets, composing-time pending selection, and full-document delete normalization.
- Manual browser verification is still recommended for Chinese IME, ShadowRoot hosts, and Android/WebView scenarios.

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
- #12
- #254
- #298
- #409
- #614
- #714
- #733
- #750


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed full-document delete normalization, selection syncing across Document/ShadowRoot, drag/drop and void-node edge cases, and regressions affecting lists, paste, images, and code blocks.
  * Improved IME/composition handling to avoid duplicate inserts and preserve pending selections.

* **New Features**
  * Upgraded Slate and related editor internals for more robust selection, movement, and public editor commands (including deselect/move/delete behaviors).
  * Added pending composition/selection state tracking for more reliable IME behavior.

* **Documentation**
  * Added a comprehensive Slate upgrade audit and migration guidance.

* **Tests**
  * New and updated unit and E2E tests, including real-clipboard paste in E2E suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->