### PR TITLE
fix(table-module): align row resize hotspot with rendered row height

### DIFF
--- a/.changeset/itchy-pens-relax.md
+++ b/.changeset/itchy-pens-relax.md
@@ -1,0 +1,10 @@
+---
+'@wangeditor-next/table-module': patch
+'@wangeditor-next/editor': patch
+---
+
+Fix table row-resize hotspot alignment after table cell content expands.
+
+The row resize UI now follows real DOM row heights (captured via table resize
+observation) instead of stale model defaults, so hovering and dragging the row
+bottom border stays accurate even when a cell grows taller from wrapped text.

--- a/packages/table-module/src/module/column-resize.ts
+++ b/packages/table-module/src/module/column-resize.ts
@@ -41,18 +41,31 @@ export function getColumnWidthRatios(columnWidths: number[]) {
  */
 let resizeObserver: ResizeObserver | null = null
 
+function getTableRowHeights(table: Element): number[] {
+  const tableRows = Array.from(table.querySelectorAll('tr'))
+
+  return tableRows.map(row => {
+    const rowRect = row.getBoundingClientRect()
+
+    return Math.max(1, Math.round(rowRect.height * 100) / 100)
+  })
+}
+
 export function observerTableResize(editor: IDomEditor, elm: Node | undefined) {
   if (isHTMLElememt(elm)) {
     const table = elm.querySelector('table')
 
     if (table) {
       resizeObserver = new ResizeObserver(([{ contentRect }]) => {
+        const rowHeights = getTableRowHeights(table)
+
         // 当非拖动引起的宽度变化，需要调整 columnWidths
         Transforms.setNodes(
           editor,
           {
             scrollWidth: contentRect.width,
             height: contentRect.height,
+            rowHeights,
           } as TableElement,
           { mode: 'highest' },
         )

--- a/packages/table-module/src/module/custom-types.ts
+++ b/packages/table-module/src/module/custom-types.ts
@@ -50,4 +50,5 @@ export type TableElement = {
   resizingRowIndex?: number // 用于标记正在调整的行索引
   isResizingRow?: boolean | null // 用于设置行 resize-bar 的 highlight 属性
   isHoverRowBorder?: boolean // 用于设置行 resize-bar 的 visible 属性
+  rowHeights?: number[] // 实际 DOM 行高快照（仅用于行拖拽热区与 UI 对齐）
 }

--- a/packages/table-module/src/module/render-elem/render-table.tsx
+++ b/packages/table-module/src/module/render-elem/render-table.tsx
@@ -69,6 +69,7 @@ function renderTable(elemNode: SlateElement, children: VNode[] | null, editor: I
     width: tableWidth = 'auto',
     height,
     columnWidths = [],
+    rowHeights = [],
     scrollWidth = 0,
     isHoverCellBorder,
     resizingIndex,
@@ -197,7 +198,10 @@ function renderTable(elemNode: SlateElement, children: VNode[] | null, editor: I
       <div className="row-resizer" contentEditable={false}>
         {(elemNode as TableElement).children.map((rowNode, index) => {
           const totalTableWidth = columnWidths.reduce((a, b) => a + b, 0)
-          const rowHeight = (rowNode as TableRowElement).height || 30
+          const rowHeightFromObserver = rowHeights[index]
+          const rowHeight = Number.isFinite(rowHeightFromObserver) && rowHeightFromObserver > 0
+            ? rowHeightFromObserver
+            : (rowNode as TableRowElement).height || 30
 
           return (
             <div className="row-resizer-item" style={{ minHeight: `${rowHeight}px` }}>

--- a/packages/table-module/src/module/row-resize.ts
+++ b/packages/table-module/src/module/row-resize.ts
@@ -35,6 +35,21 @@ function getCumulativeHeights(rowHeights: number[]) {
   return cumulativeHeights
 }
 
+function getRowHeightsForResize(tableNode: TableElement): number[] {
+  const { children: tableRows, rowHeights = [] } = tableNode
+
+  const hasValidSnapshot = (
+    rowHeights.length === tableRows.length
+    && rowHeights.every(height => Number.isFinite(height) && height > 0)
+  )
+
+  if (hasValidSnapshot) {
+    return rowHeights
+  }
+
+  return tableRows.map(row => (row as TableRowElement).height || 30)
+}
+
 // 行拖拽相关状态
 let isMouseDownForRowResize = false
 let clientYWhenMouseDown = 0
@@ -107,14 +122,15 @@ function onMouseMoveForRowHandler(event: Event) {
   const [[elemNode]] = Editor.nodes(editorWhenMouseDownForRow, {
     match: isOfType(editorWhenMouseDownForRow, 'table'),
   })
-  const { children: tableRows, resizingRowIndex = -1 } = elemNode as TableElement
+  const tableNode = elemNode as TableElement
+  const { resizingRowIndex = -1 } = tableNode
 
-  // 从实际行元素获取高度
-  const rowHeights = tableRows.map(row => (row as TableRowElement).height || 30)
+  // 优先使用 ResizeObserver 采集到的真实 DOM 行高
+  const rowHeights = getRowHeightsForResize(tableNode)
 
   let adjustRowHeights: number[]
-  const tableNode = DomEditor.getSelectedNodeByType(editorWhenMouseDownForRow, 'table') as TableElement
-  const tableDom = DomEditor.toDOMNode(editorWhenMouseDownForRow, tableNode)
+  const selectedTableNode = DomEditor.getSelectedNodeByType(editorWhenMouseDownForRow, 'table') as TableElement
+  const tableDom = DomEditor.toDOMNode(editorWhenMouseDownForRow, selectedTableNode)
 
   const tableElement = tableDom.querySelector('.table')
 
@@ -176,11 +192,8 @@ export function handleRowBorderVisible(
   if (editor.isDisabled()) { return }
   if (isMouseDownForRowResize) { return }
 
-  const {
-    children: tableRows,
-    isHoverRowBorder,
-    resizingRowIndex,
-  } = elemNode as TableElement
+  const tableNode = elemNode as TableElement
+  const { isHoverRowBorder, resizingRowIndex } = tableNode
 
   const { target } = e
 
@@ -191,8 +204,8 @@ export function handleRowBorderVisible(
       const { clientY: mouseY } = e
       const rect = parent.getBoundingClientRect()
 
-      // 从实际行元素获取高度
-      const actualRowHeights = tableRows.map(row => (row as TableRowElement).height || 30)
+      // 优先使用 ResizeObserver 采集到的真实 DOM 行高
+      const actualRowHeights = getRowHeightsForResize(tableNode)
       const cumulativeHeights = getCumulativeHeights(actualRowHeights)
 
       // 鼠标移动时，计算当前鼠标位置，判断在哪个行边界上

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -287,6 +287,91 @@ test.describe('Basic Editor', () => {
     ).toHaveCount(1)
   })
 
+  test('regression #811: row resize hotzone should follow rendered row border after content expands', async ({ page }) => {
+    await clearEditor(page)
+    await page.keyboard.type('table-resize-probe')
+
+    await waitForMenuEnabled(page, 'insertTable')
+    await getToolbarMenu(page, 'insertTable').click()
+    await page.locator('.w-e-panel-content-table').waitFor({ state: 'visible' })
+    await page.locator('.w-e-panel-content-table td[data-x="1"][data-y="1"]').click()
+
+    await page.locator('[data-testid="editor-textarea"] table tr')
+      .first()
+      .locator('th, td')
+      .first()
+      .click()
+    await page.keyboard.type('这是用于复现811的超长文本'.repeat(20))
+    await page.waitForTimeout(500)
+
+    const metrics = await page.evaluate(() => {
+      const table = document.querySelector('[data-testid="editor-textarea"] table.table') as HTMLElement | null
+      const rows = Array.from(document.querySelectorAll('[data-testid="editor-textarea"] table tr')) as HTMLElement[]
+      const editor = (window as any).wangEditorExampleBridge?.editor
+
+      if (!table || rows.length < 2 || !editor) {
+        throw new Error('table/rows/editor not ready')
+      }
+      table.scrollIntoView({ block: 'center', inline: 'nearest' })
+
+      const tableNode = editor.children.find((n: any) => n?.type === 'table')
+
+      if (!tableNode) {
+        throw new Error('table node not found in model')
+      }
+
+      const modelRowHeights = tableNode.children.map((row: any) => row?.height || 30)
+      const domRowHeights = rows.map(row => row.getBoundingClientRect().height)
+
+      const tableRect = table.getBoundingClientRect()
+      const firstRowRect = rows[0].getBoundingClientRect()
+
+      return {
+        modelRowHeights,
+        domRowHeights,
+        domFirstBorderOffset: firstRowRect.bottom - tableRect.top,
+        tableLeft: tableRect.left,
+        tableTop: tableRect.top,
+        tableWidth: tableRect.width,
+      }
+    })
+
+    const sampleX = metrics.tableLeft + Math.min(30, metrics.tableWidth / 3)
+    const hoverAtDomBorder = await page.evaluate(async ({ x, y }) => {
+      const table = document.querySelector('[data-testid="editor-textarea"] table.table') as HTMLElement | null
+      const editor = (window as any).wangEditorExampleBridge?.editor
+      const tableNode = editor?.children?.find((n: any) => n?.type === 'table')
+
+      if (!table || !tableNode) {
+        throw new Error('table or model table node missing')
+      }
+
+      table.dispatchEvent(new MouseEvent('mousemove', {
+        bubbles: true,
+        cancelable: true,
+        clientX: x,
+        clientY: y,
+      }))
+      await new Promise(resolve => {
+        setTimeout(resolve, 120)
+      })
+
+      const currentTableNode = editor?.children?.find((n: any) => n?.type === 'table')
+
+      return {
+        isHoverRowBorder: !!currentTableNode?.isHoverRowBorder,
+        resizingRowIndex: currentTableNode?.resizingRowIndex ?? -1,
+      }
+    }, {
+      x: sampleX,
+      y: metrics.tableTop + metrics.domFirstBorderOffset + 1,
+    })
+
+    expect(metrics.domRowHeights[0] - metrics.modelRowHeights[0]).toBeGreaterThan(20)
+    expect(hoverAtDomBorder.isHoverRowBorder).toBe(true)
+    expect(hoverAtDomBorder.resizingRowIndex).toBe(0)
+  })
+
   test('pastes plain text', async ({ page }) => {
     await pasteText(page, 'pasted text')
 


### PR DESCRIPTION
## Summary
- fix issue #811: table row-resize hotspot no longer drifts when a cell's content expands row height
- align row-resize UI and hover detection with real DOM row heights instead of stale default row model heights
- add e2e regression case for this scenario

## Root Cause
`table-row.height` defaults to `30` in the model and was used as the source of truth for row-resizer layout and hover-hit detection.
When cell text wraps and increases real DOM row height, the model height may remain stale (`30`), so row border hotspots stay near the old position.

## Fix
- capture current DOM row heights in `observerTableResize` and store a runtime snapshot on table node (`rowHeights`)
- use this snapshot in row resize logic:
  - row-resizer item min-height rendering
  - hover border position detection
  - drag calculation baseline
- keep existing row `height` semantics intact for serialization behavior

## Regression Coverage
Added e2e test in `tests/e2e/editor.spec.ts`:
- `regression #811: row resize hotzone should follow rendered row border after content expands`

This test verifies:
- DOM row height is larger than model default after long text wrapping
- moving near the actual rendered row bottom border activates row resize hover (`isHoverRowBorder=true`, `resizingRowIndex=0`)

## Verification
- `pnpm turbo build --filter=@wangeditor-next/editor`
- `PLAYWRIGHT_SKIP_BUILD=1 pnpm exec playwright test tests/e2e/editor.spec.ts --project=chromium --grep "regression #811|deletes a table row|deletes a table column" --reporter=list`
- `pnpm test packages/table-module/__tests__/batch-selection-simple.test.ts`
- `pnpm exec eslint packages/table-module/src/module/custom-types.ts packages/table-module/src/module/column-resize.ts packages/table-module/src/module/row-resize.ts packages/table-module/src/module/render-elem/render-table.tsx tests/e2e/editor.spec.ts`

Closes #811


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed row resize hotspot alignment in tables when cell content expands due to text wrapping, ensuring the resize cursor and drag interactions remain accurate.

* **Tests**
  * Added regression test to verify row resize alignment accuracy with expanded table content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/819?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->