### PR TITLE
fix(core): handle IME select-all composition without DOM mapping crashes

### DIFF
--- a/.changeset/green-chairs-fly.md
+++ b/.changeset/green-chairs-fly.md
@@ -1,0 +1,10 @@
+---
+'@wangeditor-next/core': patch
+'@wangeditor-next/editor': patch
+---
+
+Fix IME composition after select-all so `compositionstart/compositionend` no longer throw
+`Cannot resolve a DOM node from Slate node` in transient Slate-DOM sync windows.
+
+Align selection syncing with Slate behavior by tolerating temporary DOM mapping lag, and
+add an E2E regression case for issue #813 (`select all -> composition input`).

--- a/packages/core/src/editor/dom-editor.ts
+++ b/packages/core/src/editor/dom-editor.ts
@@ -213,6 +213,39 @@ export const DomEditor = {
   },
 
   /**
+   * Check if a Slate node currently has a mapped DOM node.
+   * During IME/composition transitions the Slate tree can update before DOM patching finishes.
+   */
+  hasDOMNodeBySlateNode(editor: IDomEditor, node: Node): boolean {
+    if (Editor.isEditor(node)) {
+      return !!EDITOR_TO_ELEMENT.get(editor)
+    }
+
+    const key = DomEditor.findKey(editor, node)
+
+    return !!KEY_TO_ELEMENT.get(key)
+  },
+
+  /**
+   * Check if both range endpoints can be resolved to DOM nodes right now.
+   */
+  canResolveDOMRange(editor: IDomEditor, range: Range): boolean {
+    try {
+      const [anchorNode] = Editor.node(editor, range.anchor.path)
+      const [focusNode] = Range.isCollapsed(range)
+        ? [anchorNode]
+        : Editor.node(editor, range.focus.path)
+
+      return (
+        DomEditor.hasDOMNodeBySlateNode(editor, anchorNode)
+        && DomEditor.hasDOMNodeBySlateNode(editor, focusNode)
+      )
+    } catch (error) {
+      return false
+    }
+  },
+
+  /**
    * Check if a DOM node is within the editor.
    */
   hasDOMNode(editor: IDomEditor, target: DOMNode, options: { editable?: boolean } = {}): boolean {
@@ -853,6 +886,10 @@ export const DomEditor = {
     for (const nodeEntry of nodeEntries) {
       if (nodeEntry != null) {
         const n = nodeEntry[0]
+
+        if (!DomEditor.hasDOMNodeBySlateNode(editor, n)) {
+          continue
+        }
         const elem = DomEditor.toDOMNode(editor, n)
 
         // 只遍历 elem 范围，考虑性能

--- a/packages/core/src/text-area/event-handlers/composition.ts
+++ b/packages/core/src/text-area/event-handlers/composition.ts
@@ -23,6 +23,14 @@ import TextArea from '../TextArea'
 const EDITOR_TO_TEXT: WeakMap<IDomEditor, string> = new WeakMap()
 const EDITOR_TO_START_CONTAINER: WeakMap<IDomEditor, DOMNode> = new WeakMap()
 
+function getDOMRangeIfReady(editor: IDomEditor, selection: Range) {
+  if (!DomEditor.canResolveDOMRange(editor, selection)) {
+    return null
+  }
+
+  return DomEditor.toDOMRange(editor, selection)
+}
+
 function areBothTextNodes(editor, selection) {
   if (Range.isCollapsed(selection)) {
     const { anchor, focus } = selection
@@ -62,6 +70,19 @@ export function handleCompositionStart(e: Event, textarea: TextArea, editor: IDo
 
   const { selection } = editor
 
+  if (selection && Range.isCollapsed(selection)) {
+    // Capture the current DOM text node before mutating Slate content.
+    const domRange = getDOMRangeIfReady(editor, selection)
+
+    if (domRange) {
+      const startContainer = domRange.startContainer
+      const curText = startContainer.textContent || ''
+
+      EDITOR_TO_TEXT.set(editor, curText)
+      EDITOR_TO_START_CONTAINER.set(editor, startContainer)
+    }
+  }
+
   if (selection && Range.isExpanded(selection)) {
     Editor.deleteFragment(editor)
 
@@ -72,18 +93,6 @@ export function handleCompositionStart(e: Event, textarea: TextArea, editor: IDo
       // restoreSelection 会对比前后 model 选区是否相同，相同就不更新了
       editorSelectionToDOM(textarea, editor, true)
     })
-  }
-
-  if (editor.selection) {
-    // 记录下 dom text ，以便触发 maxLength 时使用
-    const domRange = DomEditor.toDOMRange(editor, editor.selection)
-    const startContainer = domRange.startContainer
-    const curText = startContainer.textContent || ''
-
-    EDITOR_TO_TEXT.set(editor, curText)
-
-    // 记录下 dom range startContainer
-    EDITOR_TO_START_CONTAINER.set(editor, startContainer)
   }
   textarea.isComposing = true
 
@@ -163,9 +172,9 @@ export function handleCompositionEnd(e: Event, textarea: TextArea, editor: IDomE
     const leftLengthOfMaxLength = DomEditor.getLeftLengthOfMaxLength(editor)
 
     if (leftLengthOfMaxLength < data.length) {
-      const domRange = DomEditor.toDOMRange(editor, selection)
+      const domRange = getDOMRangeIfReady(editor, selection)
 
-      if (domRange.startContainer.nodeType === Node.TEXT_NODE) {
+      if (domRange && domRange.startContainer.nodeType === Node.TEXT_NODE) {
         domRange.startContainer.textContent = EDITOR_TO_TEXT.get(editor) || ''
       }
       if (leftLengthOfMaxLength > 0) {
@@ -182,10 +191,14 @@ export function handleCompositionEnd(e: Event, textarea: TextArea, editor: IDomE
     const domSelection = root.getSelection()
 
     if (domSelection && areBothTextNodes(editor, selection)) {
-      editor.selection = DomEditor.toSlateRange(editor, domSelection, {
+      const slateRange = DomEditor.toSlateRange(editor, domSelection, {
         exactMatch: false,
         suppressThrow: false,
       })
+
+      if (slateRange) {
+        editor.selection = slateRange
+      }
     }
     Editor.insertText(editor, data)
   }
@@ -199,7 +212,10 @@ export function handleCompositionEnd(e: Event, textarea: TextArea, editor: IDomE
       const oldStartContainer = EDITOR_TO_START_CONTAINER.get(editor) // 拼音输入开始时的 text node
 
       if (oldStartContainer == null) { return }
-      const curStartContainer = DomEditor.toDOMRange(editor, setTimeoutSelection).startContainer // 拼音输入结束时的 text node
+      const domRange = getDOMRangeIfReady(editor, setTimeoutSelection)
+
+      if (domRange == null) { return }
+      const curStartContainer = domRange.startContainer // 拼音输入结束时的 text node
 
       if (curStartContainer === oldStartContainer) {
         // 拼音输入的开始和结束，都在同一个 text node ，则不做处理

--- a/packages/core/src/text-area/syncSelection.ts
+++ b/packages/core/src/text-area/syncSelection.ts
@@ -8,7 +8,7 @@ import { Range, Transforms } from 'slate'
 
 import { DomEditor } from '../editor/dom-editor'
 import { IDomEditor } from '../editor/interface'
-import { DOMElement } from '../utils/dom'
+import { DOMElement, DOMRange } from '../utils/dom'
 import { IS_FIREFOX } from '../utils/ua'
 import {
   EDITOR_TO_ELEMENT,
@@ -106,7 +106,7 @@ export function editorSelectionToDOM(textarea: TextArea, editor: IDomEditor, foc
   if (selection && !DomEditor.hasRange(editor, selection)) {
     editor.selection = DomEditor.toSlateRange(editor, domSelection, {
       exactMatch: false,
-      suppressThrow: false,
+      suppressThrow: true,
     })
     return
   }
@@ -114,7 +114,16 @@ export function editorSelectionToDOM(textarea: TextArea, editor: IDomEditor, foc
   // Otherwise the DOM selection is out of sync, so update it.
   textarea.isUpdatingSelection = true
 
-  const newDomRange = selection && DomEditor.toDOMRange(editor, selection)
+  let newDomRange: DOMRange | null = null
+
+  try {
+    newDomRange = selection && DomEditor.toDOMRange(editor, selection)
+  } catch (error) {
+    // Align with Slate Editable behavior: during composition the Slate tree can
+    // briefly lead DOM mapping updates, so selection sync should tolerate that
+    // transient mismatch and retry on subsequent updates.
+    newDomRange = null
+  }
 
   if (newDomRange) {
     if (Range.isBackward(selection!)) {

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -94,6 +94,50 @@ test.describe('Basic Editor', () => {
     await expect(page.getByTestId('editor-html')).toContainText('e2e-text')
   })
 
+  test('regression #813: select-all then composition should not throw and should hide placeholder', async ({ page }) => {
+    const pageErrors: string[] = []
+
+    page.on('pageerror', err => {
+      pageErrors.push(err?.message || String(err))
+    })
+
+    await typeInEditor(page, 'abc')
+    await selectAll(page)
+
+    await page.evaluate(() => {
+      const el = document.querySelector('[data-testid="editor-textarea"] [contenteditable="true"]')
+
+      if (!el) {
+        throw new Error('editable not found')
+      }
+
+      const fire = (event: Event) => el.dispatchEvent(event)
+
+      fire(new CompositionEvent('compositionstart', { data: '' }))
+      fire(new InputEvent('beforeinput', {
+        inputType: 'insertCompositionText',
+        data: 'ni',
+        bubbles: true,
+        cancelable: true,
+      }))
+      fire(new InputEvent('input', {
+        inputType: 'insertCompositionText',
+        data: 'ni',
+        bubbles: true,
+      }))
+      fire(new CompositionEvent('compositionupdate', { data: 'ni' }))
+      fire(new CompositionEvent('compositionend', { data: '你' }))
+    })
+
+    await page.waitForTimeout(500)
+
+    const placeholder = page.locator('.w-e-text-placeholder')
+
+    await expect(placeholder).toBeHidden()
+    await expect(page.getByTestId('editor-html')).toContainText('<p>你</p>')
+    expect(pageErrors).toEqual([])
+  })
+
   test('does not execute script when importing untrusted html', async ({ page }) => {
     const dialogs: string[] = []
 


### PR DESCRIPTION
## Summary
- fix IME `select all -> composition` flow that could throw `Cannot resolve a DOM node from Slate node` (#813)
- align selection sync behavior with Slate's transient DOM-mismatch handling
- add an e2e regression case in `tests/e2e/editor.spec.ts` for issue #813
- add a changeset for `@wangeditor-next/core` and `@wangeditor-next/editor`

## Root Cause
During IME composition after full-selection delete, Slate model updates can briefly lead DOM mapping updates.
Some code paths still tried to resolve DOM nodes/ranges synchronously from fresh Slate nodes and threw.

## Implementation
- add `DomEditor.hasDOMNodeBySlateNode` and `DomEditor.canResolveDOMRange`
- guard composition DOM-range reads with mapping-availability checks
- skip exposed-text cleanup for nodes whose DOM mapping is not ready yet
- make selection syncing tolerate transient `toDOMRange` failures (same strategy as Slate Editable)

## Validation
- `pnpm exec eslint packages/core/src/editor/dom-editor.ts packages/core/src/text-area/event-handlers/composition.ts packages/core/src/text-area/syncSelection.ts tests/e2e/editor.spec.ts`
- `pnpm test packages/core/__tests__/text-area/event-handlers/composition.test.ts`
- `pnpm exec playwright test tests/e2e/editor.spec.ts --project=chromium --grep "regression #813" --reporter=list`
- `pnpm turbo build --filter=@wangeditor-next/editor`

## Notes
Plate currently renders `Editable` from `slate-react` directly, so this change follows Slate's handling model for composition/selection sync timing.
