### PR TITLE
fix(core): avoid rapid destroy instance race

### DIFF
--- a/.changeset/curly-lamps-know.md
+++ b/.changeset/curly-lamps-know.md
@@ -1,0 +1,6 @@
+---
+'@wangeditor-next/core': patch
+'@wangeditor-next/editor': patch
+---
+
+Avoid throwing when an editor is destroyed before textarea async initialization completes.

--- a/packages/core/__tests__/text-area/TextArea.test.ts
+++ b/packages/core/__tests__/text-area/TextArea.test.ts
@@ -8,6 +8,7 @@ import {
 
 import flushPromises from '../../../../tests/utils/flush-promises'
 import { EditorEvents } from '../../src/config/interface'
+import createEditor from '../../src/create/create-editor'
 import { DomEditor } from '../../src/editor/dom-editor'
 import * as syncSelection from '../../src/text-area/syncSelection'
 import TextArea from '../../src/text-area/TextArea'
@@ -94,5 +95,24 @@ describe('TextArea', () => {
     selectionChangeHandler.flush()
 
     expect(syncSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not throw when destroyed before async initialization finishes', async () => {
+    document.body.innerHTML = '<div id="box"></div>'
+
+    const rejectionSpy = vi.fn()
+
+    process.once('unhandledRejection', rejectionSpy)
+
+    const editor = createEditor({
+      selector: '#box',
+      content: [{ type: 'paragraph', children: [{ text: '' }] }],
+    })
+
+    editor.destroy()
+    await flushPromises()
+    await flushPromises()
+
+    expect(rejectionSpy).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/src/text-area/TextArea.ts
+++ b/packages/core/src/text-area/TextArea.ts
@@ -25,6 +25,8 @@ let ID = 1
 class TextArea {
   private selectionChangeRoot: Document | ShadowRoot | null = null
 
+  private destroyed = false
+
   // eslint-disable-next-line
   readonly id = ID++
 
@@ -75,7 +77,9 @@ class TextArea {
 
     // 异步，否则获取不到 editor 和 DOM
     promiseResolveThen(() => {
-      const editor = this.editorInstance
+      const editor = this.getActiveEditor()
+
+      if (editor == null) { return }
 
       this.bindSelectionChange(editor)
 
@@ -115,6 +119,15 @@ class TextArea {
     return editor
   }
 
+  private getActiveEditor(): IDomEditor | null {
+    if (this.destroyed) { return null }
+
+    const editor = TEXTAREA_TO_EDITOR.get(this)
+
+    if (editor == null || editor.isDestroyed) { return null }
+    return editor
+  }
+
   private bindSelectionChange(editor: IDomEditor, retries = 5) {
     if (this.selectionChangeRoot != null || editor.isDestroyed) { return }
 
@@ -145,7 +158,9 @@ class TextArea {
 
     if (targetTagName === 'INPUT' || targetTagName === 'TEXTAREA') { return }
 
-    const editor = this.editorInstance
+    const editor = this.getActiveEditor()
+
+    if (editor == null) { return }
 
     DOMSelectionToEditor(this, editor)
   }, 100)
@@ -186,7 +201,10 @@ class TextArea {
   }
 
   private onFocusAndOnBlur() {
-    const editor = this.editorInstance
+    const editor = this.getActiveEditor()
+
+    if (editor == null) { return }
+
     const { onBlur, onFocus } = editor.getConfig()
 
     this.latestEditorSelection = editor.selection
@@ -194,10 +212,16 @@ class TextArea {
     editor.on(EditorEvents.CHANGE, () => {
       if (this.latestEditorSelection == null && editor.selection != null) {
         // 异步触发 focus
-        setTimeout(() => onFocus && onFocus(editor))
+        setTimeout(() => {
+          if (this.destroyed || editor.isDestroyed) { return }
+          if (onFocus) { onFocus(editor) }
+        })
       } else if (this.latestEditorSelection != null && editor.selection == null) {
         // 异步触发 blur
-        setTimeout(() => onBlur && onBlur(editor))
+        setTimeout(() => {
+          if (this.destroyed || editor.isDestroyed) { return }
+          if (onBlur) { onBlur(editor) }
+        })
       }
 
       this.latestEditorSelection = editor.selection // 重新记录 selection
@@ -208,7 +232,10 @@ class TextArea {
    * 修改 maxLength 提示信息
    */
   private changeMaxLengthInfo() {
-    const editor = this.editorInstance
+    const editor = this.getActiveEditor()
+
+    if (editor == null) { return }
+
     const { maxLength } = editor.getConfig()
 
     if (maxLength) {
@@ -242,7 +269,9 @@ class TextArea {
    * 修改 view 状态
    */
   changeViewState() {
-    const editor = this.editorInstance
+    const editor = this.getActiveEditor()
+
+    if (editor == null) { return }
 
     // 更新 DOM
     // TODO 注意这里是否会有性能瓶颈？因为每次键盘输入，都会触发这里 —— 可单独测试大文件、多内容，如几万个字
@@ -253,6 +282,7 @@ class TextArea {
 
     // 同步选区（异步，否则拿不到 DOM 渲染结果，vdom）
     promiseResolveThen(() => {
+      if (this.destroyed || editor.isDestroyed) { return }
       editorSelectionToDOM(this, editor)
     })
   }
@@ -261,6 +291,11 @@ class TextArea {
    * 销毁 textarea
    */
   destroy() {
+    this.destroyed = true
+    this.onDOMSelectionChange.cancel()
+    this.selectionChangeRoot?.removeEventListener('selectionchange', this.onDOMSelectionChange)
+    this.selectionChangeRoot = null
+
     // 销毁 DOM （只销毁最外层 DOM 即可）
     this.$textAreaContainer.remove()
   }


### PR DESCRIPTION
## Summary
- guard textarea async initialization and delayed callbacks after destroy
- stop selectionchange throttles and listeners when the textarea is torn down
- add regression coverage for creating and immediately destroying an editor

## Testing
- `pnpm vitest run packages/core/__tests__/text-area/TextArea.test.ts`
- `pnpm exec turbo build --filter=@wangeditor-next/editor`

Fixes #735
Related: wangeditor-team/wangEditor-v5#329


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where destroying an editor instance during the async initialization process could cause unhandled errors and promise rejections. The editor now correctly manages its complete lifecycle and cleanup procedures, ensuring destruction completes safely regardless of when it's initiated relative to initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->