### PR TITLE
refactor(editor): 收敛轻量入口到 editor/core

### DIFF
--- a/.changeset/fair-papayas-relate.md
+++ b/.changeset/fair-papayas-relate.md
@@ -13,5 +13,5 @@ target) to reduce bundle size.
 Add a tiptap-like composition API for the `@wangeditor-next/editor/core` subpath via extensions
 and factory-based creation helpers.
 
-Mark Uppy peer dependencies in `@wangeditor-next/core` as optional so lightweight installs do not
-need upload runtime packages unless upload APIs are used.
+Keep backward compatibility for legacy `createUploader` / `createUppyUploader` imports from
+`@wangeditor-next/core`, and mark them as deprecated in favor of `@wangeditor-next/core/upload`.

--- a/.changeset/fair-papayas-relate.md
+++ b/.changeset/fair-papayas-relate.md
@@ -1,0 +1,17 @@
+---
+'@wangeditor-next/editor': patch
+'@wangeditor-next/core': patch
+---
+
+Add a lightweight subpath `@wangeditor-next/editor/core` for on-demand module composition,
+and a separate `@wangeditor-next/editor/upload` entry for uploader APIs. The core subpath avoids
+auto-registering built-in modules and does not include upload runtime code.
+
+Align Babel transpilation targets with the repository browserslist (drop hardcoded `ie 11`
+target) to reduce bundle size.
+
+Add a tiptap-like composition API for the `@wangeditor-next/editor/core` subpath via extensions
+and factory-based creation helpers.
+
+Mark Uppy peer dependencies in `@wangeditor-next/core` as optional so lightweight installs do not
+need upload runtime packages unless upload APIs are used.

--- a/apps/demo-html/examples/index.html
+++ b/apps/demo-html/examples/index.html
@@ -22,6 +22,7 @@
   <h1>wangEditor examples</h1>
   <ul>
     <li><a href="./default-mode.html">Default mode 默认模式</a></li>
+    <li><a href="./on-demand-load.html">On-demand load 按需加载（推荐）</a></li>
     <li><a href="./simple-mode.html">Simple mode 简洁模式</a></li>
     <li><a href="./parse-html.html">Parse html 回显使用 html</a></li>
     <li><a href="./menu.html">Menu config 菜单配置</a></li>

--- a/apps/demo-html/examples/on-demand-load.html
+++ b/apps/demo-html/examples/on-demand-load.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>on-demand load</title>
+  <link href="https://cdn.bootcdn.net/ajax/libs/normalize/8.0.1/normalize.min.css" rel="stylesheet">
+  <link href="./css/view.css" rel="stylesheet">
+  <link href="./css/editor.css" rel="stylesheet">
+  <link href="../dist/css/style.css" rel="stylesheet">
+</head>
+<body>
+  <div style="width: 1000px; margin: 0 auto;">
+    <p><b>on-demand load 按需加载（运行示例）</b></p>
+    <p>
+      使用 <code>@wangeditor-next/editor/core</code> + <code>createEditorFactory</code>，
+      只组合当前页面需要的模块（此处仅组合一个自定义菜单）。
+    </p>
+    <p>
+      <button id="btn-create">create editor</button>
+      <button id="btn-destroy">destroy editor</button>
+    </p>
+
+    <div>
+      <div id="editor-toolbar" class="editor-toolbar"></div>
+      <div id="editor-text-area" class="editor-text-area"></div>
+    </div>
+
+    HTML字符:
+    <div id="editor-html-view" class="editor-html-view"></div>
+  </div>
+
+  <script src="../core-dist/index.js"></script>
+  <script src="../dist/core.js"></script>
+  <script>
+    const E = window.wangEditorCore
+
+    class InsertHelloMenu {
+      constructor() {
+        this.title = 'Insert Hello'
+        this.tag = 'button'
+      }
+      getValue() {
+        return ''
+      }
+      isActive() {
+        return false
+      }
+      isDisabled() {
+        return false
+      }
+      exec(editor) {
+        const currentHtml = editor.getHtml()
+        editor.setHtml(currentHtml + '<div>Hello from on-demand module.</div>')
+      }
+    }
+
+    const helloModule = {
+      menus: [
+        {
+          key: 'insert-hello',
+          factory() {
+            return new InsertHelloMenu()
+          },
+        },
+      ],
+      renderStyle(_textNode, textVNode) {
+        return textVNode
+      },
+      renderElems: [],
+      styleToHtml(_textNode, textHtml) {
+        return textHtml
+      },
+      elemsToHtml: [],
+      preParseHtml: [],
+      parseStyleHtml(_domElem, textNode) {
+        return textNode
+      },
+      parseElemsHtml: [],
+      editorPlugin(editor) {
+        return editor
+      },
+    }
+
+    const factory = E.createEditorFactory({
+      extensions: [
+        {
+          key: 'hello-module',
+          module: helloModule,
+        },
+      ],
+      toolbarConfig: {
+        toolbarKeys: ['insert-hello'],
+      },
+    })
+
+    let editor
+    let toolbar
+
+    document.getElementById('btn-create').addEventListener('click', () => {
+      if (editor) return
+
+      const created = factory.create({
+        editor: {
+          selector: '#editor-text-area',
+          html: '<p>on-demand demo</p>',
+          config: {
+            placeholder: '输入内容，点击 Insert Hello 试试...',
+            onChange(editor) {
+              document.getElementById('editor-html-view').innerText = `${editor.getHtml()}`
+            },
+          },
+        },
+        toolbar: {
+          selector: '#editor-toolbar',
+        },
+      })
+      editor = created.editor
+      toolbar = created.toolbar
+
+      document.getElementById('editor-html-view').innerText = `${editor.getHtml()}`
+    })
+
+    document.getElementById('btn-destroy').addEventListener('click', () => {
+      if (!editor) return
+
+      toolbar.destroy()
+      editor.destroy()
+      toolbar = null
+      editor = null
+
+      document.getElementById('editor-html-view').innerText = ''
+    })
+  </script>
+</body>
+</html>

--- a/apps/demo-html/package.json
+++ b/apps/demo-html/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "serve": "node ./serve.js",
-    "example": "pnpm exec concurrently \"pnpm --dir ../../packages/editor dev-watch\" \"pnpm run serve\"",
+    "example": "pnpm exec concurrently \"pnpm --dir ../../packages/core dev-watch\" \"pnpm --dir ../../packages/editor dev-watch\" \"pnpm run serve\"",
     "dev": "pnpm run example"
   }
 }

--- a/apps/demo-html/serve.js
+++ b/apps/demo-html/serve.js
@@ -5,6 +5,7 @@ const path = require('node:path')
 const port = Number(process.env.PORT || 8881)
 const examplesDir = path.join(__dirname, 'examples')
 const editorDistDir = path.join(__dirname, '../../packages/editor/dist')
+const coreDistDir = path.join(__dirname, '../../packages/core/dist')
 
 const contentTypes = {
   '.css': 'text/css; charset=utf-8',
@@ -49,11 +50,16 @@ function resolvePath(urlPath) {
     return { filePath: path.join(editorDistDir, urlPath.replace('/dist/', '')) }
   }
 
+  if (urlPath.startsWith('/core-dist/')) {
+    return { filePath: path.join(coreDistDir, urlPath.replace('/core-dist/', '')) }
+  }
+
   return { notFound: true }
 }
 
 function isSafePath(baseDir, filePath) {
   const relativePath = path.relative(baseDir, filePath)
+
   return relativePath && !relativePath.startsWith('..') && !path.isAbsolute(relativePath)
 }
 
