### PR TITLE
fix(table): normalize cell Enter handling

### DIFF
--- a/.changeset/tiny-taxis-tickle.md
+++ b/.changeset/tiny-taxis-tickle.md
@@ -1,0 +1,6 @@
+---
+'@wangeditor-next/table-module': patch
+---
+
+Normalize table-cell soft line breaks to use standard `\n` handling so pressing `Enter` in a cell
+keeps the caret visible, serializes back to `<br>`, and avoids leaking `\r` into editor content.

--- a/packages/table-module/__tests__/plugin.test.ts
+++ b/packages/table-module/__tests__/plugin.test.ts
@@ -34,7 +34,43 @@ describe('TableModule module', () => {
 
       newEditor.insertBreak()
 
-      expect(mockFn).toBeCalledWith('\n\r')
+      expect(mockFn).toBeCalledWith('\n')
+    })
+
+    test('use withTable plugin when insertBreak in a table cell should insert a standard line break and keep selection valid', () => {
+      const editor = createEditor({
+        content: [
+          {
+            type: 'table',
+            width: 'auto',
+            children: [
+              {
+                type: 'table-row',
+                children: [
+                  { type: 'table-cell', children: [{ text: 'a' }] },
+                ],
+              },
+            ],
+            columnWidths: [100],
+          },
+          { type: 'paragraph', children: [{ text: '' }] },
+        ],
+      })
+
+      editor.selection = {
+        anchor: { path: [0, 0, 0, 0], offset: 1 },
+        focus: { path: [0, 0, 0, 0], offset: 1 },
+      }
+
+      editor.insertBreak()
+
+      expect((slate.Node.get(editor, [0, 0, 0, 0]) as slate.Text).text).toBe('a\n')
+      expect(editor.selection).toEqual({
+        anchor: { path: [0, 0, 0, 0], offset: 2 },
+        focus: { path: [0, 0, 0, 0], offset: 2 },
+      })
+      expect(editor.getHtml()).toContain('a<br>')
+      expect(editor.getText()).not.toContain('\r')
     })
 
     test('use withTable plugin when insertData should insertText to cell', () => {
@@ -295,7 +331,7 @@ describe('TableModule module', () => {
       })
     })
 
