### PR TITLE
fix(core): allow partial menu config overrides

### DIFF
--- a/.changeset/soft-toes-count.md
+++ b/.changeset/soft-toes-count.md
@@ -1,0 +1,6 @@
+---
+'@wangeditor-next/core': patch
+---
+
+Allow `MENU_CONF` overrides to provide partial nested menu configs so TypeScript users can set
+only `customUpload` for upload menus without re-declaring the merged default fields.

--- a/packages/core/src/config/interface.ts
+++ b/packages/core/src/config/interface.ts
@@ -199,6 +199,10 @@ export interface IMenuConfig {
   codeSelectLang: ICodeLangConfig;
 }
 
+export type IMenuConfigUpdate = {
+  [K in keyof IMenuConfig]?: Partial<IMenuConfig[K]>
+}
+
 /**
  * editor config
  */
@@ -237,7 +241,7 @@ export interface IEditorConfig {
   maxLength?: number
 
   // 各个 menu 的配置汇总，可以通过 key 获取单个 menu 的配置
-  MENU_CONF?: Partial<IMenuConfig>
+  MENU_CONF?: IMenuConfigUpdate
 
   // 悬浮菜单栏 menu
   hoverbarKeys?: IHoverbarConf


### PR DESCRIPTION
## Summary
- make `IEditorConfig.MENU_CONF` accept partial nested menu overrides
- allow TypeScript users to provide only `customUpload` for upload menus without re-declaring merged defaults
- keep runtime behavior unchanged because menu config merging already happens in `genEditorConfig`

## Verification
- `pnpm test packages/core/__tests__/config/menu-config.test.ts packages/core/__tests__/config/editor-config.test.ts packages/core/__tests__/editor/plugins/with-config.test.ts`
- Vue 3 + Vite smoke build with `@wangeditor-next/plugin-formula` still succeeds on current versions
- a TypeScript smoke check for `MENU_CONF.uploadImage/uploadVideo = { customUpload }` no longer reports the upload config errors after regenerating package d.ts files

Closes #618

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced menu configuration to support partial nested configuration overrides. You can now customize specific menu options (such as custom upload handlers) while automatically preserving default values for all remaining configuration properties. This change eliminates the need to provide complete configuration objects and significantly simplifies the overall menu setup and customization process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->