### PR TITLE
fix(table): export explicit widths for fixed tables

### DIFF
--- a/.changeset/short-taxis-check.md
+++ b/.changeset/short-taxis-check.md
@@ -1,0 +1,6 @@
+---
+'@wangeditor-next/table-module': patch
+---
+
+Export fixed-layout tables with an explicit table width when column widths are known, so `colgroup`
+constraints continue to work after rendering the HTML outside the editor.

--- a/packages/editor/__tests__/create.test.ts
+++ b/packages/editor/__tests__/create.test.ts
@@ -200,6 +200,7 @@ describe('create editor and toolbar', () => {
     const exportedHtml = editor.getHtml()
 
     expect(exportedHtml).toContain('style="width: 200px;table-layout: fixed;')
+    expect(exportedHtml).not.toContain('height:NaN')
     expect(exportedHtml).toContain('<colgroup contentEditable="false"><col width=120></col><col width=80></col></colgroup>')
   })
 })

--- a/packages/editor/__tests__/create.test.ts
+++ b/packages/editor/__tests__/create.test.ts
@@ -184,4 +184,22 @@ describe('create editor and toolbar', () => {
     expect(exportedHtml).toContain('src="https://example.com/test.png"')
     expect(exportedHtml).toContain('<p>123</p>')
   })
+
+  test('getHtml exports explicit table width when imported table uses colgroup widths', () => {
+    const html = `<table style="width: auto;table-layout: fixed;height:auto">
+      <colgroup contentEditable="false">
+        <col width="120"></col>
+        <col width="80"></col>
+      </colgroup>
+      <tbody>
+        <tr><td>A</td><td>B</td></tr>
+      </tbody>
+    </table>`
+
+    const editor = customCreateEditor({ html })
+    const exportedHtml = editor.getHtml()
+
+    expect(exportedHtml).toContain('style="width: 200px;table-layout: fixed;')
+    expect(exportedHtml).toContain('<colgroup contentEditable="false"><col width=120></col><col width=80></col></colgroup>')
+  })
 })

--- a/packages/table-module/__tests__/elem-to-html.test.ts
+++ b/packages/table-module/__tests__/elem-to-html.test.ts
@@ -111,6 +111,20 @@ describe('TableModule module', () => {
       )
     })
 