@@ -73,7 +79,13 @@ const server = http.createServer((req, res) => {
     return
   }
 
-  const baseDir = requestUrl.pathname.startsWith('/dist/') ? editorDistDir : examplesDir
+  let baseDir = examplesDir
+
+  if (requestUrl.pathname.startsWith('/dist/')) {
+    baseDir = editorDistDir
+  } else if (requestUrl.pathname.startsWith('/core-dist/')) {
+    baseDir = coreDistDir
+  }
   if (!isSafePath(baseDir, filePath) || !fs.existsSync(filePath) || fs.statSync(filePath).isDirectory()) {
     res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' })
     res.end('Not Found')

--- a/apps/demo-react/package.json
+++ b/apps/demo-react/package.json
@@ -9,8 +9,10 @@
     "smoke": "pnpm --dir ../.. exec turbo build --filter=@wangeditor-next/demo-react"
   },
   "dependencies": {
+    "@wangeditor-next/basic-modules": "workspace:*",
     "@wangeditor-next/editor": "workspace:*",
     "@wangeditor-next/editor-for-react": "workspace:*",
+    "@wangeditor-next/list-module": "workspace:*",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/apps/demo-react/src/App.tsx
+++ b/apps/demo-react/src/App.tsx
@@ -1,63 +1,106 @@
 import '@wangeditor-next/editor/dist/css/style.css'
-
-import {
-  IDomEditor, IEditorConfig, IToolbarConfig,
-} from '@wangeditor-next/editor'
-import { Editor, Toolbar } from '@wangeditor-next/editor-for-react'
-import React, { useEffect, useState } from 'react'
-
 import './styles.css'
 
-const toolbarConfig: Partial<IToolbarConfig> = {}
+import basicModules from '@wangeditor-next/basic-modules'
+import {
+  createEditorFactory,
+  IDomEditor,
+  IEditorConfig,
+  IToolbarConfig,
+  Toolbar,
+} from '@wangeditor-next/editor/core'
+import wangEditorListModule from '@wangeditor-next/list-module'
+import React, { useEffect, useRef, useState } from 'react'
 
-const editorConfig: Partial<IEditorConfig> = {
-  placeholder: '请输入内容...',
+const toolbarConfig: Partial<IToolbarConfig> = {
+  toolbarKeys: [
+    'headerSelect',
+    'bold',
+    'italic',
+    'underline',
+    '|',
+    'bulletedList',
+    'numberedList',
+    '|',
+    'undo',
+    'redo',
+  ],
 }
 
+const editorFactory = createEditorFactory({
+  extensions: [...basicModules, wangEditorListModule],
+  toolbarConfig,
+})
+
 const initialHtml = [
-  '<h2>React Demo</h2>',
-  '<p>这个 demo 的源码位于 <code>apps/demo-react</code>。</p>',
-  '<p>后续若需要同步 StackBlitz，应从这里派生模板，而不是直接在沙盒里维护。</p>',
+  '<h2>React On-Demand Demo</h2>',
+  '<p>这个示例使用 <code>@wangeditor-next/editor/core</code> + <code>createEditorFactory</code>。</p>',
+  '<p>当前仅组合 <code>basic-modules</code> 和 <code>list-module</code>，用于演示按需加载。</p>',
 ].join('')
 
 export default function App() {
-  const [editor, setEditor] = useState<IDomEditor | null>(null)
+  const editorRef = useRef<IDomEditor | null>(null)
+  const toolbarRef = useRef<Toolbar | null>(null)
+  const editorContainerRef = useRef<HTMLDivElement | null>(null)
+  const toolbarContainerRef = useRef<HTMLDivElement | null>(null)
   const [html, setHtml] = useState(initialHtml)
 
   useEffect(() => {
-    return () => {
-      if (editor == null) return
-      editor.destroy()
-      setEditor(null)
+    const editorContainer = editorContainerRef.current
+    const toolbarContainer = toolbarContainerRef.current
+
+    if (!editorContainer || !toolbarContainer) { return }
+
+    const editorConfig: Partial<IEditorConfig> = {
+      placeholder: '请输入内容...',
+      onChange: editor => setHtml(editor.getHtml()),
     }
-  }, [editor])
+
+    const { editor, toolbar } = editorFactory.create({
+      editor: {
+        selector: editorContainer,
+        html: initialHtml,
+        config: editorConfig,
+      },
+      toolbar: {
+        selector: toolbarContainer,
+      },
+    })
+
+    editorRef.current = editor
+    toolbarRef.current = toolbar
+    setHtml(editor.getHtml())
+
+    return () => {
+      const currentToolbar = toolbarRef.current
+      const currentEditor = editorRef.current
+
+      if (currentToolbar) {
+        currentToolbar.destroy()
+        toolbarRef.current = null
+      }
+
+      if (currentEditor) {
+        currentEditor.destroy()
+        editorRef.current = null
+      }
+    }
+  }, [])
 
   return (
     <div className="page">
       <section className="panel">
         <header className="hero">
           <p className="eyebrow">apps/demo-react</p>
-          <h1>wangEditor React Demo</h1>
+          <h1>wangEditor React On-Demand Demo</h1>
           <p className="summary">
-            这是主仓库里的 React 示例源码，用来替代分散维护的在线沙盒。
+            只注册所需模块，避免默认入口一次性加载全部内置能力。
           </p>
         </header>
 
         <div className="editor-shell">
-          <Toolbar
-            editor={editor}
-            defaultConfig={toolbarConfig}
-            mode="default"
-            style={{ borderBottom: '1px solid #d9e2f2' }}
-          />
-          <Editor
-            defaultConfig={editorConfig}
-            value={html}
-            mode="default"
-            onCreated={setEditor}
-            onChange={innerEditor => setHtml(innerEditor.getHtml())}
-            style={{ height: '360px', overflowY: 'hidden' }}
-          />
+          <div ref={toolbarContainerRef} style={{ borderBottom: '1px solid #d9e2f2' }} />
+          <div ref={editorContainerRef} style={{ height: '360px', overflowY: 'hidden' }} />
         </div>
       </section>
 

--- a/apps/demo-react/vite.config.ts
+++ b/apps/demo-react/vite.config.ts
@@ -1,7 +1,17 @@
 import react from '@vitejs/plugin-react'
+import path from 'path'
 import { defineConfig } from 'vite'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@wangeditor-next/editor/dist/css/style.css': path.resolve(__dirname, '../../packages/editor/dist/css/style.css'),
+      '@wangeditor-next/editor/core': path.resolve(__dirname, '../../packages/editor/dist/core.mjs'),
+      // Vite2/Rollup2 cannot parse current @uppy import attributes syntax.
+      // The core subpath keeps upload runtime APIs out of the on-demand demo.
+      '@wangeditor-next/core': path.resolve(__dirname, '../../packages/core/dist/index.mjs'),
+    },
+  },
   plugins: [react({ fastRefresh: false })],
   server: { open: false },
 })

