### PR TITLE
fix(core): align IME composition boundary handling for issue #793

### DIFF
--- a/.changeset/fuzzy-lions-trick.md
+++ b/.changeset/fuzzy-lions-trick.md
@@ -1,0 +1,12 @@
+---
+'@wangeditor-next/core': patch
+'@wangeditor-next/editor': patch
+---
+
+Fix IME composition stability for long-text Chinese input (issue #793) by
+capturing native DOM selection containers directly during composition
+boundaries instead of converting Slate ranges in transient sync windows.
+
+Align the composition flow with Slate-style handling to avoid
+`Cannot resolve a DOM point from Slate point` errors, and add regression
+coverage for repeated composition commits on long text.

--- a/packages/core/__tests__/text-area/event-handlers/composition.test.ts
+++ b/packages/core/__tests__/text-area/event-handlers/composition.test.ts
@@ -114,7 +114,12 @@ describe('composition handlers', () => {
     vi.spyOn(DomEditor, 'cleanExposedTexNodeInSelectionBlock').mockImplementation(() => {})
     vi.spyOn(DomEditor, 'setNewKey').mockImplementation(() => {})
     vi.spyOn(DomEditor, 'getLeftLengthOfMaxLength').mockReturnValue(1)
-    vi.spyOn(DomEditor, 'toDOMRange').mockReturnValue({ startContainer } as any)
+    vi.spyOn(DomEditor, 'findDocumentOrShadowRoot').mockReturnValue({
+      getSelection: () => ({
+        rangeCount: 1,
+        getRangeAt: () => ({ startContainer }),
+      }),
+    } as any)
     vi.spyOn(Editor, 'node').mockImplementation((_ed, path) => {
       if (path.length === 1) {
         return [paragraph, path] as any
@@ -127,6 +132,36 @@ describe('composition handlers', () => {
 
     expect(DomEditor.cleanExposedTexNodeInSelectionBlock).toHaveBeenCalledWith(editor)
     expect(DomEditor.setNewKey).toHaveBeenCalledWith(paragraph)
+    expect(Editor.insertText).toHaveBeenCalledWith(editor, 'a')
+    expect(textarea.changeViewState).toHaveBeenCalled()
+  })
+
+  it('handles composition end with maxLength when DOM selection cannot be resolved', () => {
+    const paragraph = { type: 'paragraph', children: [{ text: 'x' }] }
+    const codeNode = { type: 'code', children: [{ text: 'y' }] }
+    const editor = {
+      selection: createSelection(false),
+      getConfig: () => ({ maxLength: 2 }),
+    } as any
+    const textarea = { changeViewState: vi.fn() } as any
+    const event = { target: {}, data: 'abc' } as any
+
+    vi.spyOn(helpers, 'hasEditableTarget').mockReturnValue(true)
+    vi.spyOn(DomEditor, 'cleanExposedTexNodeInSelectionBlock').mockImplementation(() => {})
+    vi.spyOn(DomEditor, 'setNewKey').mockImplementation(() => {})
+    vi.spyOn(DomEditor, 'getLeftLengthOfMaxLength').mockReturnValue(1)
+    vi.spyOn(DomEditor, 'findDocumentOrShadowRoot').mockImplementation(() => {
+      throw new Error('dom root not mounted')
+    })
+    vi.spyOn(Editor, 'node').mockImplementation((_ed, path) => {
+      if (path.length === 1) {
+        return [paragraph, path] as any
+      }
+      return [codeNode, path] as any
+    })
+    vi.spyOn(Editor, 'insertText').mockImplementation(() => {})
+
+    expect(() => handleCompositionEnd(event, textarea, editor)).not.toThrow()
     expect(Editor.insertText).toHaveBeenCalledWith(editor, 'a')
     expect(textarea.changeViewState).toHaveBeenCalled()
   })
@@ -251,11 +286,19 @@ describe('composition handlers', () => {
     const event = { target: {}, data: '拼' } as any
 
     vi.spyOn(helpers, 'hasEditableTarget').mockReturnValue(true)
-    vi.spyOn(DomEditor, 'toDOMRange')
-      .mockReturnValueOnce({ startContainer: oldStartContainer } as any)
-      .mockReturnValueOnce({ startContainer: currentStartContainer } as any)
+    const getSelection = vi.fn()
+      .mockReturnValueOnce({
+        rangeCount: 1,
+        getRangeAt: () => ({ startContainer: oldStartContainer }),
+      })
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce({
+        rangeCount: 1,
+        getRangeAt: () => ({ startContainer: currentStartContainer }),
+      })
+
+    vi.spyOn(DomEditor, 'findDocumentOrShadowRoot').mockReturnValue({ getSelection } as any)
     vi.spyOn(DomEditor, 'cleanExposedTexNodeInSelectionBlock').mockImplementation(() => {})
-    vi.spyOn(DomEditor, 'findDocumentOrShadowRoot').mockReturnValue({ getSelection: () => null } as any)
     vi.spyOn(Editor, 'node').mockImplementation((_ed, path) => {
       if (JSON.stringify(path) === JSON.stringify([0])) {
         return [paragraph, path] as any
@@ -271,6 +314,7 @@ describe('composition handlers', () => {
     vi.runAllTimers()
 
     expect(oldStartContainer.textContent).toBe('before')
+    expect(getSelection).toHaveBeenCalledTimes(3)
     expect(Editor.insertText).toHaveBeenCalledWith(editor, '拼')
   })
 })

--- a/packages/core/src/text-area/event-handlers/composition.ts
+++ b/packages/core/src/text-area/event-handlers/composition.ts
@@ -23,12 +23,26 @@ import TextArea from '../TextArea'
 const EDITOR_TO_TEXT: WeakMap<IDomEditor, string> = new WeakMap()
 const EDITOR_TO_START_CONTAINER: WeakMap<IDomEditor, DOMNode> = new WeakMap()
 
-function getDOMRangeIfReady(editor: IDomEditor, selection: Range) {
-  if (!DomEditor.canResolveDOMRange(editor, selection)) {
+function getDOMSelectionStartContainer(editor: IDomEditor): DOMNode | null {
+  let root: Document | ShadowRoot
+
+  try {
+    root = DomEditor.findDocumentOrShadowRoot(editor)
+  } catch (error) {
     return null
   }
 
-  return DomEditor.toDOMRange(editor, selection)
+  const domSelection = root.getSelection()
+
+  if (!domSelection || domSelection.rangeCount <= 0) {
+    return null
+  }
+
+  try {
+    return domSelection.getRangeAt(0).startContainer
+  } catch (error) {
+    return null
+  }
 }
 
 function areBothTextNodes(editor, selection) {
@@ -71,11 +85,11 @@ export function handleCompositionStart(e: Event, textarea: TextArea, editor: IDo
   const { selection } = editor
 
   if (selection && Range.isCollapsed(selection)) {
-    // Capture the current DOM text node before mutating Slate content.
-    const domRange = getDOMRangeIfReady(editor, selection)
+    // Align with Slate: use native DOM selection snapshot for composition
+    // transitions, avoiding stale Slate->DOM mapping windows.
+    const startContainer = getDOMSelectionStartContainer(editor)
 
-    if (domRange) {
-      const startContainer = domRange.startContainer
+    if (startContainer) {
       const curText = startContainer.textContent || ''
 
       EDITOR_TO_TEXT.set(editor, curText)
@@ -172,10 +186,10 @@ export function handleCompositionEnd(e: Event, textarea: TextArea, editor: IDomE
     const leftLengthOfMaxLength = DomEditor.getLeftLengthOfMaxLength(editor)
 
     if (leftLengthOfMaxLength < data.length) {
-      const domRange = getDOMRangeIfReady(editor, selection)
+      const startContainer = getDOMSelectionStartContainer(editor)
 
-      if (domRange && domRange.startContainer.nodeType === Node.TEXT_NODE) {
-        domRange.startContainer.textContent = EDITOR_TO_TEXT.get(editor) || ''
+      if (startContainer && startContainer.nodeType === Node.TEXT_NODE) {
+        startContainer.textContent = EDITOR_TO_TEXT.get(editor) || ''
       }
       if (leftLengthOfMaxLength > 0) {
         // 剩余长度 >0 ，但小于 data 长度，截取一部分插入
@@ -212,10 +226,9 @@ export function handleCompositionEnd(e: Event, textarea: TextArea, editor: IDomE
       const oldStartContainer = EDITOR_TO_START_CONTAINER.get(editor) // 拼音输入开始时的 text node
 
       if (oldStartContainer == null) { return }
-      const domRange = getDOMRangeIfReady(editor, setTimeoutSelection)
+      const curStartContainer = getDOMSelectionStartContainer(editor)
 
-      if (domRange == null) { return }
-      const curStartContainer = domRange.startContainer // 拼音输入结束时的 text node
+      if (curStartContainer == null) { return } // 拼音输入结束时的 text node
 
       if (curStartContainer === oldStartContainer) {
         // 拼音输入的开始和结束，都在同一个 text node ，则不做处理

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -138,6 +138,60 @@ test.describe('Basic Editor', () => {
     expect(pageErrors).toEqual([])
   })
 
+  test('regression #793: repeated composition on long text should not throw DOM point error', async ({ page }) => {
+    const pageErrors: string[] = []
+
+    page.on('pageerror', err => {
+      pageErrors.push(err?.stack || err?.message || String(err))
+    })
+
+    await typeInEditor(page, 'abcdefghijklmnopqrstuvwxyz1234')
+
+    await page.evaluate(() => {
+      const el = document.querySelector('[data-testid="editor-textarea"] [contenteditable="true"]')
+
+      if (!el) {
+        throw new Error('editable not found')
+      }
+
+      const fire = (event: Event) => el.dispatchEvent(event)
+      const seq: Array<{ pinyin: string, text: string }> = [
+        { pinyin: 'ni', text: '你' },
+        { pinyin: 'hao', text: '好' },
+        { pinyin: 'zhong', text: '中' },
+        { pinyin: 'wen', text: '文' },
+        { pinyin: 'shu', text: '输' },
+        { pinyin: 'ru', text: '入' },
+      ]
+
+      for (const item of seq) {
+        fire(new CompositionEvent('compositionstart', { data: '' }))
+        fire(new InputEvent('beforeinput', {
+          inputType: 'insertCompositionText',
+          data: item.pinyin,
+          bubbles: true,
+          cancelable: true,
+        }))
+        fire(new InputEvent('input', {
+          inputType: 'insertCompositionText',
+          data: item.pinyin,
+          bubbles: true,
+        }))
+        fire(new CompositionEvent('compositionupdate', { data: item.pinyin }))
+        fire(new CompositionEvent('compositionend', { data: item.text }))
+      }
+    })
+
+    await page.waitForTimeout(800)
+
+    await expect(page.getByTestId('editor-html')).toContainText('abcdefghijklmnopqrstuvwxyz1234')
+    await expect(page.getByTestId('editor-html')).toContainText('你好中文输入')
+
+    const domPointErrors = pageErrors.filter(msg => msg.includes('Cannot resolve a DOM point from Slate point'))
+
+    expect(domPointErrors).toEqual([])
+  })
+
   test('does not execute script when importing untrusted html', async ({ page }) => {
     const dialogs: string[] = []
 


### PR DESCRIPTION
## Summary
- fix issue #793 by aligning IME composition boundary handling with Slate-style native DOM selection snapshots
- stop converting Slate ranges to DOM ranges at fragile composition windows, which caused transient `Cannot resolve a DOM point from Slate point`
- keep insertion behavior unchanged while making DOM selection reads resilient when editor DOM mapping is temporarily unavailable
- add regression coverage for repeated Chinese composition on long text

## Root Cause
During compositionstart/compositionend, Slate model and DOM tree can be temporarily out of sync. Converting current Slate selection back to DOM (toDOMRange) in that window can throw (`Cannot resolve a DOM point from Slate point`).

## Fix Details
- `composition.ts` now captures composition boundary start containers from native DOM selection (`getSelection().getRangeAt(0).startContainer`)
- this mirrors Slate/Plate direction at composition boundaries: rely on native DOM selection snapshot instead of forcing a stale Slate->DOM mapping
- safely return `null` when host DOM root/selection is not available instead of throwing

## Regression Coverage
- updated unit tests in `packages/core/__tests__/text-area/event-handlers/composition.test.ts`
- added e2e case in `tests/e2e/editor.spec.ts`:
  - regression #793: repeated composition on long text should not throw DOM point error

## Verification
- `pnpm test packages/core/__tests__/text-area/event-handlers/composition.test.ts`
- `pnpm exec playwright test tests/e2e/editor.spec.ts --project=chromium --grep "regression #813|regression #793" --reporter=list`
- `pnpm exec eslint packages/core/src/text-area/event-handlers/composition.ts packages/core/__tests__/text-area/event-handlers/composition.test.ts tests/e2e/editor.spec.ts`
- `pnpm build`

Closes #793


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed IME composition stability issue when inputting long Chinese text, preventing "Cannot resolve a DOM point" errors during repeated composition events.

* **Tests**
  * Added regression test to ensure long-text Chinese input remains stable with IME interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/817?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->