+    test('tableToHtmlConf should export explicit pixel width when columnWidths are present', () => {
+      const element = {
+        type: 'table',
+        width: 'auto',
+        columnWidths: [120, 80],
+        children: [],
+      }
+      const res = tableToHtmlConf.elemToHtml(element, '<tr><td>123</td><td>456</td></tr>')
+
+      expect(res).toBe(
+        '<table style="width: 200px;table-layout: fixed;height:auto"><colgroup contentEditable="false"><col width=120></col><col width=80></col></colgroup><tbody><tr><td>123</td><td>456</td></tr></tbody></table>',
+      )
+    })
+
     test('tableToHtmlConf should return html table string with full width style if element is set fullWith value true', () => {
       const element = {
         type: 'table',

--- a/packages/table-module/__tests__/parse-html.test.ts
+++ b/packages/table-module/__tests__/parse-html.test.ts
@@ -592,6 +592,28 @@ describe('table - parse html', () => {
     })
   })
 
+  it('table should fallback auto height to 0 instead of NaN', () => {
+    const $table = $(
+      '<table style="width: auto;table-layout: fixed;height:auto"><tr><td width="auto">A</td></tr></table>',
+    )
+    const children = [
+      {
+        type: 'table-row',
+        children: [
+          { ...TABLE_CELL_BASE_PROPS, children: [{ text: 'A' }] },
+        ],
+      },
+    ]
+
+    expect(parseTableHtmlConf.parseElemHtml($table[0], children as any, editor)).toEqual({
+      type: 'table',
+      width: 'auto',
+      height: 0,
+      children,
+      columnWidths: [90],
+    })
+  })
+
   it('table should keep columns from excel-like hidden-style cells when they contain text', () => {
     const $table = $(
       '<table><tr><td width="auto">A1</td><td style="display:none" width="auto">B1</td><td style="display: none" width="auto">C1</td></tr></table>',

--- a/packages/table-module/src/module/elem-to-html.ts
+++ b/packages/table-module/src/module/elem-to-html.ts
@@ -7,8 +7,29 @@ import { Element } from 'slate'
 
 import { TableCellElement, TableElement, TableRowElement } from './custom-types'
 
+function getExportTableWidth(tableNode: TableElement): string {
+  const { width = 'auto', columnWidths = [] } = tableNode
+
+  if (width && width !== 'auto') {
+    return width
+  }
+
+  const totalWidth = columnWidths.reduce((sum, columnWidth) => {
+    if (!Number.isFinite(columnWidth)) { return sum }
+    if (columnWidth <= 0) { return sum }
+    return sum + columnWidth
+  }, 0)
+
+  if (totalWidth > 0) {
+    return `${totalWidth}px`
+  }
+
+  return 'auto'
+}
+
 function tableToHtml(elemNode: Element, childrenHtml: string): string {
-  const { width = 'auto', columnWidths, height = 'auto' } = elemNode as TableElement
+  const tableNode = elemNode as TableElement
+  const { columnWidths, height = 'auto' } = tableNode
   const cols = columnWidths
     ?.map(colWidth => {
       return `<col width=${colWidth}></col>`
@@ -16,8 +37,9 @@ function tableToHtml(elemNode: Element, childrenHtml: string): string {
     .join('')
 
   const colgroupStr = cols ? `<colgroup contentEditable="false">${cols}</colgroup>` : ''
+  const exportedWidth = getExportTableWidth(tableNode)
 
-  return `<table style="width: ${width};table-layout: fixed;height:${height}">${colgroupStr}<tbody>${childrenHtml}</tbody></table>`
+  return `<table style="width: ${exportedWidth};table-layout: fixed;height:${height}">${colgroupStr}<tbody>${childrenHtml}</tbody></table>`
 }
 
 function tableRowToHtml(elem: Element, childrenHtml: string): string {

--- a/packages/table-module/src/module/parse-elem-html.ts
+++ b/packages/table-module/src/module/parse-elem-html.ts
@@ -9,6 +9,16 @@ import { Descendant, Text } from 'slate'
 import $, { DOMElement, getStyleValue, getTagName } from '../utils/dom'
 import { TableCellElement, TableElement, TableRowElement } from './custom-types'
 
+function parsePixelSize(value: string | null | undefined, fallback = 0): number {
+  const parsedValue = parseInt(value || '', 10)
+
+  if (Number.isNaN(parsedValue)) {
+    return fallback
+  }
+
+  return parsedValue
+}
+
 function getColgroupWidths(colgroupElements: HTMLCollection | null): number[] {
   if (!colgroupElements || colgroupElements.length === 0) { return [] }
 
@@ -98,7 +108,7 @@ function parseRowHtml(
   }
 
   // 解析行高度
-  const height = parseInt(getStyleValue($elem, 'height') || '0', 10) || undefined
+  const height = parsePixelSize(getStyleValue($elem, 'height')) || undefined
 
   return {
     type: 'table-row',
@@ -126,7 +136,7 @@ function parseTableHtml(
   if ($elem.attr('width') === '100%') { tableWidth = '100%' } // 兼容 v4 格式
 
   // 计算高度
-  const height = parseInt(getStyleValue($elem, 'height') || '0', 10)
+  const height = parsePixelSize(getStyleValue($elem, 'height'))
 
   const tableELement: TableElement = {
     type: 'table',


### PR DESCRIPTION
## Summary
- export fixed-layout tables with an explicit table width when column widths are known
- keep `colgroup` widths so exported HTML behaves like the editor render and aligns with mainstream editors
- add regression coverage for `tableToHtml` and editor `getHtml()`

## Why
Browsers do not honor `table-layout: fixed` when the table width stays `auto`, so exported HTML could still be stretched by long cell content after leaving the editor. This change follows the mainstream `colgroup` + explicit table width strategy used by editors built on fixed table layouts.

Closes #162

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed-layout tables now export with explicit computed table widths based on column definitions, preserving column constraints and avoiding invalid height values when rendered outside the editor.

* **Tests**
  * Added tests validating exported table width computation, colgroup/col preservation, and robust height parsing.

* **Chores**
  * Added a release changeset declaring a patch for the table module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->