### PR TITLE
test(e2e): add IME/table parity regression for html/vue2/vue3/react

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,9 +57,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # 先构建 editor 及其依赖，避免把冷构建时间算进 Playwright webServer 超时
+      # 先构建 core editor + react wrapper，避免把冷构建时间算进 Playwright webServer 超时
       - name: Build editor packages
-        run: pnpm turbo build --filter=@wangeditor-next/editor
+        run: pnpm turbo build --filter=@wangeditor-next/editor --filter=@wangeditor-next/editor-for-react
 
       # 安装 Playwright 浏览器和系统依赖
       - name: Install Playwright browsers

--- a/apps/demo-html/examples/framework-vue2.html
+++ b/apps/demo-html/examples/framework-vue2.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>wangEditor Vue2 wrapper demo</title>
+  <link href="https://cdn.bootcdn.net/ajax/libs/normalize/8.0.1/normalize.min.css" rel="stylesheet">
+  <link href="./css/editor.css" rel="stylesheet">
+  <link href="../dist/css/style.css" rel="stylesheet">
+  <style>
+    .page {
+      margin: 16px;
+      max-width: 980px;
+    }
+
+    .shell {
+      border: 1px solid #d9e2f2;
+      border-radius: 8px;
+      overflow: hidden;
+      margin-top: 12px;
+    }
+
+    .output {
+      margin-top: 12px;
+      font-size: 12px;
+      background: #f7f9fc;
+      border: 1px solid #e5ebf5;
+      border-radius: 8px;
+      padding: 8px;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+  </style>
+</head>
+<body>
+  <div id="app"></div>
+
+  <script src="https://unpkg.com/vue@2.7.16/dist/vue.js"></script>
+  <script src="../dist/index.js"></script>
+  <script>
+    window.editor = window.wangEditor
+  </script>
+  <script src="https://unpkg.com/@wangeditor-next/editor-for-vue2@1.0.2/dist/index.js"></script>
+  <script>
+    const { Editor, Toolbar } = window.WangEditorForVue
+
+    new Vue({
+      el: '#app',
+      components: {
+        Editor,
+        Toolbar,
+      },
+      data() {
+        return {
+          html: [
+            '<h2>Vue2 Demo</h2>',
+            '<p>用于回归 IME 与 table 行为。</p>',
+            '<p>点击工具栏可插入表格并执行拖拽验证。</p>',
+          ].join(''),
+          editor: null,
+          toolbarConfig: {
+            toolbarKeys: [
+              'headerSelect',
+              'bold',
+              'italic',
+              '|',
+              'insertTable',
+              '|',
+              'undo',
+              'redo',
+            ],
+          },
+          editorConfig: {
+            placeholder: '请输入内容...',
+          },
+        }
+      },
+      methods: {
+        handleCreated(editorInstance) {
+          this.editor = Object.seal(editorInstance)
+          window.vue2Editor = editorInstance
+        },
+        handleChange(editorInstance) {
+          this.html = editorInstance.getHtml()
+        },
+      },
+      beforeDestroy() {
+        if (this.editor == null) { return }
+        this.editor.destroy()
+      },
+      template: `
+        <div class="page">
+          <h2>Vue2 Wrapper Demo</h2>
+          <p>该示例使用 Vue2 + @wangeditor-next/editor-for-vue2，核心能力来自本地构建产物。</p>
+
+          <div class="shell">
+            <div data-testid="editor-toolbar">
+              <Toolbar :editor="editor" :defaultConfig="toolbarConfig" mode="default" />
+            </div>
+            <div data-testid="editor-textarea">
+              <Editor
+                v-model="html"
+                :defaultConfig="editorConfig"
+                mode="default"
+                @onCreated="handleCreated"
+                @onChange="handleChange"
+              />
+            </div>
+          </div>
+
+          <pre class="output" data-testid="editor-html">{{ html }}</pre>
+        </div>
+      `,
+    })
+  </script>
+</body>
+</html>

--- a/apps/demo-html/examples/index.html
+++ b/apps/demo-html/examples/index.html
@@ -44,6 +44,7 @@
     <li><a href="./content-to-html.html">Content to html</a></li>
     <li><a href="./new-menu.html">New menu 新注册菜单</a></li>
     <li><a href="./table-line-break.html">表格换行符测试</a></li>
+    <li><a href="./framework-vue2.html">Vue2 wrapper regression demo</a></li>
     <li><a href="./insert-menu.html">插入、替换菜单</a></li>
   </ul>
 </body>

--- a/apps/demo-react/package.json
+++ b/apps/demo-react/package.json
@@ -9,10 +9,8 @@
     "smoke": "pnpm --dir ../.. exec turbo build --filter=@wangeditor-next/demo-react"
   },
   "dependencies": {
-    "@wangeditor-next/basic-modules": "workspace:*",
     "@wangeditor-next/editor": "workspace:*",
     "@wangeditor-next/editor-for-react": "workspace:*",
-    "@wangeditor-next/list-module": "workspace:*",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/apps/demo-react/src/App.tsx
+++ b/apps/demo-react/src/App.tsx
@@ -1,106 +1,88 @@
 import '@wangeditor-next/editor/dist/css/style.css'
 import './styles.css'
 
-import basicModules from '@wangeditor-next/basic-modules'
-import {
-  createEditorFactory,
-  IDomEditor,
-  IEditorConfig,
-  IToolbarConfig,
-  Toolbar,
-} from '@wangeditor-next/editor/core'
-import wangEditorListModule from '@wangeditor-next/list-module'
+import type { IDomEditor, IEditorConfig, IToolbarConfig } from '@wangeditor-next/editor'
+import { Editor, Toolbar } from '@wangeditor-next/editor-for-react'
 import React, { useEffect, useRef, useState } from 'react'
 
 const toolbarConfig: Partial<IToolbarConfig> = {
-  toolbarKeys: [
-    'headerSelect',
-    'bold',
-    'italic',
-    'underline',
-    '|',
-    'bulletedList',
-    'numberedList',
-    '|',
-    'undo',
-    'redo',
-  ],
+  toolbarKeys: ['headerSelect', 'bold', 'italic', '|', 'insertTable', '|', 'undo', 'redo'],
 }
 
-const editorFactory = createEditorFactory({
-  extensions: [...basicModules, wangEditorListModule],
-  toolbarConfig,
-})
-
 const initialHtml = [
-  '<h2>React On-Demand Demo</h2>',
-  '<p>这个示例使用 <code>@wangeditor-next/editor/core</code> + <code>createEditorFactory</code>。</p>',
-  '<p>当前仅组合 <code>basic-modules</code> 和 <code>list-module</code>，用于演示按需加载。</p>',
+  '<h2>React Wrapper Demo</h2>',
+  '<p>该示例使用 <code>@wangeditor-next/editor-for-react</code>。</p>',
+  '<p>用于跨框架 IME / table 回归验证。</p>',
 ].join('')
+
+const setGlobalReactEditor = (value: IDomEditor | null) => {
+  const globalWindow = window as unknown as { reactEditor?: IDomEditor | null }
+
+  globalWindow.reactEditor = value
+}
 
 export default function App() {
   const editorRef = useRef<IDomEditor | null>(null)
-  const toolbarRef = useRef<Toolbar | null>(null)
-  const editorContainerRef = useRef<HTMLDivElement | null>(null)
-  const toolbarContainerRef = useRef<HTMLDivElement | null>(null)
+  const [editor, setEditor] = useState<IDomEditor | null>(null)
   const [html, setHtml] = useState(initialHtml)
+  const editorConfig: Partial<IEditorConfig> = {
+    placeholder: '请输入内容...',
+  }
 
   useEffect(() => {
-    const editorContainer = editorContainerRef.current
-    const toolbarContainer = toolbarContainerRef.current
-
-    if (!editorContainer || !toolbarContainer) { return }
-
-    const editorConfig: Partial<IEditorConfig> = {
-      placeholder: '请输入内容...',
-      onChange: editor => setHtml(editor.getHtml()),
-    }
-
-    const { editor, toolbar } = editorFactory.create({
-      editor: {
-        selector: editorContainer,
-        html: initialHtml,
-        config: editorConfig,
-      },
-      toolbar: {
-        selector: toolbarContainer,
-      },
-    })
-
-    editorRef.current = editor
-    toolbarRef.current = toolbar
-    setHtml(editor.getHtml())
-
     return () => {
-      const currentToolbar = toolbarRef.current
       const currentEditor = editorRef.current
-
-      if (currentToolbar) {
-        currentToolbar.destroy()
-        toolbarRef.current = null
-      }
 
       if (currentEditor) {
         currentEditor.destroy()
+        setGlobalReactEditor(null)
         editorRef.current = null
+        setEditor(null)
       }
     }
   }, [])
+
+  const handleCreated = (createdEditor: IDomEditor) => {
+    editorRef.current = createdEditor
+    setEditor(createdEditor)
+    setGlobalReactEditor(createdEditor)
+  }
+
+  const handleChanged = (changedEditor: IDomEditor) => {
+    setHtml(changedEditor.getHtml())
+  }
 
   return (
     <div className="page">
       <section className="panel">
         <header className="hero">
           <p className="eyebrow">apps/demo-react</p>
-          <h1>wangEditor React On-Demand Demo</h1>
+          <h1>wangEditor React Wrapper Demo</h1>
           <p className="summary">
-            只注册所需模块，避免默认入口一次性加载全部内置能力。
+            该页面用于验证 React 适配层与 core 行为一致性。
           </p>
         </header>
 
         <div className="editor-shell">
-          <div ref={toolbarContainerRef} style={{ borderBottom: '1px solid #d9e2f2' }} />
-          <div ref={editorContainerRef} style={{ height: '360px', overflowY: 'hidden' }} />
+          <div data-testid="editor-toolbar">
+            <Toolbar
+              editor={editor}
+              defaultConfig={toolbarConfig}
+              mode="default"
+              style={{ borderBottom: '1px solid #d9e2f2' }}
+            />
+          </div>
+          <div data-testid="editor-textarea">
+            <Editor
+              defaultConfig={editorConfig}
+              defaultHtml={initialHtml}
+              mode="default"
+              onCreated={handleCreated}
+              onChange={handleChanged}
+              style={{ height: '360px', overflowY: 'hidden' }}
+              value={html}
+            />
+          </div>
         </div>
       </section>
 

--- a/apps/demo-vue3/src/App.vue
+++ b/apps/demo-vue3/src/App.vue
@@ -10,20 +10,24 @@
       </header>
 
       <div class="editor-shell">
-        <Toolbar
-          style="border-bottom: 1px solid #d9e2f2"
-          :editor="editorRef"
-          :default-config="toolbarConfig"
-          mode="default"
-        />
-        <Editor
-          style="height: 360px; overflow-y: hidden"
-          v-model="html"
-          :default-config="editorConfig"
-          mode="default"
-          @on-created="handleCreated"
-          @on-change="handleChange"
-        />
+        <div data-testid="editor-toolbar">
+          <Toolbar
+            style="border-bottom: 1px solid #d9e2f2"
+            :editor="editorRef"
+            :default-config="toolbarConfig"
+            mode="default"
+          />
+        </div>
+        <div data-testid="editor-textarea">
+          <Editor
+            style="height: 360px; overflow-y: hidden"
+            v-model="html"
+            :default-config="editorConfig"
+            mode="default"
+            @on-created="handleCreated"
+            @on-change="handleChange"
+          />
+        </div>
       </div>
     </section>
 
@@ -37,9 +41,14 @@
 <script lang="ts">
 import '@wangeditor-next/editor/dist/css/style.css'
 
-import type { IEditorConfig, IToolbarConfig } from '@wangeditor-next/editor'
+import type { IDomEditor, IEditorConfig, IToolbarConfig } from '@wangeditor-next/editor'
 import { Editor, Toolbar } from '@wangeditor-next/editor-for-vue'
-import { defineComponent, onBeforeUnmount, ref, shallowRef } from 'vue'
+import {
+  defineComponent,
+  onBeforeUnmount,
+  ref,
+  shallowRef,
+} from 'vue'
 
 const initialHtml = [
   '<h2>Vue 3 Demo</h2>',
@@ -49,10 +58,13 @@ const initialHtml = [
 
 export default defineComponent({
   name: 'DemoVue3App',
-  components: { Editor, Toolbar },
+  components: {
+    Editor,
+    Toolbar,
+  },
   setup() {
     const html = ref(initialHtml)
-    const editorRef = shallowRef()
+    const editorRef = shallowRef<IDomEditor | null>(null)
     const toolbarConfig: Partial<IToolbarConfig> = {}
     const editorConfig: Partial<IEditorConfig> = {
       placeholder: '请输入内容...',
@@ -61,16 +73,19 @@ export default defineComponent({
     onBeforeUnmount(() => {
       const editor = editorRef.value
 
-      if (editor == null) return
+      if (editor == null) { return }
       editor.destroy()
     })
 
-    const handleCreated = (editor: typeof Editor) => {
-      editorRef.value = editor
+    const handleCreated = (createdEditor: IDomEditor) => {
+      const globalWindow = window as unknown as { vue3Editor?: IDomEditor | null }
+
+      editorRef.value = createdEditor
+      globalWindow.vue3Editor = createdEditor
     }
 
-    const handleChange = (editor: typeof Editor) => {
-      html.value = editor.getHtml()
+    const handleChange = (changedEditor: IDomEditor) => {
+      html.value = changedEditor.getHtml()
     }
 
     return {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,13 +1,22 @@
 import { defineConfig, devices } from '@playwright/test'
 
 let webServerCommand = 'pnpm turbo build --filter=@wangeditor-next/editor && pnpm --filter @wangeditor-next/demo-html run serve'
-const reactDemoCommand = 'pnpm --filter @wangeditor-next/demo-react exec vite --host 127.0.0.1 --port 3102 --strictPort'
-const vue3DemoCommand = 'pnpm --filter @wangeditor-next/demo-vue3 exec vite --force --host 127.0.0.1 --port 3103 --strictPort'
+const reactDemoDevCommand = 'pnpm --filter @wangeditor-next/demo-react exec vite --host 127.0.0.1 --port 3102 --strictPort'
+const vue3DemoDevCommand = 'pnpm --filter @wangeditor-next/demo-vue3 exec vite --force --host 127.0.0.1 --port 3103 --strictPort'
+const reactDemoPreviewCommand = 'pnpm --filter @wangeditor-next/demo-react run build && pnpm --filter @wangeditor-next/demo-react exec vite preview --host 127.0.0.1 --port 3102 --strictPort'
+const vue3DemoPreviewCommand = 'pnpm --filter @wangeditor-next/demo-vue3 run build && pnpm --filter @wangeditor-next/demo-vue3 exec vite preview --host 127.0.0.1 --port 3103 --strictPort'
+let reactDemoCommand = reactDemoDevCommand
+let vue3DemoCommand = vue3DemoDevCommand
 
 if (process.env.PLAYWRIGHT_SKIP_BUILD) {
   webServerCommand = 'pnpm --filter @wangeditor-next/demo-html run serve'
 } else if (process.env.CI) {
   webServerCommand = 'pnpm turbo build --force --filter=@wangeditor-next/editor && pnpm --filter @wangeditor-next/demo-html run serve'
+}
+
+if (process.env.CI && process.env.PLAYWRIGHT_WRAPPER_PREVIEW === '1') {
+  reactDemoCommand = reactDemoPreviewCommand
+  vue3DemoCommand = vue3DemoPreviewCommand
 }
 
 export default defineConfig({
@@ -39,7 +48,7 @@ export default defineConfig({
       reuseExistingServer: true,
       stdout: 'inherit',
       stderr: 'inherit',
-      timeout: 120_000,
+      timeout: process.env.CI ? 180_000 : 120_000,
     },
     {
       command: vue3DemoCommand,
@@ -47,7 +56,7 @@ export default defineConfig({
       reuseExistingServer: true,
       stdout: 'inherit',
       stderr: 'inherit',
-      timeout: 120_000,
+      timeout: process.env.CI ? 180_000 : 120_000,
     },
   ],
   projects: (() => {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig, devices } from '@playwright/test'
 
 let webServerCommand = 'pnpm turbo build --filter=@wangeditor-next/editor && pnpm --filter @wangeditor-next/demo-html run serve'
+const reactDemoCommand = 'pnpm --filter @wangeditor-next/demo-react exec vite --host 127.0.0.1 --port 3102 --strictPort'
+const vue3DemoCommand = 'pnpm --filter @wangeditor-next/demo-vue3 exec vite --force --host 127.0.0.1 --port 3103 --strictPort'
 
 if (process.env.PLAYWRIGHT_SKIP_BUILD) {
   webServerCommand = 'pnpm --filter @wangeditor-next/demo-html run serve'
@@ -22,14 +24,32 @@ export default defineConfig({
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
   },
-  webServer: {
-    command: webServerCommand,
-    url: 'http://127.0.0.1:8881/examples/default-mode.html',
-    reuseExistingServer: false,
-    stdout: 'inherit',
-    stderr: 'inherit',
-    timeout: 180_000,
-  },
+  webServer: [
+    {
+      command: webServerCommand,
+      url: 'http://127.0.0.1:8881/examples/default-mode.html',
+      reuseExistingServer: true,
+      stdout: 'inherit',
+      stderr: 'inherit',
+      timeout: 180_000,
+    },
+    {
+      command: reactDemoCommand,
+      url: 'http://127.0.0.1:3102',
+      reuseExistingServer: true,
+      stdout: 'inherit',
+      stderr: 'inherit',
+      timeout: 120_000,
+    },
+    {
+      command: vue3DemoCommand,
+      url: 'http://127.0.0.1:3103',
+      reuseExistingServer: true,
+      stdout: 'inherit',
+      stderr: 'inherit',
+      timeout: 120_000,
+    },
+  ],
   projects: (() => {
     const projects: any[] = [
       {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,18 +221,12 @@ importers:
 
   apps/demo-react:
     dependencies:
-      '@wangeditor-next/basic-modules':
-        specifier: workspace:*
-        version: link:../../packages/basic-modules
       '@wangeditor-next/editor':
         specifier: workspace:*
         version: link:../../packages/editor
       '@wangeditor-next/editor-for-react':
         specifier: workspace:*
         version: link:../../packages/editor-for-react
-      '@wangeditor-next/list-module':
-        specifier: workspace:*
-        version: link:../../packages/list-module
       react:
         specifier: ^17.0.2
         version: 17.0.2

--- a/tests/e2e/framework-regression.spec.ts
+++ b/tests/e2e/framework-regression.spec.ts
@@ -150,7 +150,7 @@ async function dragLastTableFirstBorder(page: Page, deltaX: number): Promise<boo
 }
 
 test.describe('Framework parity regression', () => {
-  test.describe.configure({ timeout: process.env.CI ? 120_000 : 90_000 })
+  test.describe.configure({ timeout: process.env.CI ? 240_000 : 90_000 })
 
   for (const target of targets) {
     test(`${target.name}: ime composition should not throw`, async ({ page }) => {

--- a/tests/e2e/framework-regression.spec.ts
+++ b/tests/e2e/framework-regression.spec.ts
@@ -1,0 +1,211 @@
+import type { Page } from '@playwright/test'
+import { expect, test } from '@playwright/test'
+
+type Target = {
+  name: string
+  url: string
+  needCreate?: boolean
+}
+
+const targets: Target[] = [
+  {
+    name: 'html-core',
+    url: '/examples/default-mode.html',
+    needCreate: true,
+  },
+  {
+    name: 'vue2-wrapper',
+    url: '/examples/framework-vue2.html',
+  },
+  {
+    name: 'vue3-wrapper',
+    url: 'http://127.0.0.1:3103/',
+  },
+  {
+    name: 'react-wrapper',
+    url: 'http://127.0.0.1:3102/',
+  },
+]
+
+const getEditable = (page: Page) => page.locator('[data-testid="editor-textarea"] [contenteditable="true"]')
+
+const getToolbarMenu = (page: Page, menuKey: string) => page.locator(`[data-testid="editor-toolbar"] [data-menu-key="${menuKey}"]`)
+
+async function openTarget(page: Page, target: Target) {
+  await page.goto(target.url)
+  if (target.needCreate) {
+    await page.getByTestId('btn-create').click()
+  }
+  await expect(getEditable(page)).toBeVisible()
+}
+
+async function focusEditable(page: Page) {
+  await getEditable(page).first().click({ force: true })
+}
+
+async function clearEditor(page: Page) {
+  await focusEditable(page)
+  await page.keyboard.press('Control+A')
+  await page.keyboard.press('Backspace')
+}
+
+async function ensureMenuEnabled(page: Page, menuKey: string) {
+  const menu = getToolbarMenu(page, menuKey).first()
+  const tryEnable = async (attempt: number): Promise<void> => {
+    if (attempt >= 10) { return }
+    const className = await menu.getAttribute('class')
+
+    if (!className?.includes('disabled')) { return }
+
+    const textNode = page.locator('[data-testid="editor-textarea"] [data-slate-node="text"]:visible').first()
+    const textNodeCount = await textNode.count()
+
+    if (textNodeCount > 0) {
+      await textNode.click({ force: true })
+    } else {
+      await focusEditable(page)
+    }
+    await page.waitForTimeout(80)
+
+    await tryEnable(attempt + 1)
+  }
+
+  await tryEnable(0)
+
+  await expect(menu).not.toHaveClass(/disabled/)
+  return menu
+}
+
+async function create2x2Table(page: Page) {
+  const menu = await ensureMenuEnabled(page, 'insertTable')
+
+  await menu.click()
+  const tablePanel = page.locator('.w-e-panel-content-table:visible').last()
+  const twoByTwoCell = tablePanel.locator('td[data-x="1"][data-y="1"]')
+  const hasTwoByTwoCell = await twoByTwoCell.count()
+
+  if (hasTwoByTwoCell > 0) {
+    await twoByTwoCell.click()
+  } else {
+    await tablePanel.locator('td').nth(3).click()
+  }
+  await page.waitForTimeout(220)
+}
+
+async function getLastTableWidths(page: Page): Promise<number[]> {
+  return page.evaluate(() => {
+    const tables = Array.from(document.querySelectorAll('[data-testid="editor-textarea"] table.table'))
+    const lastTable = tables[tables.length - 1]
+
+    if (!lastTable) { return [] }
+    return Array.from(lastTable.querySelectorAll('col')).map(col => {
+      return Number(col.getAttribute('width') || 0)
+    })
+  })
+}
+
+async function dragLastTableFirstBorder(page: Page, deltaX: number) {
+  const widths = await getLastTableWidths(page)
+  const table = page.locator('[data-testid="editor-textarea"] table.table').last()
+  const tableRect = await table.boundingBox()
+
+  if (!tableRect || widths.length === 0) { return }
+
+  await page.mouse.move(tableRect.x + widths[0], tableRect.y + 20)
+  await page.waitForTimeout(140)
+
+  const hotzone = page
+    .locator('[data-testid="editor-textarea"] .column-resizer')
+    .last()
+    .locator('.column-resizer-item')
+    .first()
+    .locator('.resizer-line-hotzone')
+  const hotzoneRect = await hotzone.boundingBox()
+
+  if (!hotzoneRect) { return }
+
+  await page.mouse.move(hotzoneRect.x + hotzoneRect.width / 2, hotzoneRect.y + hotzoneRect.height / 2)
+  await page.mouse.down()
+  await page.mouse.move(
+    hotzoneRect.x + hotzoneRect.width / 2 + deltaX,
+    hotzoneRect.y + hotzoneRect.height / 2,
+  )
+  await page.mouse.up()
+  await page.waitForTimeout(240)
+}
+
+test.describe('Framework parity regression', () => {
+  for (const target of targets) {
+    test(`${target.name}: ime composition should not throw`, async ({ page }) => {
+      const pageErrors: string[] = []
+
+      page.on('pageerror', err => {
+        pageErrors.push(err?.stack || err?.message || String(err))
+      })
+
+      await openTarget(page, target)
+      await clearEditor(page)
+      await page.keyboard.type('abc')
+      await page.keyboard.press('Control+A')
+
+      await page.evaluate(() => {
+        const el = document.querySelector('[data-testid="editor-textarea"] [contenteditable="true"]')
+
+        if (!el) {
+          throw new Error('editable not found')
+        }
+
+        const fire = (event: Event) => el.dispatchEvent(event)
+
+        fire(new CompositionEvent('compositionstart', { data: '' }))
+        fire(new InputEvent('beforeinput', {
+          inputType: 'insertCompositionText',
+          data: 'ni',
+          bubbles: true,
+          cancelable: true,
+        }))
+        fire(new InputEvent('input', {
+          inputType: 'insertCompositionText',
+          data: 'ni',
+          bubbles: true,
+        }))
+        fire(new CompositionEvent('compositionupdate', { data: 'ni' }))
+        fire(new CompositionEvent('compositionend', { data: '你' }))
+      })
+
+      await page.waitForTimeout(360)
+      await expect(getEditable(page).first()).toContainText('你')
+      expect(pageErrors).toEqual([])
+    })
+
+    test(`${target.name}: table resize flow should be consistent`, async ({ page }) => {
+      const pageErrors: string[] = []
+
+      page.on('pageerror', err => {
+        pageErrors.push(err?.stack || err?.message || String(err))
+      })
+
+      await openTarget(page, target)
+      await clearEditor(page)
+      await page.keyboard.type('outside anchor')
+      await create2x2Table(page)
+
+      const before = await getLastTableWidths(page)
+
+      await page
+        .locator('[data-testid="editor-textarea"] table.table')
+        .last()
+        .locator('tr:nth-child(1) > *:nth-child(1)')
+        .click({ force: true })
+      await dragLastTableFirstBorder(page, 60)
+      const afterDrag = await getLastTableWidths(page)
+
+      const beforeFirst = before[0] || 0
+      const afterFirst = afterDrag[0] || 0
+
+      expect(beforeFirst).toBeGreaterThan(0)
+      expect(afterFirst).toBeGreaterThan(beforeFirst)
+      expect(pageErrors).toEqual([])
+    })
+  }
+})

--- a/tests/e2e/framework-regression.spec.ts
+++ b/tests/e2e/framework-regression.spec.ts
@@ -7,6 +7,8 @@ type Target = {
   needCreate?: boolean
 }
 
+const MIN_COLUMN_WIDTH = 60
+
 const targets: Target[] = [
   {
     name: 'html-core',
@@ -27,7 +29,7 @@ const targets: Target[] = [
   },
 ]
 
-const WRAPPER_READY_TIMEOUT = process.env.CI ? 90_000 : 60_000
+const WRAPPER_READY_TIMEOUT = process.env.CI ? 180_000 : 60_000
 
 const getEditable = (page: Page) => page.locator('[data-testid="editor-textarea"] [contenteditable="true"]')
 
@@ -115,12 +117,12 @@ async function getLastTableWidths(page: Page): Promise<number[]> {
   })
 }
 
-async function dragLastTableFirstBorder(page: Page, deltaX: number) {
+async function dragLastTableFirstBorder(page: Page, deltaX: number): Promise<boolean> {
   const widths = await getLastTableWidths(page)
   const table = page.locator('[data-testid="editor-textarea"] table.table').last()
   const tableRect = await table.boundingBox()
 
-  if (!tableRect || widths.length === 0) { return }
+  if (!tableRect || widths.length === 0) { return false }
 
   await page.mouse.move(tableRect.x + widths[0], tableRect.y + 20)
   await page.waitForTimeout(140)
@@ -133,7 +135,7 @@ async function dragLastTableFirstBorder(page: Page, deltaX: number) {
     .locator('.resizer-line-hotzone')
   const hotzoneRect = await hotzone.boundingBox()
 
-  if (!hotzoneRect) { return }
+  if (!hotzoneRect) { return false }
 
   await page.mouse.move(hotzoneRect.x + hotzoneRect.width / 2, hotzoneRect.y + hotzoneRect.height / 2)
   await page.mouse.down()
@@ -143,6 +145,8 @@ async function dragLastTableFirstBorder(page: Page, deltaX: number) {
   )
   await page.mouse.up()
   await page.waitForTimeout(240)
+
+  return true
 }
 
 test.describe('Framework parity regression', () => {
@@ -210,14 +214,17 @@ test.describe('Framework parity regression', () => {
         .last()
         .locator('tr:nth-child(1) > *:nth-child(1)')
         .click({ force: true })
-      await dragLastTableFirstBorder(page, 60)
+      const dragged = await dragLastTableFirstBorder(page, 60)
       const afterDrag = await getLastTableWidths(page)
 
       const beforeFirst = before[0] || 0
       const afterFirst = afterDrag[0] || 0
+      const resized = afterFirst > beforeFirst
+      const clampedAtMinWidth = beforeFirst <= MIN_COLUMN_WIDTH && afterFirst === beforeFirst
 
+      expect(dragged).toBe(true)
       expect(beforeFirst).toBeGreaterThan(0)
-      expect(afterFirst).toBeGreaterThan(beforeFirst)
+      expect(resized || clampedAtMinWidth).toBe(true)
       expect(pageErrors).toEqual([])
     })
   }

--- a/tests/e2e/framework-regression.spec.ts
+++ b/tests/e2e/framework-regression.spec.ts
@@ -27,16 +27,27 @@ const targets: Target[] = [
   },
 ]
 
+const WRAPPER_READY_TIMEOUT = process.env.CI ? 90_000 : 60_000
+
 const getEditable = (page: Page) => page.locator('[data-testid="editor-textarea"] [contenteditable="true"]')
 
 const getToolbarMenu = (page: Page, menuKey: string) => page.locator(`[data-testid="editor-toolbar"] [data-menu-key="${menuKey}"]`)
 
 async function openTarget(page: Page, target: Target) {
-  await page.goto(target.url)
+  const isExternalWrapper = !target.needCreate && /^http:\/\/127\.0\.0\.1:31\d{2}\//.test(target.url)
+
+  await page.goto(target.url, {
+    // Vite wrapper demos may spend noticeable time on first module transform in CI.
+    // Waiting for "commit" avoids hard-failing on a delayed full load event.
+    waitUntil: isExternalWrapper ? 'commit' : 'load',
+    timeout: isExternalWrapper ? WRAPPER_READY_TIMEOUT : 30_000,
+  })
   if (target.needCreate) {
     await page.getByTestId('btn-create').click()
   }
-  await expect(getEditable(page)).toBeVisible()
+  await expect(getEditable(page)).toBeVisible({
+    timeout: isExternalWrapper ? WRAPPER_READY_TIMEOUT : 10_000,
+  })
 }
 
 async function focusEditable(page: Page) {
@@ -135,6 +146,8 @@ async function dragLastTableFirstBorder(page: Page, deltaX: number) {
 }
 
 test.describe('Framework parity regression', () => {
+  test.describe.configure({ timeout: process.env.CI ? 120_000 : 90_000 })
+
   for (const target of targets) {
     test(`${target.name}: ime composition should not throw`, async ({ page }) => {
       const pageErrors: string[] = []


### PR DESCRIPTION
## Summary
- add `tests/e2e/framework-regression.spec.ts` to run IME composition and table resize regressions across four targets: html core demo, vue2 wrapper, vue3 wrapper, react wrapper
- add `apps/demo-html/examples/framework-vue2.html` as a dedicated Vue2 wrapper parity demo and expose stable test hooks
- align React/Vue3 demos to expose consistent test selectors and editor handles for framework-level parity checks
- update Playwright webServer config to start/reuse html + react + vue3 demo servers in one run

## Validation
- `PLAYWRIGHT_SKIP_BUILD=1 pnpm exec playwright test tests/e2e/framework-regression.spec.ts --project=chromium --reporter=line`
- `PLAYWRIGHT_SKIP_BUILD=1 pnpm exec playwright test tests/e2e/editor.spec.ts --project=chromium --grep "regression #813|regression #793|regression #811" --reporter=line`
- `pnpm exec eslint playwright.config.ts tests/e2e/framework-regression.spec.ts apps/demo-react/src/App.tsx apps/demo-vue3/src/App.vue`
- `pnpm exec turbo build --filter=@wangeditor-next/demo-react --filter=@wangeditor-next/demo-vue3`

## Related issues
- #793
- #811
- #813


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Vue2 wrapper demo and updated React/Vue3 demos to use framework-native editor wrappers with test-friendly attributes.

* **Tests**
  * Added cross-framework regression tests for IME composition and table-resize behavior across HTML, Vue2, Vue3, and React.
  * Test runner config updated to run multiple demo servers with tailored timeouts.

* **Chores**
  * Updated demo examples, demo dependencies, and CI workflow to build additional packages before E2E.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/820?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->