### PR TITLE
fix(core): reset editor after full delete

### DIFF
--- a/.changeset/funny-buses-peel.md
+++ b/.changeset/funny-buses-peel.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/core': patch
+---
+
+Fix full-document delete so clearing a code block resets the editor to a single empty paragraph and shows the placeholder immediately.

--- a/packages/basic-modules/__tests__/code-block/plugin.test.ts
+++ b/packages/basic-modules/__tests__/code-block/plugin.test.ts
@@ -162,4 +162,19 @@ describe('code-block plugin', () => {
 
     expect(preList.length).toBe(0)
   })
+
+  it('deleteFragment resets a full-document code block selection to an empty paragraph', () => {
+    editor = withCodeBlock(createEditor({
+      content: [{ type: 'pre', children: [{ type: 'code', children: [{ text: 'const a = 1' }], language: '' }] }],
+    }))
+
+    editor.select([])
+    editor.deleteFragment()
+
+    expect(editor.children).toEqual([{ type: 'paragraph', children: [{ text: '' }] }])
+    expect(editor.selection).toEqual({
+      anchor: { path: [0, 0], offset: 0 },
+      focus: { path: [0, 0], offset: 0 },
+    })
+  })
 })

--- a/packages/core/src/editor/plugins/with-content.ts
+++ b/packages/core/src/editor/plugins/with-content.ts
@@ -88,6 +88,23 @@ function ensureEmptyParagraph(editor: IDomEditor) {
   })
 }
 
+function resetToEmptyParagraph(editor: IDomEditor) {
+  const initialEditorValue: Node[] = [
+    {
+      type: 'paragraph',
+      children: [{ text: '' }],
+    },
+  ]
+
+  Editor.withoutNormalizing(editor, () => {
+    for (let i = editor.children.length - 1; i >= 0; i -= 1) {
+      Transforms.removeNodes(editor, { at: [i] })
+    }
+
+    Transforms.insertNodes(editor, initialEditorValue, { at: [0] })
+  })
+}
+
 export const withContent = <T extends Editor>(editor: T) => {
   const e = editor as T & IDomEditor
   const {
@@ -200,11 +217,9 @@ export const withContent = <T extends Editor>(editor: T) => {
     deleteFragment(options)
 
     if (shouldResetToParagraph) {
-      ensureEmptyParagraph(e)
+      resetToEmptyParagraph(e)
 
-      // ensureEmptyParagraph uses withoutNormalizing to replace non-paragraph
-      // empty nodes, which can leave the selection null. Restore it to start.
-      if (e.selection == null && e.children.length > 0) {
+      if (e.children.length > 0) {
         Transforms.select(e, Editor.start(e, []))
       }
     }


### PR DESCRIPTION
## Summary\n- reset full-document delete to a single empty paragraph\n- fix code-block clearing so the placeholder appears immediately\n- add a regression test and changeset\n\n## Testing\n- pnpm vitest run packages/basic-modules/__tests__/code-block/plugin.test.ts\n- pnpm vitest run packages/core/__tests__/editor/plugins/with-content.test.ts -t "deleteFragment resets a full-document selection to an empty paragraph|clear"\n\nCloses #769

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed code block deletion behavior when the entire document consists of a code block. The editor now properly resets to a single empty paragraph and displays the placeholder text immediately.
* Improved selection positioning during code block operations to ensure consistent editor state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->