### PR TITLE
ci(release): trigger docs deploy after editor publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,3 +103,36 @@ jobs:
         run: >-
           node .github/scripts/create-consolidated-release.js
           '${{ steps.changesets.outputs.publishedPackages }}'
+
+      - name: Resolve published editor version
+        if: steps.changesets.outputs.published == 'true' && github.ref_name == 'master'
+        id: editor_version
+        env:
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+        run: |
+          set -euo pipefail
+
+          version="$(node -e "const pkgs = JSON.parse(process.env.PUBLISHED_PACKAGES || '[]'); const editor = pkgs.find(p => p.name === '@wangeditor-next/editor'); if (editor?.version) process.stdout.write(editor.version)")"
+          if [ -z "$version" ]; then
+            version="$(node -p "require('./packages/editor/package.json').version")"
+            echo "Fallback to packages/editor/package.json version: $version"
+          else
+            echo "Published @wangeditor-next/editor version: $version"
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger docs site deployment for released editor version
+        if: steps.changesets.outputs.published == 'true' && github.ref_name == 'master' && secrets.DOCS_REPO_DISPATCH_TOKEN != ''
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.DOCS_REPO_DISPATCH_TOKEN }}
+          repository: wangeditor-next/docs
+          event-type: editor-release-published
+          client-payload: >-
+            {"version":"${{ steps.editor_version.outputs.version }}","sourceRepo":"${{ github.repository }}","sourceSha":"${{ github.sha }}","sourceRunId":"${{ github.run_id }}"}
+
+      - name: Warn when docs dispatch token is missing
+        if: steps.changesets.outputs.published == 'true' && github.ref_name == 'master' && secrets.DOCS_REPO_DISPATCH_TOKEN == ''
+        run: |
+          echo "::warning::DOCS_REPO_DISPATCH_TOKEN is not set. Skip triggering wangeditor-next/docs deployment."


### PR DESCRIPTION
## Summary
- after successful publish on `master`, extract published `@wangeditor-next/editor` version from changesets output
- fallback to `packages/editor/package.json` version when not present in published package list
- dispatch `editor-release-published` event to `wangeditor-next/docs` with released version payload
- add warning-only step when `DOCS_REPO_DISPATCH_TOKEN` is not configured

## Notes
- requires repository secret `DOCS_REPO_DISPATCH_TOKEN` in `wangeditor-next/wangEditor-next`
- token has already been configured in this session
- this keeps release workflow non-blocking even if dispatch token is missing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to improve coordination between package version publishing and documentation updates, ensuring consistency across releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/821?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->