### PR TITLE
fix(table-module): expand spreadsheet col span widths

### DIFF
--- a/.changeset/bright-rules-listen.md
+++ b/.changeset/bright-rules-listen.md
@@ -2,5 +2,5 @@
 '@wangeditor-next/table-module': patch
 ---
 
-Fix pasted Excel and WPS tables dropping non-first columns when copied cells are marked
-with `display:none` in the imported HTML.
+Fix pasted Excel and WPS tables dropping non-first columns when clipboard HTML uses
+`<col span>` to describe repeated column widths.

--- a/.changeset/bright-rules-listen.md
+++ b/.changeset/bright-rules-listen.md
@@ -1,0 +1,6 @@
+---
+'@wangeditor-next/table-module': patch
+---
+
+Fix pasted Excel and WPS tables dropping non-first columns when copied cells are marked
+with `display:none` in the imported HTML.

--- a/packages/table-module/__tests__/parse-html.test.ts
+++ b/packages/table-module/__tests__/parse-html.test.ts
@@ -177,6 +177,66 @@ describe('table - parse html', () => {
     })
   })
 
+  it('table should parse microsoft excel clipboard html with all columns intact', () => {
+    const html = [
+      '<table border=0 cellpadding=0 cellspacing=0 width=192 style="border-collapse: collapse;width:144pt">',
+      '<col width=64 span=3 style="width:48pt">',
+      '<tr height=18 style="height:13.8pt">',
+      '<td height=18 align=right width=64 style="height:13.8pt;width:48pt">1</td>',
+      '<td align=right width=64 style="width:48pt">2</td>',
+      '<td align=right width=64 style="width:48pt">3</td>',
+      '</tr>',
+      '<tr height=18 style="height:13.8pt">',
+      '<td height=18 align=right style="height:13.8pt">4</td>',
+      '<td align=right>5</td>',
+      '<td align=right>6</td>',
+      '</tr>',
+      '<tr height=18 style="height:13.8pt">',
+      '<td height=18 align=right style="height:13.8pt">7</td>',
+      '<td align=right>8</td>',
+      '<td align=right>9</td>',
+      '</tr>',
+      '</table>',
+    ].join('')
+    const $table = $(html)
+    const [table] = parseElemHtmlFromCore($($table[0]), editor) as any[]
+
+    expect(table).toMatchObject({
+      type: 'table',
+      width: 'auto',
+      height: 0,
+      columnWidths: [64, 64, 64],
+      children: [
+        {
+          type: 'table-row',
+          height: 13,
+          children: [
+            { ...TABLE_CELL_BASE_PROPS, children: [{ text: '1' }] },
+            { ...TABLE_CELL_BASE_PROPS, children: [{ text: '2' }] },
+            { ...TABLE_CELL_BASE_PROPS, children: [{ text: '3' }] },
+          ],
+        },
+        {
+          type: 'table-row',
+          height: 13,
+          children: [
+            { ...TABLE_CELL_BASE_PROPS, children: [{ text: '4' }] },
+            { ...TABLE_CELL_BASE_PROPS, children: [{ text: '5' }] },
+            { ...TABLE_CELL_BASE_PROPS, children: [{ text: '6' }] },
+          ],
+        },
+        {
+          type: 'table-row',
+          height: 13,
+          children: [
+            { ...TABLE_CELL_BASE_PROPS, children: [{ text: '7' }] },
+            { ...TABLE_CELL_BASE_PROPS, children: [{ text: '8' }] },
+            { ...TABLE_CELL_BASE_PROPS, children: [{ text: '9' }] },
+          ],
+        },
+      ],
+    })
+  })
   // ============== 测试table的border相关属性 start ==============
 
   it('table cell (TD) without border style should use default border (1px)', () => {

--- a/packages/table-module/__tests__/parse-html.test.ts
+++ b/packages/table-module/__tests__/parse-html.test.ts
@@ -199,7 +199,16 @@ describe('table - parse html', () => {
       '</table>',
     ].join('')
     const $table = $(html)
-    const [table] = parseElemHtmlFromCore($($table[0]), editor) as any[]
+    const stubEditor = {
+      isInline: () => false,
+    } as any
+    const rows = Array.from($table.find('tr'))
+      .map(row => {
+        const cells = Array.from(row.children).map(cell => parseCellHtmlConf.parseElemHtml(cell as HTMLTableCellElement, [], stubEditor))
+
+        return parseRowHtmlConf.parseElemHtml(row as HTMLTableRowElement, cells, stubEditor)
+      })
+    const table = parseTableHtmlConf.parseElemHtml($table[0], rows as any, stubEditor)
 
     expect(table).toMatchObject({
       type: 'table',
@@ -211,9 +220,9 @@ describe('table - parse html', () => {
           type: 'table-row',
           height: 13,
           children: [
-            { ...TABLE_CELL_BASE_PROPS, children: [{ text: '1' }] },
-            { ...TABLE_CELL_BASE_PROPS, children: [{ text: '2' }] },
-            { ...TABLE_CELL_BASE_PROPS, children: [{ text: '3' }] },
+            { ...TABLE_CELL_BASE_PROPS, width: '64', children: [{ text: '1' }] },
+            { ...TABLE_CELL_BASE_PROPS, width: '64', children: [{ text: '2' }] },
+            { ...TABLE_CELL_BASE_PROPS, width: '64', children: [{ text: '3' }] },
           ],
         },
         {

--- a/packages/table-module/src/module/parse-elem-html.ts
+++ b/packages/table-module/src/module/parse-elem-html.ts
@@ -9,6 +9,28 @@ import { Descendant, Text } from 'slate'
 import $, { DOMElement, getStyleValue, getTagName } from '../utils/dom'
 import { TableCellElement, TableElement, TableRowElement } from './custom-types'
 
+function getColgroupWidths(colgroupElements: HTMLCollection | null): number[] {
+  if (!colgroupElements || colgroupElements.length === 0) { return [] }
+
+  const columnWidths: number[] = []
+
+  Array.from(colgroupElements).forEach((col: any) => {
+    const span = parseInt(col.getAttribute('span') || '1', 10)
+    const width = parseInt(
+      col.getAttribute('width') || getStyleValue($(col), 'width') || '90',
+      10,
+    )
+
+    if (Number.isNaN(width)) { return }
+
+    for (let i = 0; i < span; i += 1) {
+      columnWidths.push(width)
+    }
+  })
+
+  return columnWidths
+}
+
 function parseCellHtml(
   elem: DOMElement,
   children: Descendant[],
@@ -115,11 +137,7 @@ function parseTableHtml(
   }
   const tdList = $elem.find('tr')[0]?.children || []
   const colgroupElments: HTMLCollection = $elem.find('colgroup')[0]?.children || null
-  const colgroupWidths = colgroupElments
-    ? Array.from(colgroupElments)
-      .map((col: any) => parseInt(col.getAttribute('width'), 10))
-      .filter(width => !Number.isNaN(width))
-    : []
+  const colgroupWidths = getColgroupWidths(colgroupElments)
 
   if (colgroupWidths.length > 0) {
     tableELement.columnWidths = colgroupWidths


### PR DESCRIPTION
## Changes Overview
- Fix pasted Excel and WPS tables dropping non-first columns when clipboard HTML uses `<col span>`.
- Expand repeated column widths from spreadsheet clipboard HTML instead of treating each `<col>` as a single column.
- Add regression coverage using real Microsoft Excel clipboard HTML.
- Keep the existing patch changeset for the table-module release.

## Implementation Approach
- Update `packages/table-module/src/module/parse-elem-html.ts` to expand `<col span="N">` into `N` column widths.
- Continue preferring colgroup widths when present, but parse both `width` and `span` together.
- Add a focused parser regression test built from actual Excel clipboard HTML captured during reproduction.

## Testing Done
- `pnpm --filter @wangeditor-next/table-module test -- __tests__/parse-html.test.ts -t "microsoft excel clipboard html"`
- `pnpm --filter @wangeditor-next/table-module test`
- Manual verification in local demo with copied tables from Microsoft Excel and WPS

## Verification Steps
1. Open the demo editor.
2. Copy a multi-column range from Microsoft Excel or WPS.
3. Paste it into the editor.
4. Confirm all copied columns render instead of only the first column.
5. Confirm normal table paste and merged-cell flows still work.

## Additional Notes
- The earlier follow-up assumption about `display:none` cells was not the real cause for issue #783.
- The actual data-loss path was that spreadsheet clipboard HTML used `<col width="..." span="...">`, while the parser only produced a single width entry.
- This update matches the real clipboard structure captured during reproduction.

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
- #783
- Follow-up to #760


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pasted tables from Excel/WPS now preserve all columns and cell content, including cells hidden via display:none when they contain real content.
  * Column widths are now correctly derived from pasted column group info (including span), improving layout fidelity.

* **Tests**
  * Added coverage to verify preservation of hidden cells, cell content/styles, and correct column width parsing for spreadsheet clipboard HTML.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->