### PR TITLE
fix(link): normalize whitespace in imported urls

### DIFF
--- a/packages/basic-modules/__tests__/link/helper.test.ts
+++ b/packages/basic-modules/__tests__/link/helper.test.ts
@@ -96,6 +96,19 @@ describe('link module helper', () => {
     expect(linkElem.url).toBe(url)
   })
 
+  it('insert link should normalize whitespace in url', async () => {
+    editor.select(startLocation)
+
+    await insertLink(editor, 'hello', ' \nhttps://wangeditor-next.github.io/docs/a b\t ')
+
+    const links = editor.getElemsByTypePrefix('link')
+
+    expect(links.length).toBe(1)
+    const linkElem = links[0]
+
+    expect(linkElem.url).toBe('https://wangeditor-next.github.io/docs/a%20b')
+  })
+
   it('insert link with collapsed max length', async () => {
     editor.select(startLocation)
     editor.insertText('1234456789012')
@@ -241,5 +254,27 @@ describe('link module helper', () => {
     const linkElem = links[0]
 
     expect(linkElem.url).toBe(newUrl)
+  })
+
+  it('update link should normalize whitespace in url', async () => {
+    editor.select(startLocation)
+
+    const url = 'https://wangeditor-next.github.io/docs/'
+
+    await insertLink(editor, 'hello', url)
+
+    editor.select({
+      path: [0, 1, 0],
+      offset: 3,
+    })
+
+    await updateLink(editor, '', ' \nhttps://wangeditor-next.github.io/docs/a b\t ')
+
+    const links = editor.getElemsByTypePrefix('link')
+
+    expect(links.length).toBe(1)
+    const linkElem = links[0]
+
+    expect(linkElem.url).toBe('https://wangeditor-next.github.io/docs/a%20b')
   })
 })

--- a/packages/basic-modules/__tests__/link/parse-html.test.ts
+++ b/packages/basic-modules/__tests__/link/parse-html.test.ts
@@ -57,4 +57,18 @@ describe('link - parse html', () => {
       children: [{ text: 'hello ' }, { text: 'world', bold: true }],
     })
   })
+
+  it('should normalize href formatting whitespace from imported html', () => {
+    const $link = $('<a href=" \nhttps://localhost/a b\t\r " target="_blank">hello</a>')
+    const children = [{ text: 'hello' }]
+
+    const res = parseHtmlConf.parseElemHtml($link[0], children, editor)
+
+    expect(res).toEqual({
+      type: 'link',
+      url: 'https://localhost/a%20b',
+      target: '_blank',
+      children: [{ text: 'hello' }],
+    })
+  })
 })

--- a/packages/basic-modules/src/modules/link/helper.ts
+++ b/packages/basic-modules/src/modules/link/helper.ts
@@ -8,6 +8,7 @@ import { Editor, Range, Transforms } from 'slate'
 
 import { replaceSymbols } from '../../utils/util'
 import { LinkElement } from './custom-types'
+import { normalizeLinkUrl } from './url'
 
 /**
  * 校验 link
@@ -22,10 +23,11 @@ async function check(
   text: string,
   url: string,
 ): Promise<boolean> {
+  const normalizedUrl = normalizeLinkUrl(url)
   const { checkLink } = editor.getMenuConfig(menuKey)
 
   if (checkLink) {
-    const res = await checkLink(text, url)
+    const res = await checkLink(text, normalizedUrl)
 
     if (typeof res === 'string') {
       // 检验未通过，提示信息
@@ -49,14 +51,15 @@ async function check(
  * @returns parsedUrl
  */
 async function parse(menuKey: string, editor: IDomEditor, url: string): Promise<string> {
+  const normalizedUrl = normalizeLinkUrl(url)
   const { parseLinkUrl } = editor.getMenuConfig(menuKey)
 
   if (parseLinkUrl) {
-    const newUrl = await parseLinkUrl(url)
+    const newUrl = await parseLinkUrl(normalizedUrl)
 
-    return newUrl
+    return normalizeLinkUrl(newUrl)
   }
-  return url
+  return normalizedUrl
 }
 
 export function isMenuDisabled(editor: IDomEditor): boolean {

--- a/packages/basic-modules/src/modules/link/parse-elem-html.ts
+++ b/packages/basic-modules/src/modules/link/parse-elem-html.ts
@@ -8,6 +8,7 @@ import { Descendant, Text } from 'slate'
 
 import $, { DOMElement } from '../../utils/dom'
 import { LinkElement } from './custom-types'
+import { normalizeLinkUrl } from './url'
 
 function parseHtml(elem: DOMElement, children: Descendant[], editor: IDomEditor): LinkElement {
   const $elem = $(elem)
@@ -25,7 +26,7 @@ function parseHtml(elem: DOMElement, children: Descendant[], editor: IDomEditor)
 
   return {
     type: 'link',
-    url: $elem.attr('href') || '',
+    url: normalizeLinkUrl($elem.attr('href') || ''),
     target: $elem.attr('target') || '',
     // @ts-ignore
     children,

--- a/packages/basic-modules/src/modules/link/url.ts
+++ b/packages/basic-modules/src/modules/link/url.ts
@@ -1,0 +1,22 @@
+/**
+ * @description normalize link url
+ * @author OpenAI
+ */
+
+const URL_FORMATTING_WHITESPACE_REGEX = /[\t\n\f\r]+/g
+const URL_SPACE_REGEX = / /g
+
+/**
+ * Normalize URLs imported from HTML editors such as Microsoft Office.
+ * Formatting whitespace inside href values should not survive as literal
+ * line breaks, while real spaces should be serialized as %20.
+ */
+export function normalizeLinkUrl(url: string): string {
+  const normalizedUrl = url.replace(URL_FORMATTING_WHITESPACE_REGEX, '').trim()
+
+  if (normalizedUrl.indexOf(' ') < 0) {
+    return normalizedUrl
+  }
+
+  return normalizedUrl.replace(URL_SPACE_REGEX, '%20')
+}


### PR DESCRIPTION
## Summary
- normalize formatting whitespace in imported and edited link URLs
- encode preserved URL spaces as `%20` instead of keeping literal spaces/newlines
- add regression tests for HTML import and insert/update link flows

Closes #768

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * URLs with whitespace characters are now properly normalized when inserting, updating, or importing links from HTML. Spaces are automatically converted to `%20` for proper URL encoding.

* **Tests**
  * Added test coverage for URL whitespace normalization in link operations and HTML parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->