### PR TITLE
fix(table-module): keep column resize working after setHtml

### DIFF
--- a/.changeset/green-lamps-sit.md
+++ b/.changeset/green-lamps-sit.md
@@ -1,0 +1,11 @@
+---
+'@wangeditor-next/table-module': patch
+'@wangeditor-next/editor': patch
+---
+
+Fix table column resize after `setHtml` when the current selection is outside the table.
+
+Column drag now captures the target table path on `mousedown` and keeps using
+that path during `mousemove`, instead of looking up the table from current
+selection state. This keeps full-width table column resize usable after
+`setHtml` without requiring an extra click inside a cell first.

--- a/packages/table-module/__tests__/column-resize.test.ts
+++ b/packages/table-module/__tests__/column-resize.test.ts
@@ -18,6 +18,9 @@ Object.defineProperty(window, 'getComputedStyle', {
 
 Object.defineProperty(HTMLElement.prototype, 'closest', {
   value(selector: string) {
+    if (selector === '[data-block-type="table-cell"]') {
+      return this.getAttribute('data-block-type') === 'table-cell' ? this : null
+    }
     if (selector === '.table') {
       return {
         getBoundingClientRect: () => ({
@@ -208,10 +211,8 @@ describe('column resize module', () => {
     tableDom.appendChild(innerTable)
 
     vi.spyOn(editor, 'getMenuConfig').mockReturnValue({ minWidth: 90 } as any)
-    vi.spyOn(slate.Editor, 'nodes').mockReturnValue((function* () {
-      yield [table, [0]] as slate.NodeEntry<slate.Node>
-    }()))
-    vi.spyOn(core.DomEditor, 'getSelectedNodeByType').mockReturnValue(table as any)
+    vi.spyOn(core.DomEditor, 'findPath').mockReturnValue([0] as slate.Path)
+    vi.spyOn(slate.Editor, 'node').mockReturnValue([table as slate.Node, [0]])
     vi.spyOn(core.DomEditor, 'toDOMNode').mockReturnValue(tableDom)
     const setNodesSpy = vi.spyOn(slate.Transforms, 'setNodes').mockImplementation(() => {})
 
@@ -231,7 +232,7 @@ describe('column resize module', () => {
     expect(setNodesSpy).toHaveBeenCalledWith(
       editor,
       { columnWidths: [80, 180, 100] } as TableElement,
-      { mode: 'highest' },
+      { at: [0] },
     )
 
     window.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
@@ -246,10 +247,8 @@ describe('column resize module', () => {
     }
 
     vi.spyOn(editor, 'getMenuConfig').mockReturnValue({ minWidth: 95 } as any)
-    vi.spyOn(slate.Editor, 'nodes').mockReturnValue((function* () {
-      yield [table, [0]] as slate.NodeEntry<slate.Node>
-    }()))
-    vi.spyOn(core.DomEditor, 'getSelectedNodeByType').mockReturnValue(table as any)
+    vi.spyOn(core.DomEditor, 'findPath').mockReturnValue([0] as slate.Path)
+    vi.spyOn(slate.Editor, 'node').mockReturnValue([table as slate.Node, [0]])
     vi.spyOn(core.DomEditor, 'toDOMNode').mockReturnValue(document.createElement('div'))
     const setNodesSpy = vi.spyOn(slate.Transforms, 'setNodes').mockImplementation(() => {})
 
@@ -268,7 +267,7 @@ describe('column resize module', () => {
     expect(setNodesSpy).toHaveBeenCalledWith(
       editor,
       { columnWidths: [95, 120, 100] } as TableElement,
-      { mode: 'highest' },
+      { at: [0] },
     )
   })
 })

--- a/packages/table-module/src/module/column-resize.ts
+++ b/packages/table-module/src/module/column-resize.ts
@@ -1,8 +1,12 @@
 import { DomEditor, IDomEditor, isHTMLElememt } from '@wangeditor-next/core'
 import throttle from 'lodash.throttle'
-import { Editor, Element as SlateElement, Transforms } from 'slate'
+import {
+  Editor,
+  Element as SlateElement,
+  Path,
+  Transforms,
+} from 'slate'
 
-import { isOfType } from '../utils'
 import $ from '../utils/dom'
 import { TableElement } from './custom-types'
 
@@ -88,6 +92,7 @@ let isSelectionOperation = false
 let isMouseDownForResize = false
 let clientXWhenMouseDown = 0
 let editorWhenMouseDown: IDomEditor | null = null
+let tablePathWhenMouseDown: Path | null = null
 const $window = $(window)
 
 function onMouseDown(event: Event) {
@@ -98,7 +103,7 @@ function onMouseDown(event: Event) {
   if (elem.closest('[data-block-type="table-cell"]')) {
     isSelectionOperation = true
   } else if (elem.tagName === 'DIV' && elem.closest('.column-resizer-item')) {
-    if (editorWhenMouseDown === null) { return }
+    if (editorWhenMouseDown === null || tablePathWhenMouseDown === null) { return }
 
     // 记录必要信息
     isMouseDownForResize = true
@@ -183,22 +188,47 @@ function calculateAdjacentWidthsByBorderPosition(
 const onMouseMove = throttle((event: Event) => {
   if (!isMouseDownForResize) { return }
   if (editorWhenMouseDown === null) { return }
+  if (tablePathWhenMouseDown === null) { return }
   event.preventDefault()
 
   const { clientX } = event as MouseEvent
   const widthChange = clientX - clientXWhenMouseDown // 计算宽度变化
 
-  const [[elemNode]] = Editor.nodes(editorWhenMouseDown, {
-    match: isOfType(editorWhenMouseDown, 'table'),
-  })
-  const { columnWidths = [], resizingIndex = -1 } = elemNode as TableElement
+  let tableNode: TableElement | null = null
+  let tablePath: Path | null = null
+
+  try {
+    const [node, path] = Editor.node(editorWhenMouseDown, tablePathWhenMouseDown)
+
+    if (Editor.isEditor(node) || !SlateElement.isElement(node) || node.type !== 'table') {
+      return
+    }
+
+    tableNode = node as TableElement
+    tablePath = path
+  } catch {
+    return
+  }
+
+  if (tableNode === null || tablePath === null) { return }
+
+  const { columnWidths = [], resizingIndex = -1 } = tableNode
+
+  if (columnWidths.length === 0 || resizingIndex < 0 || resizingIndex >= columnWidths.length) {
+    return
+  }
 
   let adjustColumnWidths: number[]
-  const tableNode = DomEditor.getSelectedNodeByType(editorWhenMouseDown, 'table') as TableElement
-  const tableDom = DomEditor.toDOMNode(editorWhenMouseDown, tableNode)
+  let tableDom: HTMLElement | null = null
+
+  try {
+    tableDom = DomEditor.toDOMNode(editorWhenMouseDown, tableNode)
+  } catch {
+    tableDom = null
+  }
 
   // 所有列都采用相同的拖拽逻辑：当前列宽度增加，其他列不变
-  const tableElement = tableDom.querySelector('.table')
+  const tableElement = tableDom?.querySelector('.table')
 
   if (tableElement) {
     const tableRect = tableElement.getBoundingClientRect()
@@ -219,7 +249,7 @@ const onMouseMove = throttle((event: Event) => {
 
   // 应用新的列宽度
   Transforms.setNodes(editorWhenMouseDown, { columnWidths: adjustColumnWidths } as TableElement, {
-    mode: 'highest',
+    at: tablePath,
   })
 }, 100)
 
@@ -227,6 +257,7 @@ function onMouseUp(_event: Event) {
   isSelectionOperation = false
   isMouseDownForResize = false
   editorWhenMouseDown = null
+  tablePathWhenMouseDown = null
   document.body.style.cursor = ''
 
   // 解绑事件
@@ -326,7 +357,13 @@ export function handleCellBorderHighlight(editor: IDomEditor, e: MouseEvent) {
   }
 }
 
-export function handleCellBorderMouseDown(editor: IDomEditor, _elemNode: SlateElement) {
+export function handleCellBorderMouseDown(editor: IDomEditor, elemNode: SlateElement) {
   if (isMouseDownForResize) { return } // 此时正在修改列宽
   editorWhenMouseDown = editor
+
+  try {
+    tablePathWhenMouseDown = DomEditor.findPath(editor, elemNode)
+  } catch {
+    tablePathWhenMouseDown = null
+  }
 }

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -372,6 +372,108 @@ test.describe('Basic Editor', () => {
     expect(hoverAtDomBorder.resizingRowIndex).toBe(0)
   })
 
+  test('regression #297: column resize should work after setHtml without selecting table first', async ({ page }) => {
+    await page.evaluate(() => {
+      const editor = (window as any).wangEditorExampleBridge?.editor
+
+      if (!editor) {
+        throw new Error('editor not ready')
+      }
+
+      editor.setHtml(`
+        <p>before table</p>
+        <table style="width: 100%;">
+          <tbody>
+            <tr><td>col-1</td><td>col-2</td><td>col-3</td></tr>
+            <tr><td>a</td><td>b</td><td>c</td></tr>
+          </tbody>
+        </table>
+        <p>after table</p>
+      `)
+    })
+
+    const metrics = await page.evaluate(() => {
+      const table = document.querySelector('[data-testid="editor-textarea"] table.table') as HTMLTableElement | null
+      const firstCol = table?.querySelector('col') as HTMLTableColElement | null
+
+      if (!table || !firstCol) {
+        throw new Error('table not ready')
+      }
+
+      table.scrollIntoView({ block: 'center', inline: 'nearest' })
+      const tableRect = table.getBoundingClientRect()
+      const firstColWidth = Number(firstCol.getAttribute('width') || 0)
+
+      if (!Number.isFinite(firstColWidth) || firstColWidth <= 0) {
+        throw new Error('first column width is invalid')
+      }
+
+      return {
+        borderX: tableRect.left + firstColWidth,
+        borderY: tableRect.top + tableRect.height / 2,
+        beforeWidth: firstColWidth,
+      }
+    })
+
+    await page.locator('[data-testid="editor-textarea"] p').last().click()
+    await page.evaluate(() => {
+      const editor = (window as any).wangEditorExampleBridge?.editor
+      const tableNode = editor?.children?.find((n: any) => n?.type === 'table')
+
+      if (!tableNode) {
+        throw new Error('table node not found')
+      }
+
+      // 在 e2e 中直接设置索引，稳定触发列拖拽逻辑
+      tableNode.resizingIndex = 0
+    })
+
+    await page.evaluate(({ borderX, borderY }) => {
+      const hotzone = document.querySelector('.column-resizer .resizer-line-hotzone') as HTMLElement | null
+
+      if (!hotzone) {
+        throw new Error('resize hotzone not found')
+      }
+
+      hotzone.dispatchEvent(new MouseEvent('mousedown', {
+        bubbles: true,
+        cancelable: true,
+        clientX: borderX,
+        clientY: borderY,
+      }))
+      window.dispatchEvent(new MouseEvent('mousemove', {
+        bubbles: true,
+        cancelable: true,
+        clientX: borderX + 60,
+        clientY: borderY,
+      }))
+      window.dispatchEvent(new MouseEvent('mouseup', {
+        bubbles: true,
+        cancelable: true,
+        clientX: borderX + 60,
+        clientY: borderY,
+      }))
+    }, {
+      borderX: metrics.borderX,
+      borderY: metrics.borderY,
+    })
+    await page.waitForTimeout(150)
+
+    const afterWidth = await page.evaluate(() => {
+      const firstCol = document.querySelector(
+        '[data-testid="editor-textarea"] table col',
+      ) as HTMLTableColElement | null
+
+      if (!firstCol) {
+        throw new Error('first table col not found')
+      }
+
+      return Number(firstCol.getAttribute('width') || 0)
+    })
+
+    expect(afterWidth).toBeGreaterThan(metrics.beforeWidth + 8)
+  })
+
   test('pastes plain text', async ({ page }) => {
     await pasteText(page, 'pasted text')
 


### PR DESCRIPTION
## Changes Overview
Fixes table column resize failing after `setHtml` when selection is outside table (`#297`).

## Implementation Approach
- Capture target table path on column-resize `mousedown`.
- During drag `mousemove`, resolve and update the same table by captured path.
- Remove dependency on current selection (`DomEditor.getSelectedNodeByType`) for this drag flow.

## Testing Done
- Added e2e regression: `regression #297: column resize should work after setHtml without selecting table first`.
- Ran:
  - `pnpm e2e --grep "regression #297"`
  - `pnpm e2e --grep "deletes a table row|deletes a table column|regression #811|regression #297"`
  - `pnpm eslint packages/table-module/src/module/column-resize.ts tests/e2e/editor.spec.ts`
  - `pnpm turbo build --filter=@wangeditor-next/table-module --filter=@wangeditor-next/editor`

## Verification Steps
1. Open `examples/default-mode.html` and create editor.
2. Execute `editor.setHtml(...)` with a `table style="width: 100%"` payload.
3. Click outside table (e.g. paragraph below table).
4. Drag first column resizer.
5. Confirm first column width increases on first drag (no extra cell click needed).

## Additional Notes
- Added changeset: patch for `@wangeditor-next/table-module` and `@wangeditor-next/editor`.

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
Closes #297


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Table column resizing now reliably works after editor content is updated (e.g., setting HTML), even when the table isn’t currently selected.

* **Tests**
  * Added an end-to-end regression test to confirm column-resize behavior remains stable after content updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/822?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->