-    test('use withTable plugin when deleteFragment should expand half-break selections inside a cell', () => {
+    test('use withTable plugin when deleteBackward should remove a table cell line break as a single standard character', () => {
       const editor = createEditor({
         content: [
           {
@@ -305,7 +341,7 @@ describe('TableModule module', () => {
               {
                 type: 'table-row',
                 children: [
-                  { type: 'table-cell', children: [{ text: 'a\n\rb' }] },
+                  { type: 'table-cell', children: [{ text: 'a\nb' }] },
                 ],
               },
             ],
@@ -313,21 +349,52 @@ describe('TableModule module', () => {
           },
         ],
       })
-      const originalDeleteFragment = vi.fn()
 
-      editor.deleteFragment = originalDeleteFragment as any
-      const wrappedEditor = withTable(editor)
-      const setSelectionSpy = vi.spyOn(slate.Transforms, 'setSelection')
-
-      wrappedEditor.selection = {
+      editor.selection = {
         anchor: { path: [0, 0, 0, 0], offset: 2 },
         focus: { path: [0, 0, 0, 0], offset: 2 },
       }
 
-      wrappedEditor.deleteFragment('character')
+      editor.deleteBackward('character')
 
-      expect(setSelectionSpy).toHaveBeenCalled()
-      expect(originalDeleteFragment).toHaveBeenCalledWith('character')
+      expect((slate.Node.get(editor, [0, 0, 0, 0]) as slate.Text).text).toBe('ab')
+      expect(editor.selection).toEqual({
+        anchor: { path: [0, 0, 0, 0], offset: 1 },
+        focus: { path: [0, 0, 0, 0], offset: 1 },
+      })
+    })
+
+    test('use withTable plugin when deleteForward should remove a table cell line break as a single standard character', () => {
+      const editor = createEditor({
+        content: [
+          {
+            type: 'table',
+            width: 'auto',
+            children: [
+              {
+                type: 'table-row',
+                children: [
+                  { type: 'table-cell', children: [{ text: 'a\nb' }] },
+                ],
+              },
+            ],
+            columnWidths: [100],
+          },
+        ],
+      })
+
+      editor.selection = {
+        anchor: { path: [0, 0, 0, 0], offset: 1 },
+        focus: { path: [0, 0, 0, 0], offset: 1 },
+      }
+
+      editor.deleteForward('character')
+
+      expect((slate.Node.get(editor, [0, 0, 0, 0]) as slate.Text).text).toBe('ab')
+      expect(editor.selection).toEqual({
+        anchor: { path: [0, 0, 0, 0], offset: 1 },
+        focus: { path: [0, 0, 0, 0], offset: 1 },
+      })
     })
 
     test('use withTable plugin when normalizeNode should append a trailing paragraph after the last table', () => {

--- a/packages/table-module/src/module/plugin.ts
+++ b/packages/table-module/src/module/plugin.ts
@@ -14,13 +14,14 @@ import {
   NodeEntry,
   Path,
   Point,
-  Selection,
   Text,
   Transforms,
 } from 'slate'
 
 import { EDITOR_TO_SELECTION } from './weak-maps'
 import { withSelection } from './with-selection'
+
+const CELL_BREAK = '\n'
 
 // table cell 内部的删除处理
 function deleteHandler(newEditor: IDomEditor): boolean {
@@ -42,27 +43,6 @@ function deleteHandler(newEditor: IDomEditor): boolean {
   }
 
   return false
-}
-
-// #region 删除 cell 内的换行
-/**
- * 判断光标是否在换行符中间 \n|\r
- * @param newEditor
- * @param location
- */
-function isHalfBreak(newEditor: IDomEditor, location: Point): boolean {
-  const offset = location.offset
-
-  if (offset === 0) { return false }
-  const node = Editor.node(newEditor, location)
-
-  if (!Text.isText(node[0])) { return false }
-
-  const text = Node.string((node[0]))
-
-  if (offset >= text.length) { return false }
-
-  return text[offset - 1] === '\n' && text[offset] === '\r'
 }
 
 /**
@@ -100,15 +80,17 @@ function deleteCellBreak(newEditor: IDomEditor, unit: Parameters<IDomEditor['del
   if (aboveCell == null || cellNodeEntry == null || !Path.equals(aboveCell[1], cellNodeEntry[1])) { return false }
   const targetNode = Editor.node(newEditor, targetPoint)
 
-  if (!Text.isText(targetNode[0]) || targetNode[0].text.length < 2) { return false } // 如果存在\n\r，那长度必定大于2
+  if (!Text.isText(targetNode[0]) || targetNode[0].text.length < CELL_BREAK.length) { return false }
 
-  // 处理光标在换行符首/尾的情况,|表示光标  |\n\r   \n\r|
+  // 处理光标在换行符首/尾的情况,|表示光标  |\n   \n|
   const parameters: Parameters<typeof String.prototype.slice> = direction === 'backward'
-    ? [targetPoint.offset - 2, targetPoint.offset]
-    : [targetPoint.offset, targetPoint.offset + 2]
+    ? [targetPoint.offset - CELL_BREAK.length, targetPoint.offset]
+    : [targetPoint.offset, targetPoint.offset + CELL_BREAK.length]
+
+  if (parameters[0] < 0) { return false }
 
   const nodeText = Node.string(targetNode[0])
-  const isBreak = nodeText.slice(...parameters) === '\n\r'
+  const isBreak = nodeText.slice(...parameters) === CELL_BREAK
 
   if (isBreak) {
     Transforms.insertText(newEditor, nodeText.slice(0, parameters[0]) + nodeText.slice(parameters[1]), {
@@ -117,23 +99,15 @@ function deleteCellBreak(newEditor: IDomEditor, unit: Parameters<IDomEditor['del
         focus: Editor.end(newEditor, targetPoint.path),
       },
     })
-    return true
-  }
-
-  // 处理光标在换行符中间的情况
-  if (isHalfBreak(newEditor, targetPoint)) {
-    Transforms.insertText(newEditor, nodeText.slice(0, selection.anchor.offset - 1) + nodeText.slice(selection.anchor.offset + 1), {
-      at: {
-        anchor: Editor.start(newEditor, targetPoint.path),
-        focus: Editor.end(newEditor, targetPoint.path),
-      },
+    Transforms.select(newEditor, {
+      anchor: { path: targetPoint.path, offset: parameters[0] },
+      focus: { path: targetPoint.path, offset: parameters[0] },
     })
     return true
   }
 
   return false
 }
-// #endregion
 
 /**
  * 判断该 location 有没有命中 table
@@ -185,7 +159,6 @@ function withTable<T extends IDomEditor>(editor: T): T {
     insertBreak,
     deleteBackward,
     deleteForward,
-    deleteFragment,
     normalizeNode,
     insertData,
     handleTab,
@@ -198,8 +171,8 @@ function withTable<T extends IDomEditor>(editor: T): T {
     const selectedNode = DomEditor.getSelectedNodeByType(newEditor, 'table')
 
     if (selectedNode != null) {
-      // 选中了 table ，则在 cell 内换行
-      newEditor.insertText('\n\r')
+      // 选中了 table ，则在 cell 内插入标准换行
+      newEditor.insertText(CELL_BREAK)
       return
     }
 
@@ -310,41 +283,6 @@ function withTable<T extends IDomEditor>(editor: T): T {
 
     // 执行默认的删除
     deleteForward(unit)
-  }
-
-  // 重写区域选中的删除，修正可能半选的换行符
-  newEditor.deleteFragment = unit => {
-    const { selection } = newEditor
-
-    if (!selection) { return }
-    let hasChange = false
-    const newSelection: Selection = {
-      anchor: selection.anchor,
-      focus: selection.focus,
-    }
-    // 是否是从左到右的选区
-    const isLeftToRight = Point.isBefore(newSelection.anchor, newSelection.focus)
-
-    if (isHalfBreak(newEditor, selection.anchor)) {
-      const nv = Editor[isLeftToRight ? 'before' : 'after'](newEditor, selection.anchor)
-
-      if (nv) {
-        newSelection.anchor = nv
-      }
-      hasChange = true
-    }
-    if (isHalfBreak(newEditor, selection.focus)) {
-      const nv = Editor[isLeftToRight ? 'after' : 'before'](newEditor, selection.focus)
-
-      if (nv) {
-        newSelection.focus = nv
-      }
-      hasChange = true
-    }
-    if (hasChange) {
-      Transforms.setSelection(newEditor, newSelection)
-    }
-    deleteFragment(unit)
   }
 
   // 重新 normalize

--- a/packages/table-module/src/module/plugin.ts
+++ b/packages/table-module/src/module/plugin.ts
@@ -83,25 +83,28 @@ function deleteCellBreak(newEditor: IDomEditor, unit: Parameters<IDomEditor['del
   if (!Text.isText(targetNode[0]) || targetNode[0].text.length < CELL_BREAK.length) { return false }
 
   // 处理光标在换行符首/尾的情况,|表示光标  |\n   \n|
-  const parameters: Parameters<typeof String.prototype.slice> = direction === 'backward'
-    ? [targetPoint.offset - CELL_BREAK.length, targetPoint.offset]
-    : [targetPoint.offset, targetPoint.offset + CELL_BREAK.length]
+  const startOffset = direction === 'backward'
+    ? targetPoint.offset - CELL_BREAK.length
+    : targetPoint.offset
+  const endOffset = direction === 'backward'
+    ? targetPoint.offset
+    : targetPoint.offset + CELL_BREAK.length
 
-  if (parameters[0] < 0) { return false }
+  if (startOffset < 0) { return false }
 
   const nodeText = Node.string(targetNode[0])
-  const isBreak = nodeText.slice(...parameters) === CELL_BREAK
+  const isBreak = nodeText.slice(startOffset, endOffset) === CELL_BREAK
 
   if (isBreak) {
-    Transforms.insertText(newEditor, nodeText.slice(0, parameters[0]) + nodeText.slice(parameters[1]), {
+    Transforms.insertText(newEditor, nodeText.slice(0, startOffset) + nodeText.slice(endOffset), {
       at: {
         anchor: Editor.start(newEditor, targetPoint.path),
         focus: Editor.end(newEditor, targetPoint.path),
       },
     })
     Transforms.select(newEditor, {
-      anchor: { path: targetPoint.path, offset: parameters[0] },
-      focus: { path: targetPoint.path, offset: parameters[0] },
+      anchor: { path: targetPoint.path, offset: startOffset },
+      focus: { path: targetPoint.path, offset: startOffset },
     })
     return true
   }


### PR DESCRIPTION
## Summary
- normalize table cell Enter handling to use a standard `\n` break instead of the special `\n\r` sequence
- keep caret movement stable when deleting a line break inside a table cell
- add regression coverage for insertBreak, HTML serialization, and forward/backward deletion in table cells

## Testing
- pnpm test packages/table-module

Closes #619

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed table cell line break behavior so pressing Enter keeps the cursor visible, serializes line breaks to <br> in HTML, and prevents stray carriage-return characters from appearing in editor content.
* **Tests**
  * Updated and added tests to validate table cell break insertion, deletion, serialization, and selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->