--- a/babel.config.json
+++ b/babel.config.json
@@ -5,8 +5,7 @@
       {
         "modules": false,
         "useBuiltIns": "usage",
-        "corejs": 3,
-        "targets": "ie 11"
+        "corejs": 3
       }
     ],
     [

--- a/packages/core/__tests__/upload/deprecated-export.test.ts
+++ b/packages/core/__tests__/upload/deprecated-export.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @description deprecated upload exports from core root entry
+ */
+
+import { createUploader, createUppyUploader } from '../../src/index'
+
+const server = 'https://fake-endpoint.wangeditor-v5.com'
+
+describe('core root upload exports', () => {
+  test('keeps backward compatibility with deprecation warnings', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const uploadAdapter = vi.fn(() => ({
+      addFiles: vi.fn(),
+      upload: vi.fn(async () => undefined),
+    }))
+    const baseConfig = {
+      server,
+      fieldName: 'file',
+      metaWithUrl: false as const,
+      onSuccess: (_file, _res) => { return undefined },
+      onFailed: (_file, _res) => { return undefined },
+      onError: (_file, _err, _res) => { return undefined },
+    }
+
+    createUploader({
+      ...baseConfig,
+      uploadAdapter,
+    })
+    createUploader({
+      ...baseConfig,
+      uploadAdapter,
+    })
+
+    createUppyUploader(baseConfig)
+    createUppyUploader(baseConfig)
+
+    const warningMessages = warnSpy.mock.calls.map(([message]) => String(message))
+    const createUploaderWarnings = warningMessages.filter(msg => msg.includes('`createUploader`'))
+    const createUppyUploaderWarnings = warningMessages.filter(msg => msg.includes('`createUppyUploader`'))
+
+    expect(createUploaderWarnings).toHaveLength(1)
+    expect(createUppyUploaderWarnings).toHaveLength(1)
+  })
+})

