### PR TITLE
fix(core): sync fullscreen menu icon/title state

### DIFF
--- a/packages/core/__tests__/menus/bar-items.test.ts
+++ b/packages/core/__tests__/menus/bar-items.test.ts
@@ -1,8 +1,11 @@
 import { Editor, Text } from 'slate'
 
+import { EditorEvents } from '../../src/config/interface'
 import { DomEditor } from '../../src/editor/dom-editor'
 import { i18nChangeLanguage } from '../../src/i18n'
 import HoverBar from '../../src/menus/bar/HoverBar'
+import Toolbar from '../../src/menus/bar/Toolbar'
+import BaseButton from '../../src/menus/bar-item/BaseButton'
 import DropPanelButton from '../../src/menus/bar-item/DropPanelButton'
 import ModalButton from '../../src/menus/bar-item/ModalButton'
 import * as positionHelpers from '../../src/menus/helpers/position'
@@ -11,6 +14,7 @@ import $ from '../../src/utils/dom'
 import {
   BAR_ITEM_TO_EDITOR,
   HOVER_BAR_TO_EDITOR,
+  TOOLBAR_TO_EDITOR,
 } from '../../src/utils/weak-maps'
 
 function createEditorStub() {
@@ -33,6 +37,10 @@ function createEditorStub() {
 async function flushMicrotasks() {
   await Promise.resolve()
   await Promise.resolve()
+}
+
+class TestButton extends BaseButton {
+  onButtonClick() {}
 }
 
 describe('bar item lifecycle', () => {
@@ -136,6 +144,87 @@ describe('bar item lifecycle', () => {
     (button as any).$button[0].click()
 
     expect((button as any).dropPanel.isShow).toBe(false)
+  })
+
+  test('BaseButton.changeMenuState refreshes icon and tooltip from the latest menu state', async () => {
+    const editor = createEditorStub()
+    let isFullScreen = false
+    const fullScreenSvg = '<svg><path d="M1 1"></path></svg>'
+    const cancelFullScreenSvg = '<svg><path d="M2 2"></path></svg>'
+    const menu = {
+      title: 'Full screen',
+      tag: 'button',
+      iconSvg: fullScreenSvg,
+      getValue: () => '',
+      isActive: () => isFullScreen,
+      isDisabled: () => false,
+      getIcon: () => (isFullScreen
+        ? cancelFullScreenSvg
+        : fullScreenSvg),
+      getTitle: () => (isFullScreen ? 'Cancel full screen' : 'Full screen'),
+      exec: vi.fn(),
+    }
+
+    const button = new TestButton('fullScreen', menu as any)
+
+    BAR_ITEM_TO_EDITOR.set(button as any, editor)
+    await flushMicrotasks()
+
+    isFullScreen = true
+    button.changeMenuState()
+
+    expect((button as any).$button.find('path').attr('d')).toBe('M2 2')
+    expect((button as any).$button.attr('data-tooltip')).toBe('Cancel full screen')
+  })
+
+  test('BaseButton click uses the post-exec state to refresh icon and tooltip', async () => {
+    const editor = createEditorStub()
+    let isFullScreen = false
+    const fullScreenSvg = '<svg><path d="M1 1"></path></svg>'
+    const cancelFullScreenSvg = '<svg><path d="M2 2"></path></svg>'
+    const menu = {
+      title: 'Full screen',
+      tag: 'button',
+      iconSvg: fullScreenSvg,
+      getValue: () => '',
+      isActive: () => isFullScreen,
+      isDisabled: () => false,
+      getIcon: () => (isFullScreen
+        ? cancelFullScreenSvg
+        : fullScreenSvg),
+      getTitle: () => (isFullScreen ? 'Cancel full screen' : 'Full screen'),
+      exec: vi.fn(() => {
+        isFullScreen = !isFullScreen
+      }),
+    }
+
+    const button = new TestButton('fullScreen', menu as any)
+
+    BAR_ITEM_TO_EDITOR.set(button as any, editor)
+    await flushMicrotasks();
+    (button as any).$button[0].click()
+
+    expect(menu.exec).toHaveBeenCalledTimes(1)
+    expect((button as any).$button.find('path').attr('d')).toBe('M2 2')
+    expect((button as any).$button.attr('data-tooltip')).toBe('Cancel full screen')
+  })
+
+  test('Toolbar listens to fullscreen events and keeps menu state synced', async () => {
+    const editor = createEditorStub()
+    const container = document.createElement('div')
+
+    document.body.appendChild(container)
+
+    const toolbar = new Toolbar(container, { toolbarKeys: [] })
+
+    TOOLBAR_TO_EDITOR.set(toolbar as any, editor)
+    await flushMicrotasks()
+
+    expect(editor.on).toHaveBeenCalledWith(EditorEvents.CHANGE, expect.any(Function))
+    expect(editor.on).toHaveBeenCalledWith(EditorEvents.FULLSCREEN, expect.any(Function))
+    expect(editor.on).toHaveBeenCalledWith(EditorEvents.UNFULLSCREEN, expect.any(Function))
+
+    toolbar.destroy()
   })
 
   test('HoverBar updates state for new selections and skips re-render for the same inline path', async () => {

--- a/packages/core/src/menus/bar-item/BaseButton.ts
+++ b/packages/core/src/menus/bar-item/BaseButton.ts
@@ -3,17 +3,20 @@
  * @author wangfupeng
  */
 
-import { IButtonMenu, IDropPanelMenu, IModalMenu } from '../interface'
 import $, { Dom7Array } from '../../utils/dom'
-import { IBarItem, getEditorInstance } from './index'
-import { clearSvgStyle } from '../helpers/helpers'
 import { promiseResolveThen } from '../../utils/util'
+import { clearSvgStyle } from '../helpers/helpers'
+import { IButtonMenu, IDropPanelMenu, IModalMenu } from '../interface'
+import { getEditorInstance, IBarItem } from './index'
 import { addTooltip } from './tooltip'
 
 abstract class BaseButton implements IBarItem {
-  readonly $elem: Dom7Array = $(`<div class="w-e-bar-item"></div>`)
-  protected readonly $button: Dom7Array = $(`<button type="button"></button>`)
+  readonly $elem: Dom7Array = $('<div class="w-e-bar-item"></div>')
+
+  protected readonly $button: Dom7Array = $('<button type="button"></button>')
+
   menu: IButtonMenu | IDropPanelMenu | IModalMenu
+
   private disabled = false
 
   constructor(key: string, menu: IButtonMenu | IDropPanelMenu | IModalMenu, inGroup = false) {
@@ -21,13 +24,16 @@ abstract class BaseButton implements IBarItem {
 
     // 验证 tag
     const { tag, width } = menu
-    if (tag !== 'button') throw new Error(`Invalid tag '${tag}', expected 'button'`)
+
+    if (tag !== 'button') { throw new Error(`Invalid tag '${tag}', expected 'button'`) }
 
     // ----------------- 初始化 dom -----------------
     const { title, hotkey = '', iconSvg = '' } = menu
     const { $button } = this
+
     if (iconSvg) {
       const $svg = $(iconSvg)
+
       clearSvgStyle($svg) // 清理 svg 样式（扩展的菜单，svg 是不可控的，所以要清理一下）
       $button.append($svg)
     } else {
@@ -62,7 +68,7 @@ abstract class BaseButton implements IBarItem {
 
       editor.hidePanelOrModal() // 隐藏当前的各种 panel
 
-      if (this.disabled) return
+      if (this.disabled) { return }
 
       this.exec() // 执行 menu.exec
       this.onButtonClick() // 执行其他的逻辑
@@ -76,9 +82,9 @@ abstract class BaseButton implements IBarItem {
     const editor = getEditorInstance(this)
     const menu = this.menu
     const value = menu.getValue(editor)
-    this.setIcon()
-    this.setTooltip()
+
     menu.exec(editor, value)
+    this.changeMenuState()
   }
 
   // 交给子类去扩展
@@ -90,6 +96,7 @@ abstract class BaseButton implements IBarItem {
     const active = this.menu.isActive(editor)
 
     const className = 'active'
+
     if (active) {
       // 设置为 active
       $button.addClass(className)
@@ -110,9 +117,10 @@ abstract class BaseButton implements IBarItem {
     }
 
     // 永远 enable
-    if (this.menu.alwaysEnable) disabled = false
+    if (this.menu.alwaysEnable) { disabled = false }
 
     const className = 'disabled'
+
     if (disabled) {
       // 设置为 disabled
       $button.addClass(className)
@@ -127,12 +135,14 @@ abstract class BaseButton implements IBarItem {
   private setIcon() {
     const editor = getEditorInstance(this)
     const { $button } = this
-    if (!this.menu.getIcon) return
+
+    if (!this.menu.getIcon) { return }
     const iconSvg = this.menu.getIcon(editor)
 
     if (iconSvg) {
       $button.find('svg').remove()
       const $svg = $(iconSvg)
+
       clearSvgStyle($svg)
       $button.append($svg)
     }
@@ -141,9 +151,11 @@ abstract class BaseButton implements IBarItem {
   private setTooltip() {
     const editor = getEditorInstance(this)
     const { $button } = this
-    if (!this.menu.getTitle) return
+
+    if (!this.menu.getTitle) { return }
     const title = this.menu.getTitle(editor)
     const iconSvg = this.menu.iconSvg
+
     if (title && iconSvg) {
       addTooltip($button, iconSvg, title)
     }
@@ -152,6 +164,8 @@ abstract class BaseButton implements IBarItem {
   changeMenuState() {
     this.setActive()
     this.setDisabled()
+    this.setIcon()
+    this.setTooltip()
   }
 }
 

--- a/packages/core/src/menus/bar/Toolbar.ts
+++ b/packages/core/src/menus/bar/Toolbar.ts
@@ -63,6 +63,8 @@ class Toolbar {
       const editor = this.getEditorInstance()
 
       editor.on(EditorEvents.CHANGE, this.changeToolbarState)
+      editor.on(EditorEvents.FULLSCREEN, this.syncToolbarState)
+      editor.on(EditorEvents.UNFULLSCREEN, this.syncToolbarState)
     })
   }
 
@@ -256,13 +258,17 @@ class Toolbar {
     return editor
   }
 
+  private syncToolbarState = () => {
+    this.toolbarItems.forEach(toolbarItem => {
+      toolbarItem.changeMenuState()
+    })
+  }
+
   /**
    * editor onChange 时触发（涉及 DOM 操作，加防抖）
    */
   changeToolbarState = debounce(() => {
-    this.toolbarItems.forEach(toolbarItem => {
-      toolbarItem.changeMenuState()
-    })
+    this.syncToolbarState()
   }, 200)
 
   /**


### PR DESCRIPTION
## Summary
- update BaseButton to refresh menu state after menu.exec, so icon/title uses the latest editor state
- include icon/title refresh in changeMenuState for external state transitions
- make Toolbar sync on FULLSCREEN and UNFULLSCREEN events

## Tests
- pnpm exec vitest run packages/core/__tests__/menus/bar-items.test.ts
- pnpm exec vitest run packages/core/__tests__/editor/plugins/with-dom.test.ts
- pnpm exec vitest run packages/basic-modules/__tests__/full-screen/full-screen-menu.test.ts

Fixes #799


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Toolbar UI now properly synchronizes when entering and exiting fullscreen mode.
  * Button icons, tooltips, and disabled states now accurately reflect menu state following command execution.

* **Tests**
  * Comprehensive test coverage added for toolbar event listener registration and button state management during interactive operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->