### PR TITLE
fix(table-module): preserve excel table columns

### DIFF
--- a/.changeset/empty-poets-care.md
+++ b/.changeset/empty-poets-care.md
@@ -1,0 +1,6 @@
+---
+'@wangeditor-next/table-module': patch
+'@wangeditor-next/editor': patch
+---
+
+Preserve Excel-imported table cells that use `display:none` styles but still contain content.

--- a/packages/table-module/__tests__/parse-html.test.ts
+++ b/packages/table-module/__tests__/parse-html.test.ts
@@ -56,6 +56,18 @@ describe('table - pre parse html', () => {
     expect(res.outerHTML).toBe('<table><tr><td width="auto">hello</td></tr></table>')
   })
 
+  it('should preserve cells that use display:none but still contain imported content', () => {
+    const $table = $(
+      '<table><tbody><tr><td>A1</td><td style="display:none">B1</td><td style="display: none">C1</td></tr></tbody></table>',
+    )
+
+    const res = preParseTableHtmlConf.preParseHtml($table[0])
+
+    expect(res.outerHTML).toBe(
+      '<table><tr><td width="auto">A1</td><td style="display:none" width="auto">B1</td><td style="display: none" width="auto">C1</td></tr></table>',
+    )
+  })
+
   it('should preserve line breaks when flattening paragraphs inside cells', () => {
     const $table = $(
       [
@@ -117,6 +129,20 @@ describe('table - parse html', () => {
       width: 'auto',
       children,
       hidden: true,
+    })
+  })
+
+  it('table cell with display:none and actual content should still be imported', () => {
+    const $cell = $('<td style="display:none">visible from excel</td>')
+
+    expect(parseCellHtmlConf.parseElemHtml($cell[0], [], editor)).toEqual({
+      type: 'table-cell',
+      isHeader: false,
+      colSpan: 1,
+      rowSpan: 1,
+      width: 'auto',
+      children: [{ text: 'visible from excel' }],
+      hidden: false,
     })
   })
 
@@ -494,6 +520,30 @@ describe('table - parse html', () => {
       height: 124,
       children,
       columnWidths: [80, 80, 200],
+    })
+  })
+
+  it('table should keep columns from excel-like hidden-style cells when they contain text', () => {
+    const $table = $(
+      '<table><tr><td width="auto">A1</td><td style="display:none" width="auto">B1</td><td style="display: none" width="auto">C1</td></tr></table>',
+    )
+    const children = [
+      {
+        type: 'table-row',
+        children: [
+          { ...TABLE_CELL_BASE_PROPS, children: [{ text: 'A1' }] },
+          { ...TABLE_CELL_BASE_PROPS, children: [{ text: 'B1' }] },
+          { ...TABLE_CELL_BASE_PROPS, children: [{ text: 'C1' }] },
+        ],
+      },
+    ]
+
+    expect(parseTableHtmlConf.parseElemHtml($table[0], children as any, editor)).toEqual({
+      type: 'table',
+      width: 'auto',
+      height: 0,
+      children,
+      columnWidths: [90, 90, 90],
     })
   })
 })

--- a/packages/table-module/src/module/parse-elem-html.ts
+++ b/packages/table-module/src/module/parse-elem-html.ts
@@ -15,6 +15,7 @@ function parseCellHtml(
   editor: IDomEditor,
 ): TableCellElement {
   const $elem = $(elem)
+  const cellText = $elem.text().replace(/\s+/gm, ' ').trim()
 
   children = children.filter(child => {
     if (DomEditor.getNodeType(child) === 'paragraph') { return true }
@@ -30,7 +31,7 @@ function parseCellHtml(
 
   const colSpan = parseInt($elem.attr('colSpan') || '1', 10)
   const rowSpan = parseInt($elem.attr('rowSpan') || '1', 10)
-  const hidden = getStyleValue($elem, 'display') === 'none'
+  const hidden = getStyleValue($elem, 'display') === 'none' && cellText.length === 0
   const width = $elem.attr('width') || 'auto'
 
   return {

--- a/packages/table-module/src/module/pre-parse-html.ts
+++ b/packages/table-module/src/module/pre-parse-html.ts
@@ -53,7 +53,7 @@ function normalizeCellParagraphs(cellHtml: string): string {
 }
 
 /**
- * pre-prase table ，去掉 <tbody> 和处理单元格中的 <p> 标签，以及删除隐藏的单元格
+ * pre-prase table ，去掉 <tbody> 和处理单元格中的 <p> 标签
  * @param table table elem
  */
 function preParse(tableElem: DOMElement): DOMElement {
@@ -73,33 +73,14 @@ function preParse(tableElem: DOMElement): DOMElement {
   $table.append($tr)
   $tbody.remove()
 
-  // 删除带有 style="display:none" 的单元格（通常来自复制的隐藏内容）
-  const $allCells = $table.find('td, th')
-
-  for (let i = 0; i < $allCells.length; i += 1) {
-    const cell = $allCells[i]
-    const $cell = $(cell)
-    const styleAttr = $cell.attr('style')
-
-    // 检查style属性是否包含display:none或display: none
-    if (styleAttr) {
-      // 使用正则表达式匹配display:none，支持空格变化
-      const displayNoneRegex = /display\s*:\s*none/i
-
-      if (displayNoneRegex.test(styleAttr)) {
-        $cell.remove()
-      }
-    }
-    // 设置width属性为auto
-    $cell.attr('width', 'auto')
-  }
-
-  // 处理表格单元格中的 <p> 标签（通常来自Word复制）
   const $cells = $table.find('td, th')
 
   for (let i = 0; i < $cells.length; i += 1) {
     const cell = $cells[i]
     const $cell = $(cell)
+
+    // 设置 width 属性为 auto
+    $cell.attr('width', 'auto')
 
     // 直接处理单元格中的所有 <p> 标签
     let cellHtml = $cell.html() || ''


### PR DESCRIPTION
## Summary
- stop dropping imported table cells solely because they carry `display:none` styles
- only treat empty hidden cells as internal placeholders during table parsing
- add regression coverage for Excel-like table imports that previously lost columns

## Testing
- pnpm vitest run packages/table-module/__tests__/parse-html.test.ts
- pnpm vitest run packages/table-module/__tests__/elem-to-html.test.ts packages/table-module/__tests__/menu/delete-row.test.ts packages/table-module/__tests__/menu/delete-col.test.ts packages/table-module/__tests__/menu/merge-split-cell.test.ts packages/table-module/__tests__/render-elem.test.ts

Fixes #783


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of hidden table cells imported from Excel; cells with `display:none` styling now remain in the table when they contain content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->