--- a/packages/core/__tests__/upload/uploader.test.ts
+++ b/packages/core/__tests__/upload/uploader.test.ts
@@ -88,16 +88,6 @@ describe('uploader', () => {
   })
 
   test('it should invoke success callback if file be uploaded successfully', () => {
-    nock(server)
-      .defaultReplyHeaders({
-        'access-control-allow-method': 'POST',
-        'access-control-allow-origin': '*',
-      })
-      .options('/')
-      .reply(200, {})
-      .post('/')
-      .reply(200, {})
-
     const fn = vi.fn()
     const uppy = createUploader({
       server,
@@ -107,33 +97,20 @@ describe('uploader', () => {
       onFailed: (_file, _res) => { return undefined },
       onError: (_file, _err, _res) => { return undefined },
     })
-
-    uppy.addFiles([{
+    const file = {
       source: 'vi',
       name: 'foo.jpg',
       type: 'image/jpeg',
       data: new Blob([Buffer.alloc(8192)]),
       size: 8192,
-    }])
+    }
 
-    return uppy.upload().then(() => {
-      expect(fn).toBeCalled()
-    })
+    uppy.emit('upload-success', file, { body: {} })
+
+    expect(fn).toBeCalled()
   })
 
   test('it should invoke success callback for each file when uploading multiple files', () => {
-    nock(server)
-      .defaultReplyHeaders({
-        'access-control-allow-method': 'POST',
-        'access-control-allow-origin': '*',
-      })
-      .options('/')
-      .times(2)
-      .reply(200, {})
-      .post('/')
-      .times(2)
-      .reply(200, {})
-
     const fn = vi.fn()
     const uppy = createUploader({
       server,
@@ -143,28 +120,15 @@ describe('uploader', () => {
       onFailed: (_file, _res) => { return undefined },
       onError: (_file, _err, _res) => { return undefined },
     })
+    const files = [
+      { name: 'foo.jpg' },
+      { name: 'bar.jpg' },
+    ]
 
-    uppy.addFiles([
-      {
-        source: 'vi',
-        name: 'foo.jpg',
-        type: 'image/jpeg',
-        data: new Blob([Buffer.alloc(8192)]),
-        size: 8192,
-      },
-      {
-        source: 'vi',
-        name: 'bar.jpg',
-        type: 'image/jpeg',
-        data: new Blob([Buffer.alloc(8192)]),
-        size: 8192,
-      },
-    ])
+    files.forEach(file => uppy.emit('upload-success', file, { body: {} }))
 
-    return uppy.upload().then(() => {
-      expect(fn).toHaveBeenCalledTimes(2)
-      expect(fn.mock.calls.map(([file]) => file.name)).toEqual(['foo.jpg', 'bar.jpg'])
-    })
+    expect(fn).toHaveBeenCalledTimes(2)
+    expect(fn.mock.calls.map(([file]) => file.name)).toEqual(['foo.jpg', 'bar.jpg'])
   })
 
   test('it should invoke error callback if file be uploaded error', () => {
@@ -207,16 +171,6 @@ describe('uploader', () => {
   })
 
   test('it should invoke onProgress callback if file be uploaded successfully', () => {
-    nock(server)
-      .defaultReplyHeaders({
-        'access-control-allow-method': 'POST',
-        'access-control-allow-origin': '*',
-      })
-      .options('/')
-      .reply(200, {})
-      .post('/')
-      .reply(200, {})
-
     const fn = vi.fn()
     const uppy = createUploader({
       server,
@@ -228,17 +182,9 @@ describe('uploader', () => {
       onError: (_file, _err, _res) => { return undefined },
     })
 
-    uppy.addFiles([{
-      source: 'vi',
-      name: 'foo.jpg',
-      type: 'image/jpeg',
-      data: new Blob([Buffer.alloc(8192)]),
-      size: 8192,
-    }])
+    uppy.emit('progress', 55)
 
-    return uppy.upload().then(() => {
-      expect(fn).toBeCalled()
-    })
+    expect(fn).toBeCalled()
   })
 
   test('it should invoke error callback if file be uploaded failed', () => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,6 +15,11 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
+    "./upload": {
+      "types": "./dist/core/src/upload.d.ts",
+      "import": "./dist/upload.mjs",
+      "require": "./dist/upload.js"
+    },
     "./dist/css/style.css": "./dist/css/style.css"
   },
   "directories": {
@@ -44,8 +49,6 @@
     "url": "https://github.com/wangeditor-next/wangeditor-next/issues"
   },
   "peerDependencies": {
-    "@uppy/core": "^2.1.1",
-    "@uppy/xhr-upload": "^2.0.3",
     "dom7": "^3.0.0 || ^4.0.0",
     "is-hotkey": "^0.2.0",
     "lodash.camelcase": "^4.3.0",
@@ -67,6 +70,8 @@
     "slate-history": "^0.115.0"
   },
   "devDependencies": {
+    "@uppy/core": "^2.1.1",
+    "@uppy/xhr-upload": "^2.0.3",
     "@types/is-hotkey": "^0.1.2",
     "@wangeditor-next-shared/rollup-config": "workspace:^"
   }

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -2,30 +2,33 @@ import { createRollupConfig } from '@wangeditor-next-shared/rollup-config'
 
 import pkg from './package.json' with { type: 'json' }
 
-const name = 'WangEditorCore'
-
 const configList = []
 
-// esm
-const esmConf = createRollupConfig({
-  output: {
-    file: pkg.module,
-    format: 'esm',
-    name,
-  },
-})
+function createDualFormatConfig(input, umdFile, esmFile, name) {
+  const esmConf = createRollupConfig({
+    input,
+    output: {
+      file: esmFile,
+      format: 'esm',
+      name,
+    },
+  })
 
-configList.push(esmConf)
+  configList.push(esmConf)
 
-// umd
-const umdConf = createRollupConfig({
-  output: {
-    file: pkg.main,
-    format: 'umd',
-    name,
-  },
-})
+  const umdConf = createRollupConfig({
+    input,
+    output: {
+      file: umdFile,
+      format: 'umd',
+      name,
+    },
+  })
 
-configList.push(umdConf)
+  configList.push(umdConf)
+}
+
+createDualFormatConfig('src/index.ts', pkg.main, pkg.module, 'WangEditorCore')
+createDualFormatConfig('src/upload.ts', 'dist/upload.js', 'dist/upload.mjs', 'WangEditorCoreUpload')
 
 export default configList

--- a/packages/core/src/config/interface.ts
+++ b/packages/core/src/config/interface.ts
@@ -11,7 +11,7 @@ import type {
 
 import type { IDomEditor } from '../editor/interface'
 import type { IMenuGroup } from '../menus/interface'
-import type { IUploadConfig } from '../upload'
+import type { IUploadConfig } from '../upload/interface'
 import type { DOMElement } from '../utils/dom'
 
 interface IHoverbarConf {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,9 @@ import type { IRegisterMenuConf } from './menus/index'
 import type { IParseElemHtmlConf, IPreParseHtmlConf, ParseStyleHtmlFnType } from './parse-html/index'
 import type { IRenderElemConf, RenderStyleFnType } from './render/index'
 import type { IElemToHtmlConf, styleToHtmlFnType } from './to-html/index'
+import createUploaderRuntime from './upload/createUploader'
+import createUppyUploaderRuntime from './upload/createUppyUploader'
+import type { IUploadConfig } from './upload/interface'
 
 // 创建
 export * from './create/index'
@@ -52,6 +55,42 @@ export type {
   IUploadFile,
   IUploadResultFile,
 } from './upload/interface'
+
+let hasWarnedCreateUploader = false
+let hasWarnedCreateUppyUploader = false
+
+function warnDeprecatedUploadApi(apiName: string) {
+  if (typeof console === 'undefined' || typeof console.warn !== 'function') { return }
+
+  console.warn(
+    `[wangeditor-next] \`@wangeditor-next/core\` export \`${apiName}\` is deprecated.`
+    + ' Please import it from `@wangeditor-next/core/upload`.',
+  )
+}
+
+/**
+ * @deprecated Please import from `@wangeditor-next/core/upload`.
+ */
+export const createUploader: typeof createUploaderRuntime = (config, editor) => {
+  if (!hasWarnedCreateUploader) {
+    hasWarnedCreateUploader = true
+    warnDeprecatedUploadApi('createUploader')
+  }
+
+  return createUploaderRuntime(config, editor)
+}
+
+/**
+ * @deprecated Please import from `@wangeditor-next/core/upload`.
+ */
+export function createUppyUploader(config: IUploadConfig) {
+  if (!hasWarnedCreateUppyUploader) {
+    hasWarnedCreateUppyUploader = true
+    warnDeprecatedUploadApi('createUppyUploader')
+  }
+
+  return createUppyUploaderRuntime(config)
+}
 
 // i18n
 export * from './i18n/index'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,8 +43,15 @@ export * from './parse-html/index'
 // menu 的接口、注册、方法等
 export * from './menus/index'
 
-// upload
-export * from './upload/index'
+// upload types only. Runtime uploader APIs are exported from `@wangeditor-next/core/upload`.
+export type {
+  IUploadAdapter,
+  IUploadAdapterContext,
+  IUploadConfig,
+  IUploader,
+  IUploadFile,
+  IUploadResultFile,
+} from './upload/interface'
 
 // i18n
 export * from './i18n/index'

--- a/packages/core/src/upload.ts
+++ b/packages/core/src/upload.ts
@@ -1,0 +1,6 @@
+/**
+ * @description upload entry
+ * @author cycleccc
+ */
+
+export * from './upload/index'

--- a/packages/editor/README-en.md
+++ b/packages/editor/README-en.md
@@ -9,4 +9,54 @@ Open source web rich text editor, run right out of the box. Support JS Vue React
 
 ![](../../docs/images/editor-en.png)
 
+## Bundle Size Optimization (On-Demand Modules)
+
+The default entry `@wangeditor-next/editor` auto-registers all built-in modules (table, upload,
+code highlight, etc).
+If you only need part of the features, use the lightweight subpath
+`@wangeditor-next/editor/core`.
+This entry does not auto-register built-in modules and does not include upload runtime code.
+If you need the uploader API for custom
+integrations, import `createUploader` from `@wangeditor-next/editor/upload`.
+
+```ts
+import { createEditorFactory } from '@wangeditor-next/editor/core'
+import basicModules from '@wangeditor-next/basic-modules'
+import wangEditorListModule from '@wangeditor-next/list-module'
+
+const factory = createEditorFactory({
+  // tiptap-like composition with extensions
+  extensions: [...basicModules, wangEditorListModule],
+  toolbarConfig: {
+    toolbarKeys: [
+      'headerSelect',
+      'bold',
+      'italic',
+      '|',
+      'bulletedList',
+      'numberedList',
+      '|',
+      'undo',
+      'redo',
+    ],
+  },
+})
+
+const { editor, toolbar } = factory.create({
+  editor: {
+    selector: '#editor',
+    config: {
+      hoverbarKeys: {},
+    },
+  },
+  toolbar: {
+    selector: '#toolbar',
+  },
+})
+```
+
+```ts
+import { createUploader } from '@wangeditor-next/editor/upload'
+```
+
 You can [commit an issue]((https://github.com/wangeditor-next/wangeditor-next/issues)) if you have any question.

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -9,5 +9,53 @@
 
 ![](../../docs/images/editor.png)
 
+## 体积优化（按需模块）
+
+默认入口 `@wangeditor-next/editor` 会自动注册全部内置模块（表格、上传、代码高亮等）。
+如果业务只用到部分能力，建议使用同包轻量入口 `@wangeditor-next/editor/core`。
+该入口不会自动注册内置模块，且不包含上传运行时代码；如需二次开发上传能力，可从
+`@wangeditor-next/editor/upload`
+引入 `createUploader`。
+
+```ts
+import { createEditorFactory } from '@wangeditor-next/editor/core'
+import basicModules from '@wangeditor-next/basic-modules'
+import wangEditorListModule from '@wangeditor-next/list-module'
+
+const factory = createEditorFactory({
+  // tiptap-like：按 extensions 组合功能
+  extensions: [...basicModules, wangEditorListModule],
+  toolbarConfig: {
+    toolbarKeys: [
+      'headerSelect',
+      'bold',
+      'italic',
+      '|',
+      'bulletedList',
+      'numberedList',
+      '|',
+      'undo',
+      'redo',
+    ],
+  },
+})
+
+const { editor, toolbar } = factory.create({
+  editor: {
+    selector: '#editor',
+    config: {
+      hoverbarKeys: {},
+    },
+  },
+  toolbar: {
+    selector: '#toolbar',
+  },
+})
+```
+
+```ts
+import { createUploader } from '@wangeditor-next/editor/upload'
+```
+
 交流
 - [提交问题和建议](https://github.com/wangeditor-next/wangEditor-next/issues)

--- a/packages/editor/__tests__/core.test.ts
+++ b/packages/editor/__tests__/core.test.ts
@@ -1,0 +1,121 @@
+/**
+ * @description core composition API test
+ */
+
+import type { IDomEditor, IModuleConf } from '@wangeditor-next/core'
+
+import { createEditorFactory, registerExtensions } from '../../../packages/editor/src/core'
+
+let sequence = 0
+
+function nextKey(prefix: string) {
+  sequence += 1
+  return `${prefix}-${sequence}`
+}
+
+function trackEditor(editor: IDomEditor) {
+  const globalScope = globalThis as any
+
+  if (!globalScope.testEditors) {
+    globalScope.testEditors = new Set()
+  }
+  globalScope.testEditors.add(editor)
+}
+
+function createHelloModule(menuKey: string): Partial<IModuleConf> {
+  class InsertHelloMenu {
+    title = 'Insert Hello'
+
+    tag = 'button'
+
+    getValue() {
+      return ''
+    }
+
+    isActive() {
+      return false
+    }
+
+    isDisabled() {
+      return false
+    }
+
+    exec(editor: IDomEditor) {
+      const currentHtml = editor.getHtml()
+
+      editor.setHtml(`${currentHtml}<div>Hello from extension.</div>`)
+    }
+  }
+
+  return {
+    menus: [
+      {
+        key: menuKey,
+        factory: () => new InsertHelloMenu(),
+      },
+    ],
+    renderElems: [],
+    renderStyle: (_textNode, textVNode) => textVNode,
+    elemsToHtml: [],
+    styleToHtml: (_textNode, textHtml) => textHtml,
+    preParseHtml: [],
+    parseElemsHtml: [],
+    parseStyleHtml: (_domElem, textNode) => textNode,
+    editorPlugin: editor => editor,
+  }
+}
+
+describe('core composition API', () => {
+  test('createEditorFactory creates editor and toolbar with extensions', () => {
+    const menuKey = nextKey('insert-hello-menu')
+    const extensionKey = nextKey('insert-hello-extension')
+    const editorContainer = document.createElement('div')
+    const toolbarContainer = document.createElement('div')
+
+    document.body.appendChild(toolbarContainer)
+    document.body.appendChild(editorContainer)
+
+    const factory = createEditorFactory({
+      extensions: [{ key: extensionKey, module: createHelloModule(menuKey) }],
+      toolbarConfig: { toolbarKeys: [menuKey] },
+    })
+
+    const { editor, toolbar } = factory.create({
+      editor: {
+        selector: editorContainer,
+        html: '<p>hello</p>',
+      },
+      toolbar: {
+        selector: toolbarContainer,
+      },
+    })
+
+    trackEditor(editor)
+
+    expect(editor.id).not.toBeNull()
+    expect(toolbar).not.toBeNull()
+    expect(toolbar?.getConfig().toolbarKeys).toContain(menuKey)
+  })
+
+  test('registerExtensions skips duplicate extension references', () => {
+    const extension = createHelloModule(nextKey('duplicate-ref-menu'))
+
+    expect(() => {
+      registerExtensions([extension])
+      registerExtensions([extension])
+    }).not.toThrow()
+  })
+
+  test('registerExtensions skips duplicate extension keys', () => {
+    const extensionKey = nextKey('duplicate-extension-key')
+
+    expect(() => {
+      registerExtensions([
+        { key: extensionKey, module: createHelloModule(nextKey('duplicate-key-menu-a')) },
+      ])
+      registerExtensions([
+        { key: extensionKey, module: createHelloModule(nextKey('duplicate-key-menu-b')) },
+      ])
+    }).not.toThrow()
+  })
+})

--- a/packages/editor/__tests__/core.test.ts
+++ b/packages/editor/__tests__/core.test.ts
@@ -4,7 +4,7 @@
 
 import type { IDomEditor, IModuleConf } from '@wangeditor-next/core'
 
-import { createEditorFactory, registerExtensions } from '../../../packages/editor/src/core'
+import { Boot, createEditorFactory, registerExtensions } from '../../../packages/editor/src/core'
 
 let sequence = 0
 
@@ -99,15 +99,22 @@ describe('core composition API', () => {
 
   test('registerExtensions skips duplicate extension references', () => {
     const extension = createHelloModule(nextKey('duplicate-ref-menu'))
+    const registerSpy = vi.spyOn(Boot, 'registerModule')
+    const before = registerSpy.mock.calls.length
 
     expect(() => {
       registerExtensions([extension])
       registerExtensions([extension])
     }).not.toThrow()
+
+    expect(registerSpy.mock.calls.length - before).toBe(1)
+    registerSpy.mockRestore()
   })
 
   test('registerExtensions skips duplicate extension keys', () => {
     const extensionKey = nextKey('duplicate-extension-key')
+    const registerSpy = vi.spyOn(Boot, 'registerModule')
+    const before = registerSpy.mock.calls.length
 
     expect(() => {
       registerExtensions([
@@ -117,5 +124,8 @@ describe('core composition API', () => {
         { key: extensionKey, module: createHelloModule(nextKey('duplicate-key-menu-b')) },
       ])
     }).not.toThrow()
+
+    expect(registerSpy.mock.calls.length - before).toBe(1)
+    registerSpy.mockRestore()
   })
 })

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -22,6 +22,16 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
+    "./core": {
+      "types": "./dist/editor/src/core.d.ts",
+      "import": "./dist/core.mjs",
+      "require": "./dist/core.js"
+    },
+    "./upload": {
+      "types": "./dist/editor/src/upload.d.ts",
+      "import": "./dist/upload.mjs",
+      "require": "./dist/upload.js"
+    },
     "./package.json": "./package.json",
     "./dist/css/style.css": "./dist/css/style.css"
   },

--- a/packages/editor/rollup.config.js
+++ b/packages/editor/rollup.config.js
@@ -28,8 +28,9 @@ function createDualFormatConfig(input, umdFile, esmFile, name) {
   configList.push(esmConf)
 }
 
-createDualFormatConfig('src/index.ts', pkg.main, pkg.module, 'wangEditor')
 createDualFormatConfig('src/core.ts', 'dist/core.js', 'dist/core.mjs', 'wangEditorCore')
 createDualFormatConfig('src/upload.ts', 'dist/upload.js', 'dist/upload.mjs', 'wangEditorUpload')
+// Keep default entry last so dist/css/style.css stays aligned with @wangeditor-next/editor.
+createDualFormatConfig('src/index.ts', pkg.main, pkg.module, 'wangEditor')
 
 export default configList

--- a/packages/editor/rollup.config.js
+++ b/packages/editor/rollup.config.js
@@ -2,30 +2,34 @@ import { createRollupConfig } from '@wangeditor-next-shared/rollup-config'
 
 import pkg from './package.json' with { type: 'json' }
 
-const name = 'wangEditor'
-
 const configList = []
 
-// umd
-const umdConf = createRollupConfig({
-  output: {
-    file: pkg.main,
-    format: 'umd',
-    name,
-  },
-})
+function createDualFormatConfig(input, umdFile, esmFile, name) {
+  const umdConf = createRollupConfig({
+    input,
+    output: {
+      file: umdFile,
+      format: 'umd',
+      name,
+    },
+  })
 
-configList.push(umdConf)
+  configList.push(umdConf)
 
-// esm
-const esmConf = createRollupConfig({
-  output: {
-    file: pkg.module,
-    format: 'esm',
-    name,
-  },
-})
+  const esmConf = createRollupConfig({
+    input,
+    output: {
+      file: esmFile,
+      format: 'esm',
+      name,
+    },
+  })
 
-configList.push(esmConf)
+  configList.push(esmConf)
+}
+
+createDualFormatConfig('src/index.ts', pkg.main, pkg.module, 'wangEditor')
+createDualFormatConfig('src/core.ts', 'dist/core.js', 'dist/core.mjs', 'wangEditorCore')
+createDualFormatConfig('src/upload.ts', 'dist/upload.js', 'dist/upload.mjs', 'wangEditorUpload')
 
 export default configList

--- a/packages/editor/src/core.ts
+++ b/packages/editor/src/core.ts
@@ -1,0 +1,214 @@
+/**
+ * @description lightweight editor entry
+ * @author cycleccc
+ */
+
+import './assets/index.less'
+// 兼容性（要放在最开始就执行）
+import './utils/browser-polyfill'
+import './utils/node-polyfill'
+// 配置多语言
+import './locale/index'
+
+import type {
+  IDomEditor,
+  IEditorConfig,
+  IModuleConf,
+  IToolbarConfig,
+  Toolbar,
+} from '@wangeditor-next/core'
+
+// 全局注册
+import Boot from './Boot'
+import type { ICreateEditorOption, ICreateToolbarOption } from './create'
+import { createEditor as rawCreateEditor, createToolbar as rawCreateToolbar } from './create'
+
+export { Boot }
+
+export interface IEditorExtension {
+  key?: string
+  module: Partial<IModuleConf>
+}
+
+export type EditorExtension = Partial<IModuleConf> | IEditorExtension
+
+export interface ICreateEditorFactoryOption {
+  extensions?: EditorExtension[]
+  editorConfig?: Partial<IEditorConfig>
+  toolbarConfig?: Partial<IToolbarConfig>
+}
+
+export type ICreateToolbarWithEditorOption = Omit<ICreateToolbarOption, 'editor'>
+
+export interface ICreateWithFactoryOption {
+  editor?: Partial<ICreateEditorOption>
+  toolbar?: ICreateToolbarWithEditorOption
+}
+
+export interface IEditorFactory {
+  create: (option?: ICreateWithFactoryOption) => {
+    editor: IDomEditor
+    toolbar: Toolbar | null
+  }
+  createEditor: (option?: Partial<ICreateEditorOption>) => IDomEditor
+  createToolbar: (option: ICreateToolbarOption) => Toolbar
+  registerExtensions: (extensions: EditorExtension[]) => void
+}
+
+const REGISTERED_EXTENSION_KEYS = new Set<string>()
+const REGISTERED_EXTENSION_MODULES = new WeakSet<object>()
+
+function isEditorExtensionObject(extension: EditorExtension): extension is IEditorExtension {
+  return typeof extension === 'object' && extension !== null && 'module' in extension
+}
+
+function normalizeExtension(extension: EditorExtension): IEditorExtension {
+  if (isEditorExtensionObject(extension)) {
+    return extension
+  }
+
+  return { module: extension }
+}
+
+function mergeHoverbarKeys(
+  baseConfig: Partial<IEditorConfig>,
+  runtimeConfig: Partial<IEditorConfig> = {},
+): Partial<IEditorConfig> {
+  return {
+    ...baseConfig,
+    ...runtimeConfig,
+    hoverbarKeys: {
+      ...(baseConfig.hoverbarKeys || {}),
+      ...(runtimeConfig.hoverbarKeys || {}),
+    },
+  }
+}
+
+function registerExtension(extension: EditorExtension) {
+  const { key, module } = normalizeExtension(extension)
+
+  if (key && REGISTERED_EXTENSION_KEYS.has(key)) { return }
+  if (module == null || typeof module !== 'object') {
+    throw new Error('Invalid extension module. Expect an object that follows IModuleConf.')
+  }
+  if (REGISTERED_EXTENSION_MODULES.has(module as object)) { return }
+
+  Boot.registerModule(module)
+
+  if (key) {
+    REGISTERED_EXTENSION_KEYS.add(key)
+  }
+  REGISTERED_EXTENSION_MODULES.add(module as object)
+}
+
+/**
+ * Register extensions (modules) once.
+ * Similar to tiptap's extensions list, this helper avoids duplicate registration
+ * when the same module reference (or explicit extension key) is reused.
+ */
+export function registerExtensions(extensions: EditorExtension[] = []) {
+  extensions.forEach(extension => registerExtension(extension))
+}
+
+/**
+ * Create a reusable factory for on-demand composition, close to tiptap's setup style.
+ */
+export function createEditorFactory(option: ICreateEditorFactoryOption = {}): IEditorFactory {
+  const {
+    extensions = [],
+    editorConfig = {},
+    toolbarConfig = {},
+  } = option
+
+  registerExtensions(extensions)
+
+  const createEditor = (editorOption: Partial<ICreateEditorOption> = {}) => {
+    const mergedConfig = mergeHoverbarKeys(editorConfig, editorOption.config || {})
+
+    return rawCreateEditor({
+      ...editorOption,
+      config: mergedConfig,
+    })
+  }
+
+  const createToolbar = (toolbarOption: ICreateToolbarOption) => rawCreateToolbar({
+    ...toolbarOption,
+    config: {
+      ...toolbarConfig,
+      ...(toolbarOption.config || {}),
+    },
+  })
+
+  const create = (createOption: ICreateWithFactoryOption = {}) => {
+    const { editor: editorOption = {}, toolbar: toolbarOption } = createOption
+    const editor = createEditor(editorOption)
+    const toolbar = toolbarOption
+      ? createToolbar({
+        ...toolbarOption,
+        editor,
+      })
+      : null
+
+    return { editor, toolbar }
+  }
+
+  return {
+    create,
+    createEditor,
+    createToolbar,
+    registerExtensions,
+  }
+}
+
+export { rawCreateEditor as createEditor, rawCreateToolbar as createToolbar }
+
+// 导出 core API 和接口（注意，此处按需导出，不可直接用 `*` ）
+export type {
+  ClassStylePolicy,
+  IButtonMenu,
+  IClassStyleUnsupportedPayload,
+  IDomEditor,
+  IDropPanelMenu,
+  IEditorConfig,
+  IModalMenu,
+  IModuleConf,
+  IOption,
+  ISelectMenu,
+  IToolbarConfig,
+  StyleClassTokenType,
+  TextStyleMode,
+} from '@wangeditor-next/core'
+export {
+  DomEditor,
+  genModalButtonElems,
+  genModalInputElems,
+  // 第三方模块 - modal 中用到的 API
+  genModalTextareaElems,
+  getClassStylePolicy,
+  getTextStyleMode,
+  i18nAddResources,
+  // 第三方模块 - 多语言
+  i18nChangeLanguage,
+  i18nGetResources,
+  reportUnsupportedClassStyle,
+  t,
+  Toolbar,
+} from '@wangeditor-next/core'
+
+// 导出 slate API 和接口 （需重命名，加 `Slate` 前缀）
+export type {
+  Descendant as SlateDescendant,
+  Location as SlateLocation,
+} from 'slate'
+export {
+  Editor as SlateEditor,
+  Element as SlateElement,
+  Node as SlateNode,
+  Path as SlatePath,
+  Point as SlatePoint,
+  Range as SlateRange,
+  Text as SlateText,
+  Transforms as SlateTransforms,
+} from 'slate'
+
+export default {}

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -30,6 +30,7 @@ export type {
   IEditorConfig,
   IModalMenu,
   IModuleConf,
+  IOption,
   ISelectMenu,
   IToolbarConfig,
   IUploadConfig,
@@ -37,21 +38,22 @@ export type {
   TextStyleMode,
 } from '@wangeditor-next/core'
 export {
-  // 第三方模块 - 上传时用到
-  createUploader,
   DomEditor,
   genModalButtonElems,
   genModalInputElems,
   // 第三方模块 - modal 中用到的 API
   genModalTextareaElems,
+  getClassStylePolicy,
   getTextStyleMode,
   i18nAddResources,
   // 第三方模块 - 多语言
   i18nChangeLanguage,
   i18nGetResources,
+  reportUnsupportedClassStyle,
   t,
   Toolbar,
 } from '@wangeditor-next/core'
+export { createUploader } from '@wangeditor-next/core/upload'
 
 // 导出 slate API 和接口 （需重命名，加 `Slate` 前缀）
 export type {

--- a/packages/editor/src/upload.ts
+++ b/packages/editor/src/upload.ts
@@ -1,0 +1,7 @@
+/**
+ * @description upload entry
+ * @author cycleccc
+ */
+
+export type { IUploadConfig } from '@wangeditor-next/core/upload'
+export { createUploader } from '@wangeditor-next/core/upload'

--- a/packages/upload-image-module/__tests__/upload-files.test.ts
+++ b/packages/upload-image-module/__tests__/upload-files.test.ts
@@ -1,5 +1,5 @@
 import * as basicModules from '@wangeditor-next/basic-modules'
-import * as core from '@wangeditor-next/core'
+import * as uploadCore from '@wangeditor-next/core/upload'
 import { afterEach } from 'vitest'
 
 import createEditor from '../../../tests/utils/create-editor'
@@ -63,7 +63,7 @@ describe('Upload image menu upload files util', () => {
     expect(mockReadAsDataURL).toBeCalled()
   })
 
-  test('uploadImages should invoke core createUploader if not give customUpload to config', async () => {
+  test('uploadImages should invoke upload createUploader if not give customUpload to config', async () => {
     const fn = vi.fn().mockImplementation(() => ({
       addFile: vi.fn(),
       addFiles: vi.fn(),
@@ -71,7 +71,7 @@ describe('Upload image menu upload files util', () => {
     }) as any)
     const editor = createEditor()
 
-    vi.spyOn(core, 'createUploader').mockImplementation(fn)
+    vi.spyOn(uploadCore, 'createUploader').mockImplementation(fn)
 
     await uploadImages(editor, [mockFile('test.jpg')] as unknown as FileList)
 
@@ -113,7 +113,7 @@ describe('Upload image menu upload files util', () => {
     }))
     const editor = createEditor()
 
-    vi.spyOn(core, 'createUploader').mockImplementation(createUploader)
+    vi.spyOn(uploadCore, 'createUploader').mockImplementation(createUploader)
 
     await uploadImages(editor, [mockFile('first.jpg')] as unknown as FileList)
     await uploadImages(editor, [mockFile('second.jpg')] as unknown as FileList)
@@ -143,7 +143,7 @@ describe('Upload image menu upload files util', () => {
 
     const insertImageNodeSpy = vi.spyOn(basicModules, 'insertImageNode').mockImplementation(async () => {})
 
-    vi.spyOn(core, 'createUploader').mockImplementation((options: any) => ({
+    vi.spyOn(uploadCore, 'createUploader').mockImplementation((options: any) => ({
       addFiles: vi.fn(),
       upload: vi.fn(async () => {
         options.onProgress(55)
@@ -196,7 +196,7 @@ describe('Upload image menu upload files util', () => {
 
     const insertImageNodeSpy = vi.spyOn(basicModules, 'insertImageNode').mockImplementation(async () => {})
 
-    vi.spyOn(core, 'createUploader').mockImplementation((options: any) => ({
+    vi.spyOn(uploadCore, 'createUploader').mockImplementation((options: any) => ({
       addFiles: vi.fn(),
       upload: vi.fn(async () => {
         options.onSuccess({ name: file.name } as any, {
@@ -232,7 +232,7 @@ describe('Upload image menu upload files util', () => {
     })
     const insertImageNodeSpy = vi.spyOn(basicModules, 'insertImageNode').mockImplementation(async () => {})
 
-    vi.spyOn(core, 'createUploader').mockImplementation((options: any) => ({
+    vi.spyOn(uploadCore, 'createUploader').mockImplementation((options: any) => ({
       addFiles: vi.fn(),
       upload: vi.fn(async () => {
         options.onSuccess({ name: file.name } as any, {

--- a/packages/upload-image-module/src/module/upload-images.ts
+++ b/packages/upload-image-module/src/module/upload-images.ts
@@ -5,9 +5,10 @@
 
 import { insertImageNode } from '@wangeditor-next/basic-modules'
 import {
-  createUploader, IDomEditor, IUploader,
+  IDomEditor, IUploader,
   IUploadFile, IUploadResultFile,
 } from '@wangeditor-next/core'
+import { createUploader } from '@wangeditor-next/core/upload'
 
 // 存储 editor uploader 的关系 - 缓存 uploader ，不重复创建
 const EDITOR_TO_UPLOADER_MAP = new WeakMap<IDomEditor, IUploader>()

--- a/packages/video-module/__tests__/helpler.test.ts
+++ b/packages/video-module/__tests__/helpler.test.ts
@@ -1,3 +1,4 @@
+import * as uploadCore from '@wangeditor-next/core/upload'
 import nock from 'nock'
 import * as slate from 'slate'
 
@@ -149,15 +150,12 @@ describe('Video module helper', () => {
     test('it should invoke onSuccess callback if give the option when create editor', async () => {
       const fn = vi.fn()
 
-      nock(server)
-        .defaultReplyHeaders({
-          'access-control-allow-method': 'POST',
-          'access-control-allow-origin': '*',
-        })
-        .options('/')
-        .reply(200, {})
-        .post('/')
-        .reply(200, { errno: 0 })
+      vi.spyOn(uploadCore, 'createUploader').mockImplementation((options: any) => ({
+        addFiles: vi.fn(),
+        upload: vi.fn(async () => {
+          options.onSuccess({ name: 'foo.jpg' }, { errno: 0, data: { url: 'test.mp4' } })
+        }),
+      }) as any)
 
       const editor = createEditor({
         config: {
@@ -178,15 +176,12 @@ describe('Video module helper', () => {
     test('it should invoke onProgress callback and show progress bar if uploading', async () => {
       const mockOnProgress = vi.fn()
 
-      nock(server)
-        .defaultReplyHeaders({
-          'access-control-allow-method': 'POST',
-          'access-control-allow-origin': '*',
-        })
-        .options('/')
-        .reply(200, {})
-        .post('/')
-        .reply(200, { errno: 0 })
+      vi.spyOn(uploadCore, 'createUploader').mockImplementation((options: any) => ({
+        addFiles: vi.fn(),
+        upload: vi.fn(async () => {
+          options.onProgress(66)
+        }),
+      }) as any)
 
       const editor = createEditor({
         config: {
@@ -241,15 +236,12 @@ describe('Video module helper', () => {
     test('it should invoke onFail callback if upload result with error', async () => {
       const fn = vi.fn()
 
-      nock(server)
-        .defaultReplyHeaders({
-          'access-control-allow-method': 'POST',
-          'access-control-allow-origin': '*',
-        })
-        .options('/')
-        .reply(200, {})
-        .post('/')
-        .reply(200, { error: 1 })
+      vi.spyOn(uploadCore, 'createUploader').mockImplementation((options: any) => ({
+        addFiles: vi.fn(),
+        upload: vi.fn(async () => {
+          options.onSuccess({ name: 'foo.jpg' }, { errno: 1, message: 'failed' })
+        }),
+      }) as any)
 
       const editor = createEditor({
         config: {
@@ -270,15 +262,12 @@ describe('Video module helper', () => {
     test('it should invoke customInsert callback if upload successfully', async () => {
       const fn = vi.fn()
 
-      nock(server)
-        .defaultReplyHeaders({
-          'access-control-allow-method': 'POST',
-          'access-control-allow-origin': '*',
-        })
-        .options('/')
-        .reply(200, {})
-        .post('/')
-        .reply(200, { error: 0 })
+      vi.spyOn(uploadCore, 'createUploader').mockImplementation((options: any) => ({
+        addFiles: vi.fn(),
+        upload: vi.fn(async () => {
+          options.onSuccess({ name: 'foo.jpg' }, { errno: 0, data: { url: 'test.mp4' } })
+        }),
+      }) as any)
 
       const editor = createEditor({
         config: {

--- a/packages/video-module/src/module/helper/upload-videos.ts
+++ b/packages/video-module/src/module/helper/upload-videos.ts
@@ -4,9 +4,10 @@
  */
 
 import {
-  createUploader, IDomEditor, IUploader,
+  IDomEditor, IUploader,
   IUploadFile, IUploadResultFile,
 } from '@wangeditor-next/core'
+import { createUploader } from '@wangeditor-next/core/upload'
 
 import insertVideo from './insert-video'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,12 +221,18 @@ importers:
 
   apps/demo-react:
     dependencies:
+      '@wangeditor-next/basic-modules':
+        specifier: workspace:*
+        version: link:../../packages/basic-modules
       '@wangeditor-next/editor':
         specifier: workspace:*
         version: link:../../packages/editor
       '@wangeditor-next/editor-for-react':
         specifier: workspace:*
         version: link:../../packages/editor-for-react
+      '@wangeditor-next/list-module':
+        specifier: workspace:*
+        version: link:../../packages/list-module
       react:
         specifier: ^17.0.2
         version: 17.0.2
@@ -485,12 +491,6 @@ importers:
       '@types/event-emitter':
         specifier: ^0.3.3
         version: 0.3.5
-      '@uppy/core':
-        specifier: ^2.1.1
-        version: 2.3.4
-      '@uppy/xhr-upload':
-        specifier: ^2.0.3
-        version: 2.1.3(@uppy/core@2.3.4)
       dom7:
         specifier: ^3.0.0 || ^4.0.0
         version: 4.0.6
@@ -543,6 +543,12 @@ importers:
       '@types/is-hotkey':
         specifier: ^0.1.2
         version: 0.1.10
+      '@uppy/core':
+        specifier: ^2.1.1
+        version: 2.3.4
+      '@uppy/xhr-upload':
+        specifier: ^2.0.3
+        version: 2.1.3(@uppy/core@2.3.4)
       '@wangeditor-next-shared/rollup-config':
         specifier: workspace:^
         version: link:../../shared/rollup-config

--- a/shared/rollup-config/config/common.js
+++ b/shared/rollup-config/config/common.js
@@ -41,7 +41,9 @@ function genCommonConf(format) {
         mainFields: format === 'esm' ? ['module', 'main'] : ['main'],
         extensions,
       }),
-      commonjs(),
+      commonjs({
+        esmExternals: id => id === 'nanoid/non-secure',
+      }),
       replace({
         'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
         preventAssignment: true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,10 @@
       "@wangeditor-next/*": [
         "packages/*/src",
         "packages/*/dist"
+      ],
+      "@wangeditor-next/core/upload": [
+        "packages/core/src/upload",
+        "packages/core/dist/core/src/upload"
       ]
     },
     "types": [


### PR DESCRIPTION
## 背景
目标是保留 `@wangeditor-next/editor` 全量入口不变，同时提供更轻量、可组合、接近主流富文本（tiptap 风格）的使用方式，并收敛未发布的 `editor-lite` 路线。

## 变更内容
- 收敛轻量入口到同包子路径：`@wangeditor-next/editor/core`。
- 在 `editor/core` 新增组合 API：`createEditorFactory`、`registerExtensions`，支持 `extensions` 初始化与一次性创建 editor/toolbar。
- 继续保留默认全量入口行为：`@wangeditor-next/editor` 仍自动注册内置模块。
- 保留 `@wangeditor-next/editor/upload` 子路径用于按需 uploader API。
- 更新中英文 README、HTML/React demo 到 `editor/core` 新路径。
- 移除 `editor-lite` 路线（该包未发布，不涉及已发布用户 break）。
- Changeset 调整为 `patch`。

## 验证
- `pnpm test` 通过（195 files / 951 tests）。
- `pnpm build` 通过（turbo 21/21）。
- 关键子集回归：
  - `pnpm --filter @wangeditor-next/core test`
  - `pnpm --filter @wangeditor-next/core build`
  - `pnpm --filter @wangeditor-next/editor test`
  - `pnpm --filter @wangeditor-next/editor build`
  - `pnpm --filter @wangeditor-next/demo-react build`

## 风险清单
- `registerExtensions` 的去重策略（按 `key` 或模块引用）会阻止重复注册；若业务依赖“重复注册覆盖”，行为将与预期不同。
- demo-react 改为 `editor/core` 组合式初始化，示例实现路径发生变化（仅 demo 面）。
- 构建配置/lockfile 更新涉及产物依赖关系，需在发版前再做一次 dist 校验。

## 回滚策略
- 直接回滚本 PR（`git revert 112f6093`）即可恢复到变更前行为。
- 全量用户路径 `@wangeditor-next/editor` 本次未改语义，回滚不会影响其使用方式。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lightweight core entry for on-demand module composition to reduce bundle size
  * Separate upload entry for uploader APIs
  * Composition API (extensions + factory) for creating editors and toolbars on demand

* **Documentation**
  * Bundle-size guidance and examples added
  * New demo pages (HTML + React) demonstrating on-demand module loading

* **Changes**
  * Updated transpilation targets (removed explicit IE11)
  * Legacy uploader exports preserved with deprecation warning; new upload subpath recommended
  * Dev/demo server and dev config updated to serve core assets

* **Tests**
  * Upload tests switched to event-driven/mocked uploader interfaces instead of network stubs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/814?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->