### PR TITLE
fix(core): preserve caret in multi-editor pages

### DIFF
--- a/.changeset/green-ravens-sparkle.md
+++ b/.changeset/green-ravens-sparkle.md
@@ -1,0 +1,6 @@
+---
+'@wangeditor-next/core': patch
+'@wangeditor-next/editor': patch
+---
+
+Fix multi-editor pages losing the active caret when switching between editors.

--- a/packages/core/__tests__/editor/plugins/with-selection.test.ts
+++ b/packages/core/__tests__/editor/plugins/with-selection.test.ts
@@ -4,14 +4,20 @@
  */
 
 import { Editor } from 'slate'
+import { afterEach, vi } from 'vitest'
 
 import flushPromises from '../../../../../tests/utils/flush-promises'
+import { DomEditor } from '../../../src/editor/dom-editor'
 import { withSelection } from '../../../src/editor/plugins/with-selection'
 import createCoreEditor from '../../create-core-editor' // packages/core 不依赖 packages/editor ，不能使用后者的 createEditor
 
 function createEditor(...args) {
   return withSelection(createCoreEditor(...args))
 }
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 describe('editor selection API', () => {
   function getStartLocation(editor) {
@@ -49,5 +55,33 @@ describe('editor selection API', () => {
 
     editor.select([])
     expect(editor.isSelectedAll()).toBeTruthy()
+  })
+
+  it('does not clear another editor DOM selection when deselecting', () => {
+    const editor = createEditor()
+    const removeAllRanges = vi.fn()
+    const domSelection = {
+      rangeCount: 1,
+      anchorNode: document.createTextNode('anchor'),
+      focusNode: document.createTextNode('focus'),
+      removeAllRanges,
+    }
+
+    vi.spyOn(DomEditor, 'findDocumentOrShadowRoot').mockReturnValue({
+      getSelection: () => domSelection,
+    } as any)
+    const hasDOMNodeSpy = vi.spyOn(DomEditor, 'hasDOMNode')
+
+    hasDOMNodeSpy.mockReturnValue(false)
+
+    editor.selection = {
+      anchor: { path: [0, 0], offset: 0 },
+      focus: { path: [0, 0], offset: 0 },
+    }
+
+    editor.deselect()
+
+    expect(removeAllRanges).not.toHaveBeenCalled()
+    expect(editor.selection).toBeNull()
   })
 })

--- a/packages/core/__tests__/text-area/syncSelection.test.ts
+++ b/packages/core/__tests__/text-area/syncSelection.test.ts
@@ -317,8 +317,9 @@ describe('DOMSelectionToEditor', () => {
 
   it('deselects when readonly selection leaves the editor', () => {
     const editor = {
-      deselect: vi.fn(),
+      selection: createSelection(),
       getConfig: () => ({ readOnly: true }),
+      onChange: vi.fn(),
     } as any
     const textarea = { isComposing: false, isUpdatingSelection: false, isDraggingInternally: false } as any
 
@@ -340,11 +341,16 @@ describe('DOMSelectionToEditor', () => {
 
     DOMSelectionToEditor(textarea, editor)
 
-    expect(editor.deselect).toHaveBeenCalled()
+    expect(editor.selection).toBeNull()
+    expect(editor.onChange).toHaveBeenCalled()
   })
 
   it('deselects when editor is not active element', () => {
-    const editor = { getConfig: () => ({ readOnly: false }) } as any
+    const editor = {
+      selection: createSelection(),
+      getConfig: () => ({ readOnly: false }),
+      onChange: vi.fn(),
+    } as any
     const textarea = { isComposing: false, isUpdatingSelection: false, isDraggingInternally: false } as any
 
     const root = { activeElement: document.createElement('div'), getSelection: () => null }
@@ -352,17 +358,21 @@ describe('DOMSelectionToEditor', () => {
 
     vi.spyOn(DomEditor, 'findDocumentOrShadowRoot').mockReturnValue(root as any)
     vi.spyOn(DomEditor, 'toDOMNode').mockReturnValue(editorElement as any)
-    const deselectSpy = vi.spyOn(Transforms, 'deselect').mockImplementation(() => {})
 
     IS_FOCUSED.set(editor, true)
     DOMSelectionToEditor(textarea, editor)
 
     expect(IS_FOCUSED.has(editor)).toBe(false)
-    expect(deselectSpy).toHaveBeenCalled()
+    expect(editor.selection).toBeNull()
+    expect(editor.onChange).toHaveBeenCalled()
   })
 
   it('deselects when dom selection is missing', () => {
-    const editor = { getConfig: () => ({ readOnly: false }) } as any
+    const editor = {
+      selection: createSelection(),
+      getConfig: () => ({ readOnly: false }),
+      onChange: vi.fn(),
+    } as any
     const textarea = { isComposing: false, isUpdatingSelection: false, isDraggingInternally: false } as any
 
     const editorElement = document.createElement('div')
@@ -370,11 +380,38 @@ describe('DOMSelectionToEditor', () => {
 
     vi.spyOn(DomEditor, 'findDocumentOrShadowRoot').mockReturnValue(root as any)
     vi.spyOn(DomEditor, 'toDOMNode').mockReturnValue(editorElement as any)
-    const deselectSpy = vi.spyOn(Transforms, 'deselect').mockImplementation(() => {})
 
     DOMSelectionToEditor(textarea, editor)
 
-    expect(deselectSpy).toHaveBeenCalled()
+    expect(editor.selection).toBeNull()
+    expect(editor.onChange).toHaveBeenCalled()
+  })
+
+  it('does not clear another editor caret when a different editor becomes active', () => {
+    const editor = {
+      selection: createSelection(),
+      getConfig: () => ({ readOnly: false }),
+      onChange: vi.fn(),
+    } as any
+    const textarea = { isComposing: false, isUpdatingSelection: false, isDraggingInternally: false } as any
+
+    const activeEditorElement = document.createElement('div')
+    const domSelection = createDomSelection({
+      rangeCount: 1,
+      anchorNode: document.createTextNode('a'),
+      focusNode: document.createTextNode('a'),
+    })
+    const root = { activeElement: activeEditorElement, getSelection: () => domSelection }
+    const editorElement = document.createElement('div')
+
+    vi.spyOn(DomEditor, 'findDocumentOrShadowRoot').mockReturnValue(root as any)
+    vi.spyOn(DomEditor, 'toDOMNode').mockReturnValue(editorElement as any)
+
+    DOMSelectionToEditor(textarea, editor)
+
+    expect(domSelection.removeAllRanges).not.toHaveBeenCalled()
+    expect(editor.selection).toBeNull()
+    expect(editor.onChange).toHaveBeenCalled()
   })
 
   it('selects range when anchor and focus are selectable', () => {

--- a/packages/core/src/editor/plugins/with-selection.ts
+++ b/packages/core/src/editor/plugins/with-selection.ts
@@ -30,7 +30,12 @@ export const withSelection = <T extends Editor>(editor: T) => {
     const root = DomEditor.findDocumentOrShadowRoot(e)
     const domSelection = root.getSelection()
 
-    if (domSelection && domSelection.rangeCount > 0) {
+    const selectionBelongsToEditor = domSelection
+      && domSelection.rangeCount > 0
+      && DomEditor.hasDOMNode(e, domSelection.anchorNode as any)
+      && DomEditor.hasDOMNode(e, domSelection.focusNode as any)
+
+    if (selectionBelongsToEditor) {
       domSelection.removeAllRanges()
     }
 

--- a/packages/core/src/text-area/syncSelection.ts
+++ b/packages/core/src/text-area/syncSelection.ts
@@ -17,6 +17,16 @@ import {
 import { hasSelectableTarget, hasTarget } from './helpers'
 import TextArea from './TextArea'
 
+function clearSelectionWithoutDomEffect(editor: IDomEditor) {
+  if (editor.selection == null) { return }
+
+  // Transforms.deselect ultimately calls editor.deselect(), which clears the
+  // shared DOM Selection. In multi-editor pages that can erase the active
+  // editor's caret, so only clear the Slate model selection here.
+  editor.selection = null
+  editor.onChange()
+}
+
 /**
  * editor onchange 时，将 editor selection 同步给 DOM
  * @param textarea textarea
@@ -188,12 +198,12 @@ export function DOMSelectionToEditor(textarea: TextArea, editor: IDomEditor) {
     IS_FOCUSED.set(editor, true)
   } else {
     IS_FOCUSED.delete(editor)
-    Transforms.deselect(editor)
+    clearSelectionWithoutDomEffect(editor)
     return
   }
 
   if (!domSelection) {
-    return Transforms.deselect(editor)
+    return clearSelectionWithoutDomEffect(editor)
   }
 
   const { anchorNode, focusNode } = domSelection
@@ -215,7 +225,7 @@ export function DOMSelectionToEditor(textarea: TextArea, editor: IDomEditor) {
       Transforms.select(editor, range)
     }
   } else if (config.readOnly) {
-    Transforms.deselect(editor)
+    clearSelectionWithoutDomEffect(editor)
   } else {
     // 禁用此行，让光标选区继续生效
     // Transforms.deselect(editor)

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -285,11 +285,23 @@ test.describe('Multi Editors', () => {
     const editor2 = page.locator('#editor-text-area-2 [contenteditable="true"]')
 
     await editor1.click()
+    await expect
+      .poll(async () => page.evaluate(() => ({
+        activeId: document.activeElement?.id,
+        rangeCount: document.getSelection()?.rangeCount ?? 0,
+      })))
+      .toEqual({ activeId: 'w-e-textarea-1', rangeCount: 1 })
     await page.keyboard.type('abc')
     await expect(page.locator('#content-view-1')).toContainText('编辑器1abc')
-    await expect(page.locator('#content-view-2')).toBeEmpty()
+    await expect(page.locator('#content-view-2')).toContainText('编辑器2')
 
     await editor2.click()
+    await expect
+      .poll(async () => page.evaluate(() => ({
+        activeId: document.activeElement?.id,
+        rangeCount: document.getSelection()?.rangeCount ?? 0,
+      })))
+      .toEqual({ activeId: 'w-e-textarea-2', rangeCount: 1 })
     await page.keyboard.type('xyz')
     await expect(page.locator('#content-view-1')).toContainText('编辑器1abc')
     await expect(page.locator('#content-view-2')).toContainText('编辑器2xyz')

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -276,3 +276,22 @@ test.describe('Basic Editor', () => {
     await expect(textareaContainer).not.toHaveClass(/w-e-full-screen-container/)
   })
 })
+
+test.describe('Multi Editors', () => {
+  test('edits each editor independently', async ({ page }) => {
+    await page.goto('/examples/multi-editors.html')
+
+    const editor1 = page.locator('#editor-text-area-1 [contenteditable="true"]')
+    const editor2 = page.locator('#editor-text-area-2 [contenteditable="true"]')
+
+    await editor1.click()
+    await page.keyboard.type('abc')
+    await expect(page.locator('#content-view-1')).toContainText('编辑器1abc')
+    await expect(page.locator('#content-view-2')).toBeEmpty()
+
+    await editor2.click()
+    await page.keyboard.type('xyz')
+    await expect(page.locator('#content-view-1')).toContainText('编辑器1abc')
+    await expect(page.locator('#content-view-2')).toContainText('编辑器2xyz')
+  })
+})


### PR DESCRIPTION
## Summary
- preserve the active DOM caret when another editor clears its Slate selection
- keep the multi-editor demo stable when switching focus between editors
- add a patch changeset for release

## Verification
- pnpm vitest run packages/core/__tests__/text-area/syncSelection.test.ts packages/core/__tests__/editor/plugins/with-selection.test.ts
- PLAYWRIGHT_SKIP_BUILD=1 pnpm playwright test tests/e2e/editor.spec.ts -g "edits each editor independently"

Refs #775

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where the active caret position would be lost when switching between multiple editor instances on the same page, ensuring proper caret preservation across multi-editor scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->