### PR TITLE
fix(core): clear stale selection before setHtml

### DIFF
--- a/.changeset/nice-countries-rest.md
+++ b/.changeset/nice-countries-rest.md
@@ -1,0 +1,6 @@
+---
+'@wangeditor-next/core': patch
+'@wangeditor-next/editor': patch
+---
+
+Avoid restoring stale selections when `setHtml` replaces the entire document content.

--- a/packages/core/__tests__/editor/plugins/with-content.test.ts
+++ b/packages/core/__tests__/editor/plugins/with-content.test.ts
@@ -11,6 +11,7 @@ import { parseHtmlConf } from '../../../../basic-modules/src/modules/link/parse-
 import { registerParseElemHtmlConf } from '../../../src'
 import { IDomEditor } from '../../../src/editor/interface'
 import { withContent } from '../../../src/editor/plugins/with-content'
+import { EDITOR_TO_SELECTION } from '../../../src/utils/weak-maps'
 import createCoreEditor from '../../create-core-editor' // packages/core 不依赖 packages/editor ，不能使用后者的 createEditor
 
 function createEditor(...args) {
@@ -444,6 +445,64 @@ describe('editor content API', () => {
 
       expect(editor.getHtml()).toBe(newHtml)
       expect(editor.isDisabled()).toBe(true)
+    })
+
+    it('setHtml falls back to document start when previous selection is no longer valid', async () => {
+      const editor = createEditor({
+        content: [
+          { type: 'paragraph', children: [{ text: '' }] },
+          { type: 'paragraph', children: [{ text: 'middle' }] },
+          { type: 'paragraph', children: [{ text: 'tail' }] },
+        ],
+      })
+
+      let isFocused = true
+
+      vi.spyOn(editor, 'focus').mockImplementation(() => {})
+      vi.spyOn(editor, 'isFocused').mockImplementation(() => isFocused)
+      vi.spyOn(editor, 'select').mockImplementation((selection: any) => {
+        editor.selection = Editor.range(editor, selection)
+      })
+      setEditorSelection(editor, {
+        anchor: { path: [2, 0], offset: 2 },
+        focus: { path: [2, 0], offset: 2 },
+      })
+
+      expect(() => editor.setHtml('<div>world</div>')).not.toThrow()
+      expect(editor.getHtml()).toBe('<div>world</div>')
+      expect(editor.selection).toEqual({
+        anchor: { path: [0, 0], offset: 0 },
+        focus: { path: [0, 0], offset: 0 },
+      })
+
+      isFocused = false
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    it('setHtml clears stale cached selection before focusing', () => {
+      const editor = createEditor({
+        content: [
+          { type: 'paragraph', children: [{ text: '' }] },
+          { type: 'paragraph', children: [{ text: 'middle' }] },
+          { type: 'paragraph', children: [{ text: 'tail' }] },
+        ],
+      })
+
+      editor.selection = null
+      EDITOR_TO_SELECTION.set(editor, {
+        anchor: { path: [2, 0], offset: 2 },
+        focus: { path: [2, 0], offset: 2 },
+      })
+
+      vi.spyOn(editor, 'focus').mockImplementation(() => {
+        if (EDITOR_TO_SELECTION.has(editor)) {
+          throw new Error('stale cached selection was restored before setHtml reset')
+        }
+      })
+
+      expect(() => editor.setHtml('<div>world</div>')).not.toThrow()
+      expect(EDITOR_TO_SELECTION.has(editor)).toBe(false)
     })
 
     it('setHtml uses sanitizeHtml config before parsing', () => {

--- a/packages/core/src/editor/plugins/with-content.ts
+++ b/packages/core/src/editor/plugins/with-content.ts
@@ -526,6 +526,7 @@ export const withContent = <T extends Editor>(editor: T) => {
 
     // 删除当前内容
     e.enable()
+    EDITOR_TO_SELECTION.delete(e)
     e.focus()
     // 需要标准的{anchor:xxx, focus: xxxx} 否则无法通过slate history的检查
     // 使用 e.select([]) e.selectAll() 生成的location不是标准的{anchor: xxxx, focus: xxx}形式
@@ -547,7 +548,13 @@ export const withContent = <T extends Editor>(editor: T) => {
     }
     if (e.isFocused()) {
       try {
-        e.select(JSON.parse(editorSelectionStr)) // 选中原来的位置
+        const previousSelection = JSON.parse(editorSelectionStr)
+
+        if (Range.isRange(previousSelection) && DomEditor.hasRange(e, previousSelection)) {
+          e.select(previousSelection) // 选中原来的位置
+        } else {
+          e.select(Editor.start(e, []))
+        }
       } catch (ex) {
         e.select(Editor.start(e, [])) // 选中开始
       }


### PR DESCRIPTION
## Summary
- clear cached selection state before `setHtml` focuses the editor
- only restore the previous selection when it still maps to the new document
- add regression coverage for stale selection recovery during full-content replacement

## Testing
- `pnpm vitest run packages/core/__tests__/editor/plugins/with-content.test.ts`
- `pnpm exec eslint packages/core/src/editor/plugins/with-content.ts packages/core/__tests__/editor/plugins/with-content.test.ts`
- `pnpm exec turbo build --filter=@wangeditor-next/editor`
- local Playwright browser repro for issue #780 dialog flow

Refs #780


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed selection state handling when replacing entire document content. The editor now properly validates and restores previous selections when applicable, falling back to the document start if the selection is no longer valid in the new content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->