### PR TITLE
fix(core): align IME selection handling with Slate

### DIFF
--- a/.changeset/fresh-cups-march.md
+++ b/.changeset/fresh-cups-march.md
@@ -1,0 +1,6 @@
+---
+'@wangeditor-next/core': patch
+'@wangeditor-next/editor': patch
+---
+
+Fix IME selection handling so composition does not restore stale selections on commit.

--- a/packages/core/__tests__/text-area/event-handlers/composition.test.ts
+++ b/packages/core/__tests__/text-area/event-handlers/composition.test.ts
@@ -140,7 +140,7 @@ describe('composition handlers', () => {
     expect(EDITOR_TO_PENDING_COMPOSITION_END.has(editor)).toBe(false)
   })
 
-  it('applies pending selection before inserting committed composition text', () => {
+  it('does not restore pending selection before inserting committed composition text', () => {
     const paragraph = { type: 'paragraph', children: [{ text: 'x' }] }
     const pendingSelection = {
       anchor: { path: [0, 0], offset: 1 },
@@ -170,7 +170,7 @@ describe('composition handlers', () => {
 
     handleCompositionEnd(event, textarea, editor)
 
-    expect(selectSpy).toHaveBeenCalledWith(editor, pendingSelection)
+    expect(selectSpy).not.toHaveBeenCalled()
     expect(Editor.insertText).toHaveBeenCalledWith(editor, '拼')
     expect(EDITOR_TO_PENDING_SELECTION.has(editor)).toBe(false)
   })

--- a/packages/core/__tests__/text-area/syncSelection.test.ts
+++ b/packages/core/__tests__/text-area/syncSelection.test.ts
@@ -411,7 +411,7 @@ describe('DOMSelectionToEditor', () => {
     expect(Range.isCollapsed(range)).toBe(false)
   })
 
-  it('stores a pending selection instead of selecting while composing', () => {
+  it('skips selection updates while composing', () => {
     const editor = { getConfig: () => ({ readOnly: false }) } as any
     const textarea = { isComposing: true, isUpdatingSelection: false, isDraggingInternally: false } as any
 
@@ -438,7 +438,7 @@ describe('DOMSelectionToEditor', () => {
     DOMSelectionToEditor(textarea, editor)
 
     expect(selectSpy).not.toHaveBeenCalled()
-    expect(EDITOR_TO_PENDING_SELECTION.get(editor)).toEqual(range)
+    expect(EDITOR_TO_PENDING_SELECTION.has(editor)).toBe(false)
   })
 
   it('skips selection when slate range cannot be resolved during selectionchange', () => {

--- a/packages/core/src/text-area/event-handlers/composition.ts
+++ b/packages/core/src/text-area/event-handlers/composition.ts
@@ -4,7 +4,7 @@
  */
 
 import {
-  Editor, Element, Range, Text, Transforms,
+  Editor, Element, Range, Text,
 } from 'slate'
 
 import { DomEditor } from '../../editor/dom-editor'
@@ -120,16 +120,7 @@ export function handleCompositionEnd(e: Event, textarea: TextArea, editor: IDomE
     EDITOR_TO_PENDING_COMPOSITION_END.delete(editor)
     EDITOR_TO_PENDING_SELECTION.delete(editor)
   } else {
-    const pendingSelection = EDITOR_TO_PENDING_SELECTION.get(editor)
-
     EDITOR_TO_PENDING_SELECTION.delete(editor)
-
-    if (
-      pendingSelection
-      && (!editor.selection || !Range.equals(editor.selection, pendingSelection))
-    ) {
-      Transforms.select(editor, pendingSelection)
-    }
   }
 
   const { selection } = editor

--- a/packages/core/src/text-area/syncSelection.ts
+++ b/packages/core/src/text-area/syncSelection.ts
@@ -12,7 +12,6 @@ import { DOMElement } from '../utils/dom'
 import { IS_FIREFOX } from '../utils/ua'
 import {
   EDITOR_TO_ELEMENT,
-  EDITOR_TO_PENDING_SELECTION,
   IS_FOCUSED,
 } from '../utils/weak-maps'
 import { hasSelectableTarget, hasTarget } from './helpers'
@@ -202,18 +201,9 @@ export function DOMSelectionToEditor(textarea: TextArea, editor: IDomEditor) {
   const anchorNodeSelectable = hasSelectableTarget(editor, anchorNode)
   const focusNodeInEditor = hasTarget(editor, focusNode)
 
-  if (isComposing) {
-    if (anchorNodeSelectable && focusNodeInEditor) {
-      const range = DomEditor.toSlateRange(editor, domSelection, {
-        exactMatch: false,
-        suppressThrow: true,
-      })
-
-      EDITOR_TO_PENDING_SELECTION.set(editor, range)
-    }
-
-    return
-  }
+  // Align with Slate's Editable: on non-Android flows, selectionchange events
+  // that happen during IME composition should not mutate editor.selection.
+  if (isComposing) { return }
 
   if (anchorNodeSelectable && focusNodeInEditor) {
     const range = DomEditor.toSlateRange(editor, domSelection, {


### PR DESCRIPTION
## Summary

Align IME selection handling with Slate's upstream Editable behavior for non-Android browsers.

This removes the local pending-selection restore that was introduced during the Slate 0.123 upgrade and could restore stale Slate points at `compositionend`, leading to:
- `Cannot resolve a DOM point from Slate point`
- cursor jumping to the wrong line
- duplicated text insertion after Chinese IME commits

Refs #775

## Changes

- ignore `selectionchange` updates while composing instead of storing a pending Slate selection
- stop restoring a pending selection during `compositionend`
- keep the existing `beforeinput` flush and duplicate `insertFromComposition` protection
- add regression coverage for the IME selection path
- add a changeset for `@wangeditor-next/core` and `@wangeditor-next/editor`

## Validation

- `pnpm vitest run packages/core/__tests__/text-area/event-handlers/composition.test.ts packages/core/__tests__/text-area/syncSelection.test.ts packages/core/__tests__/text-area/event-handlers/before-input.test.ts packages/core/__tests__/text-area/TextArea.test.ts packages/core/__tests__/text-area/syncSelection-firefox.test.ts`
- `pnpm exec eslint packages/core/src/text-area/syncSelection.ts packages/core/src/text-area/event-handlers/composition.ts packages/core/__tests__/text-area/event-handlers/composition.test.ts packages/core/__tests__/text-area/syncSelection.test.ts`
- manual verification on local HTML demo with Chinese IME input in the middle/end of a line

## Notes

This intentionally follows Slate's non-Android composition behavior more closely rather than introducing an editor-specific workaround.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed IME composition handling to prevent restoring stale selections when committing composed text. This improves the input experience for IME-based languages.

* **Chores**
  * Added versioning changeset for patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->