### PR TITLE
fix(editor-for-react): avoid firing onChange during init and value sync

### DIFF
--- a/packages/editor-for-react/__tests__/editor.test.tsx
+++ b/packages/editor-for-react/__tests__/editor.test.tsx
@@ -1,0 +1,178 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { act } from 'react-dom/test-utils'
+
+import Editor from '../src/components/Editor'
+
+type CreateEditorOptions = {
+  config?: {
+    onChange?: (editor: any) => void
+    onCreated?: (editor: any) => void
+    onDestroyed?: (editor: any) => void
+  }
+  html?: string
+}
+
+const createEditor = vi.fn((options: CreateEditorOptions = {}) => {
+  let html = options.html || ''
+
+  const editor: any = {
+    __react_on_change: undefined,
+    getHtml: vi.fn(() => html),
+    setHtml: vi.fn((newHtml: string) => {
+      html = newHtml
+      options.config?.onChange?.(editor)
+    }),
+    destroy: vi.fn(() => {
+      options.config?.onDestroyed?.(editor)
+    }),
+    setHtmlForTest: (newHtml: string) => {
+      html = newHtml
+    },
+    emitChangeForTest: () => {
+      options.config?.onChange?.(editor)
+    },
+  }
+
+  Promise.resolve().then(() => {
+    options.config?.onCreated?.(editor)
+    options.config?.onChange?.(editor)
+  })
+
+  return editor
+})
+
+vi.mock('@wangeditor-next/editor', () => ({
+  createEditor: (options: CreateEditorOptions) => createEditor(options),
+}))
+
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+    await new Promise(resolve => {
+      setTimeout(resolve, 0)
+    })
+  })
+}
+
+// 当前测试运行环境会把 tsx 编译到 jsx() 调用，补充全局 jsx 工厂即可执行组件渲染
+// eslint-disable-next-line no-underscore-dangle
+(globalThis as any).jsx = React.createElement
+
+describe('editor-for-react onChange behavior', () => {
+  beforeEach(() => {
+    createEditor.mockClear()
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('does not trigger onChange during initial mount when html is unchanged', async () => {
+    const onChange = vi.fn()
+    const onCreated = vi.fn()
+    const container = document.createElement('div')
+
+    document.body.appendChild(container)
+    await act(async () => {
+      ReactDOM.render(
+        React.createElement(Editor as any, {
+          value: '<p>123</p>',
+          onCreated,
+          onChange,
+          defaultConfig: {},
+          mode: 'default',
+        }),
+        container,
+      )
+    })
+
+    await flushPromises()
+    await flushPromises()
+
+    expect(onCreated).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledTimes(0)
+
+    await act(async () => {
+      ReactDOM.unmountComponentAtNode(container)
+    })
+  })
+
+  it('triggers onChange when editor content actually changes', async () => {
+    const onChange = vi.fn()
+    const container = document.createElement('div')
+
+    document.body.appendChild(container)
+    await act(async () => {
+      ReactDOM.render(
+        React.createElement(Editor as any, {
+          value: '<p>123</p>',
+          onChange,
+          defaultConfig: {},
+          mode: 'default',
+        }),
+        container,
+      )
+    })
+    await flushPromises()
+    await flushPromises()
+
+    const editor = createEditor.mock.results[0].value
+
+    editor.setHtmlForTest('<p>456</p>')
+    editor.emitChangeForTest()
+    await flushPromises()
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange.mock.calls[0][0]).toBe(editor)
+
+    await act(async () => {
+      ReactDOM.unmountComponentAtNode(container)
+    })
+  })
+
+  it('does not trigger onChange when syncing external value updates', async () => {
+    const onChange = vi.fn()
+    const container = document.createElement('div')
+
+    document.body.appendChild(container)
+    await act(async () => {
+      ReactDOM.render(
+        React.createElement(Editor as any, {
+          value: '<p>123</p>',
+          onChange,
+          defaultConfig: {},
+          mode: 'default',
+        }),
+        container,
+      )
+    })
+    await flushPromises()
+    await flushPromises()
+    onChange.mockClear()
+
+    await act(async () => {
+      ReactDOM.render(
+        React.createElement(Editor as any, {
+          value: '<p>789</p>',
+          onChange,
+          defaultConfig: {},
+          mode: 'default',
+        }),
+        container,
+      )
+    })
+    await flushPromises()
+    await flushPromises()
+
+    const editor = createEditor.mock.results[0].value
+
+    expect(editor.setHtml).toHaveBeenCalledWith('<p>789</p>')
+    expect(onChange).toHaveBeenCalledTimes(0)
+
+    await act(async () => {
+      ReactDOM.unmountComponentAtNode(container)
+    })
+  })
+})

--- a/packages/editor-for-react/src/components/Editor.tsx
+++ b/packages/editor-for-react/src/components/Editor.tsx
@@ -30,8 +30,9 @@ function EditorComponent(props: Partial<IProps>) {
     defaultContent = [], onCreated, defaultHtml = '', value = '', onChange, defaultConfig = {}, mode = 'default', style = {}, className,
   } = props
   const ref = useRef<HTMLDivElement>(null)
+  const latestHtmlRef = useRef('')
+  const isSyncingFromPropsRef = useRef(false)
   const [editor, setEditor] = useState<ICustomDomEditor | null>(null)
-  const [curValue, setCurValue] = useState('')
 
   const handleCreated = (createdEditor: IDomEditor) => {
     // 组件属性 onCreated
@@ -57,7 +58,16 @@ function EditorComponent(props: Partial<IProps>) {
 
     // eslint-disable-next-line no-underscore-dangle
     editor.__react_on_change = (e: IDomEditor) => {
-      setCurValue(e.getHtml()) // 记录当前 html 值
+      const latestHtml = e.getHtml()
+      const prevHtml = latestHtmlRef.current
+
+      latestHtmlRef.current = latestHtml // 记录当前 html 值
+
+      // 由 props 同步触发 setHtml 时，不向外触发 onChange，避免受控场景产生回环
+      if (isSyncingFromPropsRef.current) { return }
+
+      // 仅在内容发生变化时触发，对齐输入控件 onChange 语义（忽略选区/焦点变化）
+      if (latestHtml === prevHtml) { return }
 
       // 组件属性 onChange
       if (onChange) { onChange(e) }
@@ -67,22 +77,29 @@ function EditorComponent(props: Partial<IProps>) {
 
       if (onChangeFromConfig) { onChangeFromConfig(e) }
     }
-  }, [editor, defaultConfig])
+    return () => {
+      // eslint-disable-next-line no-underscore-dangle
+      editor.__react_on_change = undefined
+    }
+  }, [editor, defaultConfig, onChange])
 
   // value 变化，重置 HTML
   useEffect(() => {
     if (editor == null) { return }
 
-    if (value === curValue) { return } // 如果和当前 html 值相等，则忽略
+    if (value === latestHtmlRef.current) { return } // 如果和当前 html 值相等，则忽略
 
     // ------ 重新设置 HTML ------
     try {
+      isSyncingFromPropsRef.current = true
       editor.setHtml(value)
+      latestHtmlRef.current = editor.getHtml()
     } catch (error) {
       console.error(error)
+    } finally {
+      isSyncingFromPropsRef.current = false
     }
-
-  }, [value])
+  }, [editor, value])
 
   useEffect(() => {
     if (ref.current == null) { return }
@@ -104,6 +121,7 @@ function EditorComponent(props: Partial<IProps>) {
       mode,
     })as ICustomDomEditor
 
+    latestHtmlRef.current = newEditor.getHtml()
     setEditor(newEditor)
   }, [editor])
 


### PR DESCRIPTION
## Summary
- avoid firing React wrapper `onChange` when changes come from initial mount or `value` prop synchronization
- only propagate `onChange` when editor html actually changes
- add regression tests for mount, real user change, and controlled value sync scenarios

## Why
Issue #78 reports that `onChange` is triggered on initialization and can cause controlled usage loops.

## Validation
- `pnpm exec vitest run packages/editor-for-react/__tests__`
- `pnpm exec vitest run packages/core/__tests__/config/editor-config.test.ts`

Closes #78


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests for Editor component's `onChange` behavior and prop synchronization.

* **Bug Fixes**
  * Improved Editor component's state synchronization to prevent unwanted change events and ensure `onChange` fires only when content actually changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->