### PR TITLE
fix(core): upload files one by one by default

### DIFF
--- a/.changeset/green-impalas-serve.md
+++ b/.changeset/green-impalas-serve.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/core': patch
+---
+
+Fix default multi-file uploads to send one request per file and trigger success callbacks for every uploaded file.

--- a/packages/core/__tests__/upload/uploader.test.ts
+++ b/packages/core/__tests__/upload/uploader.test.ts
@@ -89,6 +89,48 @@ describe('uploader', () => {
     })
   })
 
+  test('it should invoke success callback for each file when uploading multiple files', () => {
+    nock(server)
+      .defaultReplyHeaders({
+        'access-control-allow-method': 'POST',
+        'access-control-allow-origin': '*',
+      })
+      .options('/')
+      .times(2)
+      .reply(200, {})
+      .post('/')
+      .times(2)
+      .reply(200, {})
+
+    const fn = vi.fn()
+    const uppy = createUploader({
+      server,
+      fieldName: 'file1',
+      metaWithUrl: false,
+      onSuccess: fn,
+      onFailed: (_file, _res) => { return undefined },
+      onError: (_file, _err, _res) => { return undefined },
+    })
+
+    uppy.addFile({
+      source: 'vi',
+      name: 'foo.jpg',
+      type: 'image/jpeg',
+      data: new Blob([Buffer.alloc(8192)]),
+    })
+    uppy.addFile({
+      source: 'vi',
+      name: 'bar.jpg',
+      type: 'image/jpeg',
+      data: new Blob([Buffer.alloc(8192)]),
+    })
+
+    return uppy.upload().then(() => {
+      expect(fn).toHaveBeenCalledTimes(2)
+      expect(fn.mock.calls.map(([file]) => file.name)).toEqual(['foo.jpg', 'bar.jpg'])
+    })
+  })
+
   test('it should invoke error callback if file be uploaded error', () => {
     nock(server)
       .defaultReplyHeaders({

--- a/packages/core/src/upload/createUploader.ts
+++ b/packages/core/src/upload/createUploader.ts
@@ -62,17 +62,14 @@ function createUploader(config: IUploadConfig): Uppy {
     headers,
     formData: true,
     fieldName,
-    bundle: true,
+    bundle: false,
     withCredentials,
     timeout,
     ...config.xhrConfig, // 支持传入更多 XHRUpload 配置项
   })
 
   // 各个 callback
-  // onSuccess 每个 file 上传成功都会触发，改用 complete 便于 files 上传
-  uppy.on('complete', result => {
-    const file = result.successful[0]
-    const { response } = file
+  uppy.on('upload-success', (file, response) => {
     const { body = {} } = response ?? {}
 
     try {


### PR DESCRIPTION
## Summary\n- disable bundled XHR uploads by default\n- fire upload success callbacks once per uploaded file\n- add a regression test for multi-file uploads and a changeset\n\n## Testing\n- pnpm vitest run packages/core/__tests__/upload/uploader.test.ts\n- pnpm vitest run packages/upload-image-module/__tests__/upload-files.test.ts\n\nCloses #743

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed multi-file uploads to send individual requests for each file instead of bundling them together.
  * Success callbacks now trigger for every uploaded file, providing proper confirmation for each item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->