### PR TITLE
fix(upload): upgrade uppy to v5 with compatibility patch

### DIFF
--- a/.changeset/green-cheetahs-sing.md
+++ b/.changeset/green-cheetahs-sing.md
@@ -1,0 +1,13 @@
+---
+'@wangeditor-next/core': patch
+'@wangeditor-next/editor': patch
+'@wangeditor-next/upload-image-module': patch
+'@wangeditor-next/video-module': patch
+---
+
+Upgrade the Uppy integration to v5 while keeping upload behavior compatible.
+
+- bump `@uppy/core` and `@uppy/xhr-upload` in `@wangeditor-next/editor` to `^5.0.0`
+- extend peer dependency ranges in `core`, `upload-image-module`, and `video-module` to support both Uppy v2 and v5
+- normalize upload header values to strings for stricter Uppy v5 XHR typings
+- add a guarded `AbortSignal.any` fallback for environments that do not implement it

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,6 +49,8 @@
     "url": "https://github.com/wangeditor-next/wangeditor-next/issues"
   },
   "peerDependencies": {
+    "@uppy/core": "^2.1.1 || ^5.0.0",
+    "@uppy/xhr-upload": "^2.0.3 || ^5.0.0",
     "dom7": "^3.0.0 || ^4.0.0",
     "is-hotkey": "^0.2.0",
     "lodash.camelcase": "^4.3.0",

--- a/packages/core/src/upload/createUploader.ts
+++ b/packages/core/src/upload/createUploader.ts
@@ -3,8 +3,6 @@
  * @author wangfupeng
  */
 
-import type Uppy from '@uppy/core'
-
 import type { IDomEditor } from '../editor/interface'
 import createUppyUploader from './createUppyUploader'
 import type { IUploadAdapter, IUploadConfig, IUploader } from './interface'
@@ -12,16 +10,23 @@ import type { IUploadAdapter, IUploadConfig, IUploader } from './interface'
 type IUploadConfigWithAdapter = IUploadConfig & {
   uploadAdapter: IUploadAdapter
 }
+type IDefaultUploader = IUploader & {
+  [key: string]: any
+}
 
 function createUploader<T extends IUploadConfig>(
   config: T,
   editor?: IDomEditor,
-): T extends IUploadConfigWithAdapter ? IUploader : Uppy {
+): T extends IUploadConfigWithAdapter ? IUploader : IDefaultUploader {
   if (config.uploadAdapter) {
-    return config.uploadAdapter({ config, editor }) as T extends IUploadConfigWithAdapter ? IUploader : Uppy
+    return config.uploadAdapter({ config, editor }) as T extends IUploadConfigWithAdapter
+      ? IUploader
+      : IDefaultUploader
   }
 
-  return createUppyUploader(config) as T extends IUploadConfigWithAdapter ? IUploader : Uppy
+  return createUppyUploader(config) as T extends IUploadConfigWithAdapter
+    ? IUploader
+    : IDefaultUploader
 }
 
 export default createUploader

--- a/packages/core/src/upload/createUppyUploader.ts
+++ b/packages/core/src/upload/createUppyUploader.ts
@@ -7,12 +7,67 @@ import Uppy from '@uppy/core'
 import XHRUpload from '@uppy/xhr-upload'
 
 import { addQueryToUrl } from '../utils/util'
-import type { IUploadConfig, IUploader, IUploadResultFile } from './interface'
+import type {
+  IUploadConfig, IUploader, IUploadHeaders, IUploadResultFile,
+} from './interface'
 
 function getUploadResultFile(file?: IUploadResultFile | null): IUploadResultFile {
   if (file) { return file }
 
   return { name: '' }
+}
+
+function normalizeHeaderValues(headers: IUploadHeaders): Record<string, string> {
+  return Object.keys(headers).reduce<Record<string, string>>((res, key) => {
+    res[key] = String(headers[key])
+    return res
+  }, {})
+}
+
+function normalizeHeaders(
+  headers: IUploadConfig['headers'],
+): Record<string, string> | ((file: unknown) => Record<string, string>) | undefined {
+  if (!headers) { return undefined }
+
+  if (typeof headers === 'function') {
+    return file => normalizeHeaderValues(headers(file as IUploadResultFile))
+  }
+
+  return normalizeHeaderValues(headers)
+}
+
+function ensureAbortSignalAny() {
+  if (typeof AbortSignal === 'undefined') { return }
+
+  const abortSignal = AbortSignal as typeof AbortSignal & {
+    any?: (signals: AbortSignal[]) => AbortSignal
+  }
+
+  if (typeof abortSignal.any === 'function') { return }
+
+  abortSignal.any = (signals: AbortSignal[]) => {
+    const controller = new AbortController()
+
+    const onAbort = (event: Event) => {
+      signals.forEach(signal => signal.removeEventListener('abort', onAbort))
+      const target = event.target as AbortSignal
+      const reason = (target as AbortSignal & { reason?: unknown }).reason
+
+      controller.abort(reason)
+    }
+
+    for (const signal of signals) {
+      if (signal.aborted) {
+        const reason = (signal as AbortSignal & { reason?: unknown }).reason
+
+        controller.abort(reason)
+        return controller.signal
+      }
+      signal.addEventListener('abort', onAbort, { once: true })
+    }
+
+    return controller.signal
+  }
 }
 
 function createUppyUploader(config: IUploadConfig): IUploader {
@@ -51,6 +106,9 @@ function createUppyUploader(config: IUploadConfig): IUploader {
     url = addQueryToUrl(url, meta)
   }
 
+  ensureAbortSignalAny()
+  const normalizedHeaders = normalizeHeaders(headers)
+
   const uppy = new Uppy({
     onBeforeUpload: files => onBeforeUpload(files) as any,
     restrictions: {
@@ -61,7 +119,7 @@ function createUppyUploader(config: IUploadConfig): IUploader {
     ...config.uppyConfig,
   }).use(XHRUpload, {
     endpoint: url,
-    headers,
+    headers: normalizedHeaders,
     formData: true,
     fieldName,
     bundle: false,

--- a/packages/core/src/upload/createUppyUploader.ts
+++ b/packages/core/src/upload/createUppyUploader.ts
@@ -3,7 +3,9 @@
  * @author wangfupeng
  */
 
+// @ts-ignore Uppy v5 types are not resolvable under current TS moduleResolution=node
 import Uppy from '@uppy/core'
+// @ts-ignore Uppy v5 types are not resolvable under current TS moduleResolution=node
 import XHRUpload from '@uppy/xhr-upload'
 
 import { addQueryToUrl } from '../utils/util'

--- a/packages/custom-types.d.ts
+++ b/packages/custom-types.d.ts
@@ -104,20 +104,4 @@ declare module 'slate' {
   }
 }
 
-// NOTE:
-// Uppy v5 types are published behind package exports that are not fully
-// resolved by the current TS "moduleResolution: node" in this repo.
-// Keep runtime imports unchanged and provide minimal ambient typings here.
-declare module '@uppy/core' {
-  const Uppy: any
-
-  export default Uppy
-}
-
-declare module '@uppy/xhr-upload' {
-  const XHRUpload: any
-
-  export default XHRUpload
-}
-
 export { BaseElement, CustomElement, ElementType }

--- a/packages/custom-types.d.ts
+++ b/packages/custom-types.d.ts
@@ -104,4 +104,20 @@ declare module 'slate' {
   }
 }
 
+// NOTE:
+// Uppy v5 types are published behind package exports that are not fully
+// resolved by the current TS "moduleResolution: node" in this repo.
+// Keep runtime imports unchanged and provide minimal ambient typings here.
+declare module '@uppy/core' {
+  const Uppy: any
+
+  export default Uppy
+}
+
+declare module '@uppy/xhr-upload' {
+  const XHRUpload: any
+
+  export default XHRUpload
+}
+
 export { BaseElement, CustomElement, ElementType }

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -64,8 +64,8 @@
     "url": "https://github.com/wangeditor-next/wangeditor-next/issues"
   },
   "dependencies": {
-    "@uppy/core": "^2.1.1",
-    "@uppy/xhr-upload": "^2.0.3",
+    "@uppy/core": "^5.0.0",
+    "@uppy/xhr-upload": "^5.0.0",
     "@wangeditor-next/basic-modules": "2.0.5",
     "@wangeditor-next/code-highlight": "2.0.5",
     "@wangeditor-next/core": "1.8.5",

--- a/packages/upload-image-module/package.json
+++ b/packages/upload-image-module/package.json
@@ -44,8 +44,8 @@
     "url": "https://github.com/wangeditor-next/wangeditor-next/issues"
   },
   "peerDependencies": {
-    "@uppy/core": "^2.0.3",
-    "@uppy/xhr-upload": "^2.0.3",
+    "@uppy/core": "^2.0.3 || ^5.0.0",
+    "@uppy/xhr-upload": "^2.0.3 || ^5.0.0",
     "@wangeditor-next/basic-modules": "2.0.5",
     "@wangeditor-next/core": "1.8.5",
     "dom7": "^3.0.0 || ^4.0.0",

--- a/packages/video-module/package.json
+++ b/packages/video-module/package.json
@@ -44,8 +44,8 @@
     "url": "https://github.com/wangeditor-next/wangeditor-next/issues"
   },
   "peerDependencies": {
-    "@uppy/core": "^2.1.4",
-    "@uppy/xhr-upload": "^2.0.7",
+    "@uppy/core": "^2.1.4 || ^5.0.0",
+    "@uppy/xhr-upload": "^2.0.7 || ^5.0.0",
     "@wangeditor-next/core": "1.8.5",
     "dom7": "^3.0.0 || ^4.0.0",
     "nanoid": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -550,11 +550,11 @@ importers:
   packages/editor:
     dependencies:
       '@uppy/core':
-        specifier: ^2.1.1
-        version: 2.3.4
+        specifier: ^5.0.0
+        version: 5.2.0
       '@uppy/xhr-upload':
-        specifier: ^2.0.3
-        version: 2.1.3(@uppy/core@2.3.4)
+        specifier: ^5.0.0
+        version: 5.2.0(@uppy/core@5.2.0)
       '@wangeditor-next/basic-modules':
         specifier: 2.0.5
         version: link:../basic-modules
@@ -777,10 +777,10 @@ importers:
   packages/upload-image-module:
     dependencies:
       '@uppy/core':
-        specifier: ^2.0.3
+        specifier: ^2.0.3 || ^5.0.0
         version: 2.3.4
       '@uppy/xhr-upload':
-        specifier: ^2.0.3
+        specifier: ^2.0.3 || ^5.0.0
         version: 2.1.3(@uppy/core@2.3.4)
       '@wangeditor-next/basic-modules':
         specifier: 2.0.5
@@ -808,10 +808,10 @@ importers:
   packages/video-module:
     dependencies:
       '@uppy/core':
-        specifier: ^2.1.4
+        specifier: ^2.1.4 || ^5.0.0
         version: 2.3.4
       '@uppy/xhr-upload':
-        specifier: ^2.0.7
+        specifier: ^2.0.7 || ^5.0.0
         version: 2.1.3(@uppy/core@2.3.4)
       '@wangeditor-next/core':
         specifier: 1.8.5
@@ -2206,6 +2206,9 @@ packages:
   '@transloadit/prettier-bytes@0.0.7':
     resolution: {integrity: sha512-VeJbUb0wEKbcwaSlj5n+LscBl9IPgLPkHVGBkh00cztv6X4L/TJXK58LzFuBKX7/GAfiGhIwH67YTLTlzvIzBA==}
 
+  '@transloadit/prettier-bytes@0.3.5':
+    resolution: {integrity: sha512-xF4A3d/ZyX2LJWeQZREZQw+qFX4TGQ8bGVP97OLRt6sPO6T0TNHBFTuRHOJh7RNmYOBmQ9MHxpolD9bXihpuVA==}
+
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
@@ -2286,6 +2289,9 @@ packages:
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
+
+  '@types/retry@0.12.2':
+    resolution: {integrity: sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==}
 
   '@types/scheduler@0.16.8':
     resolution: {integrity: sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==}
@@ -2373,19 +2379,38 @@ packages:
   '@uppy/companion-client@2.2.2':
     resolution: {integrity: sha512-5mTp2iq97/mYSisMaBtFRry6PTgZA6SIL7LePteOV5x0/DxKfrZW3DEiQERJmYpHzy7k8johpm2gHnEKto56Og==}
 
+  '@uppy/companion-client@5.1.1':
+    resolution: {integrity: sha512-DzrOWTbIZHvtgAFXBMYHk2wD27NjpBSVhY2tEiEIUhPd2CxbFRZjHM/N3HOt3VwZEAP471QWFLlJRWPcIY3A2Q==}
+    peerDependencies:
+      '@uppy/core': ^5.1.1
+
   '@uppy/core@2.3.4':
     resolution: {integrity: sha512-iWAqppC8FD8mMVqewavCz+TNaet6HPXitmGXpGGREGrakZ4FeuWytVdrelydzTdXx6vVKkOmI2FLztGg73sENQ==}
+
+  '@uppy/core@5.2.0':
+    resolution: {integrity: sha512-uvfNyz4cnaplt7LYJmEZHuqOuav0tKp4a9WKJIaH6iIj7XiqYvS2J5SEByexAlUFlzefOAyjzj4Ja2dd/8aMrw==}
 
   '@uppy/store-default@2.1.1':
     resolution: {integrity: sha512-xnpTxvot2SeAwGwbvmJ899ASk5tYXhmZzD/aCFsXePh/v8rNvR2pKlcQUH7cF/y4baUGq3FHO/daKCok/mpKqQ==}
 
+  '@uppy/store-default@5.0.0':
+    resolution: {integrity: sha512-hQtCSQ1yGiaval/wVYUWquYGDJ+bpQ7e4FhUUAsRQz1x1K+o7NBtjfp63O9I4Ks1WRoKunpkarZ+as09l02cPw==}
+
   '@uppy/utils@4.1.3':
     resolution: {integrity: sha512-nTuMvwWYobnJcytDO3t+D6IkVq/Qs4Xv3vyoEZ+Iaf8gegZP+rEyoaFT2CK5XLRMienPyqRqNbIfRuFaOWSIFw==}
+
+  '@uppy/utils@7.2.0':
+    resolution: {integrity: sha512-6lC246qszMv6bTyl/+QyHwrudgeguWkA94ME1wHn+a6uRAvmtAEaUManIfGqTJfoKvWAiCJqdJPl5xRJjhAloQ==}
 
   '@uppy/xhr-upload@2.1.3':
     resolution: {integrity: sha512-YWOQ6myBVPs+mhNjfdWsQyMRWUlrDLMoaG7nvf/G6Y3GKZf8AyjFDjvvJ49XWQ+DaZOftGkHmF1uh/DBeGivJQ==}
     peerDependencies:
       '@uppy/core': ^2.3.3
+
+  '@uppy/xhr-upload@5.2.0':
+    resolution: {integrity: sha512-3LV/X5Of6BINnKplP+CwUJ0a4/7cRFfzxwGyXnW+uCrNQHoo09dttcz3begWHejGvzenQHuUnMO3Fxyc71Pryg==}
+    peerDependencies:
+      '@uppy/core': ^5.2.0
 
   '@vitejs/plugin-react@1.3.2':
     resolution: {integrity: sha512-aurBNmMo0kz1O4qRoY+FM4epSA39y3ShWGuqfLRA/3z0oEJAdtoSfgA3aO98/PCCHAqMaduLxIxErWrVKIFzXA==}
@@ -4115,6 +4140,10 @@ packages:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
 
+  is-network-error@1.3.2:
+    resolution: {integrity: sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==}
+    engines: {node: '>=16'}
+
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
     engines: {node: '>= 0.4'}
@@ -4508,6 +4537,9 @@ packages:
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
@@ -4844,6 +4876,10 @@ packages:
   p-queue@6.6.2:
     resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
     engines: {node: '>=8'}
+
+  p-retry@6.2.1:
+    resolution: {integrity: sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==}
+    engines: {node: '>=16.17'}
 
   p-timeout@3.2.0:
     resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
@@ -5531,6 +5567,10 @@ packages:
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -7971,6 +8011,8 @@ snapshots:
 
   '@transloadit/prettier-bytes@0.0.7': {}
 
+  '@transloadit/prettier-bytes@0.3.5': {}
+
   '@trysound/sax@0.2.0': {}
 
   '@types/aria-query@5.0.4': {}
@@ -8048,6 +8090,8 @@ snapshots:
       csstype: 3.2.3
 
   '@types/resolve@1.20.2': {}
+
+  '@types/retry@0.12.2': {}
 
   '@types/scheduler@0.16.8': {}
 
@@ -8158,6 +8202,13 @@ snapshots:
       '@uppy/utils': 4.1.3
       namespace-emitter: 2.0.1
 
+  '@uppy/companion-client@5.1.1(@uppy/core@5.2.0)':
+    dependencies:
+      '@uppy/core': 5.2.0
+      '@uppy/utils': 7.2.0
+      namespace-emitter: 2.0.1
+      p-retry: 6.2.1
+
   '@uppy/core@2.3.4':
     dependencies:
       '@transloadit/prettier-bytes': 0.0.7
@@ -8169,11 +8220,29 @@ snapshots:
       nanoid: 3.3.11
       preact: 10.27.2
 
+  '@uppy/core@5.2.0':
+    dependencies:
+      '@transloadit/prettier-bytes': 0.3.5
+      '@uppy/store-default': 5.0.0
+      '@uppy/utils': 7.2.0
+      lodash: 4.17.21
+      mime-match: 1.0.2
+      namespace-emitter: 2.0.1
+      nanoid: 5.1.6
+      preact: 10.27.2
+
   '@uppy/store-default@2.1.1': {}
+
+  '@uppy/store-default@5.0.0': {}
 
   '@uppy/utils@4.1.3':
     dependencies:
       lodash.throttle: 4.1.1
+
+  '@uppy/utils@7.2.0':
+    dependencies:
+      lodash: 4.18.1
+      preact: 10.27.2
 
   '@uppy/xhr-upload@2.1.3(@uppy/core@2.3.4)':
     dependencies:
@@ -8181,6 +8250,12 @@ snapshots:
       '@uppy/core': 2.3.4
       '@uppy/utils': 4.1.3
       nanoid: 3.3.11
+
+  '@uppy/xhr-upload@5.2.0(@uppy/core@5.2.0)':
+    dependencies:
+      '@uppy/companion-client': 5.1.1(@uppy/core@5.2.0)
+      '@uppy/core': 5.2.0
+      '@uppy/utils': 7.2.0
 
   '@vitejs/plugin-react@1.3.2':
     dependencies:
@@ -10226,6 +10301,8 @@ snapshots:
 
   is-negative-zero@2.0.3: {}
 
+  is-network-error@1.3.2: {}
+
   is-number-object@1.1.1:
     dependencies:
       call-bound: 1.0.4
@@ -10659,6 +10736,8 @@ snapshots:
 
   lodash@4.17.21: {}
 
+  lodash@4.18.1: {}
+
   log-symbols@4.1.0:
     dependencies:
       chalk: 4.1.2
@@ -10980,6 +11059,12 @@ snapshots:
     dependencies:
       eventemitter3: 4.0.7
       p-timeout: 3.2.0
+
+  p-retry@6.2.1:
+    dependencies:
+      '@types/retry': 0.12.2
+      is-network-error: 1.3.2
+      retry: 0.13.1
 
   p-timeout@3.2.0:
     dependencies:
@@ -11624,6 +11709,8 @@ snapshots:
     dependencies:
       onetime: 7.0.0
       signal-exit: 4.1.0
+
+  retry@0.13.1: {}
 
   reusify@1.1.0: {}
 


### PR DESCRIPTION
## Summary

- upgrade `@uppy/core` and `@uppy/xhr-upload` used by `@wangeditor-next/editor` to `^5.0.0`
- expand peer ranges in `@wangeditor-next/core`, `@wangeditor-next/upload-image-module`, `@wangeditor-next/video-module` to support both Uppy v2 and v5
- normalize upload headers to string values for stricter Uppy v5 XHR typings
- add a guarded `AbortSignal.any` fallback for environments that do not implement it (e.g. jsdom tests)
- add patch changeset for affected packages

## API / Compatibility

- no intentional runtime breaking API change for upload usage (`uploadAdapter` and callbacks remain the same)
- TypeScript return type of `createUploader` is now widened to avoid direct dependency on Uppy exported types under v5 package exports

## Validation

- `pnpm build`
- `pnpm --filter @wangeditor-next/core test -- __tests__/upload/uploader.test.ts`
- `pnpm --filter @wangeditor-next/editor test -- __tests__/create.test.ts`
- `pnpm --filter @wangeditor-next/upload-image-module test`
- `pnpm --filter @wangeditor-next/video-module test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add support for Uppy v5 across upload modules while retaining compatibility with Uppy v2; editor updated to opt into Uppy v5.

* **Bug Fixes**
  * Normalize upload header values to satisfy stricter typings.
  * Add a guarded fallback for abort-signal handling in environments without native support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/810?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->