### PR TITLE
fix(table-module): keep table shape when cutting batch-selected cells

### DIFF
--- a/.changeset/tough-radios-play.md
+++ b/.changeset/tough-radios-play.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/table-module': patch
+---
+
+Fix table multi-cell cut behavior so cutting selected cells clears content without merging cells or corrupting table structure.

--- a/packages/table-module/__tests__/plugin.test.ts
+++ b/packages/table-module/__tests__/plugin.test.ts
@@ -8,6 +8,7 @@ import * as slate from 'slate'
 
 import createEditor from '../../../tests/utils/create-editor'
 import withTable from '../src/module/plugin'
+import { TableCursor } from '../src/module/table-cursor'
 import { EDITOR_TO_SELECTION } from '../src/module/weak-maps'
 
 describe('TableModule module', () => {
@@ -485,6 +486,67 @@ describe('TableModule module', () => {
 
       expect(originalSetNodesSpy).toHaveBeenCalledTimes(1)
       expect(originalSetNodesSpy).toHaveBeenCalledWith(wrappedEditor, { hidden: true }, {})
+    })
+
+    test('use withTable plugin when deleteFragment should only clear selected cell text in batch table selection', () => {
+      const editor = createEditor({
+        content: [
+          {
+            type: 'table',
+            width: 'auto',
+            children: [
+              {
+                type: 'table-row',
+                children: [
+                  { type: 'table-cell', children: [{ text: 'A' }] },
+                  { type: 'table-cell', children: [{ text: 'B' }] },
+                ],
+              },
+              {
+                type: 'table-row',
+                children: [
+                  { type: 'table-cell', children: [{ text: 'C' }] },
+                  { type: 'table-cell', children: [{ text: 'D' }] },
+                ],
+              },
+            ],
+            columnWidths: [100, 100],
+          },
+        ],
+      })
+      const wrappedEditor = withTable(editor)
+      const unselectSpy = vi.spyOn(TableCursor, 'unselect')
+
+      const tableSelection = [[
+        [
+          [slate.Node.get(wrappedEditor, [0, 0, 0]) as any, [0, 0, 0]],
+          {
+            rtl: 1, ltr: 1, ttb: 1, btt: 1,
+          },
+        ],
+        [
+          [slate.Node.get(wrappedEditor, [0, 0, 1]) as any, [0, 0, 1]],
+          {
+            rtl: 1, ltr: 1, ttb: 1, btt: 1,
+          },
+        ],
+      ]] as any
+
+      EDITOR_TO_SELECTION.set(wrappedEditor, tableSelection)
+      wrappedEditor.selection = {
+        anchor: { path: [0, 0, 0, 0], offset: 0 },
+        focus: { path: [0, 0, 1, 0], offset: 1 },
+      }
+
+      wrappedEditor.deleteFragment()
+
+      expect((slate.Node.get(wrappedEditor, [0, 0, 0, 0]) as slate.Text).text).toBe('')
+      expect((slate.Node.get(wrappedEditor, [0, 0, 1, 0]) as slate.Text).text).toBe('')
+      expect((slate.Node.get(wrappedEditor, [0, 1, 0, 0]) as slate.Text).text).toBe('C')
+      expect((slate.Node.get(wrappedEditor, [0, 1, 1, 0]) as slate.Text).text).toBe('D')
+      expect((slate.Node.get(wrappedEditor, [0, 0]).children as any[])).toHaveLength(2)
+      expect((slate.Node.get(wrappedEditor, [0, 1]).children as any[])).toHaveLength(2)
+      expect(unselectSpy).toHaveBeenCalledWith(wrappedEditor)
     })
   })
 })

--- a/packages/table-module/src/module/plugin.ts
+++ b/packages/table-module/src/module/plugin.ts
@@ -18,6 +18,7 @@ import {
   Transforms,
 } from 'slate'
 
+import { TableCursor } from './table-cursor'
 import { EDITOR_TO_SELECTION } from './weak-maps'
 import { withSelection } from './with-selection'
 
@@ -166,6 +167,7 @@ function withTable<T extends IDomEditor>(editor: T): T {
     insertData,
     handleTab,
     selectAll,
+    deleteFragment,
   } = editor
   const newEditor = editor
 
@@ -369,6 +371,55 @@ function withTable<T extends IDomEditor>(editor: T): T {
     }
 
     newEditor.select(newSelection) // 选中 table-cell 内部的全部文字
+  }
+
+  // 重写 deleteFragment - 批量选中 table-cell 时只清空单元格内容，不破坏表格结构
+  newEditor.deleteFragment = options => {
+    const tableSelection = EDITOR_TO_SELECTION.get(newEditor)
+
+    if (tableSelection && tableSelection.length > 0) {
+      const selectedCellPaths: Path[] = []
+
+      tableSelection.forEach(row => {
+        row.forEach(cell => {
+          const [, cellPath] = cell[0]
+
+          if (!selectedCellPaths.some(path => Path.equals(path, cellPath))) {
+            selectedCellPaths.push(cellPath)
+          }
+        })
+      })
+
+      const firstCellPath = selectedCellPaths[0]
+
+      selectedCellPaths.forEach(cellPath => {
+        // 在复杂操作后 path 可能失效，跳过即可
+        if (!Node.has(newEditor, cellPath)) { return }
+
+        const start = Editor.start(newEditor, cellPath)
+        const end = Editor.end(newEditor, cellPath)
+
+        // 每次只选中单个 cell 的内容，再走原生 deleteFragment
+        // 避免跨 cell 删除触发 merge_node，导致表格结构错乱
+        Transforms.select(newEditor, {
+          anchor: start,
+          focus: end,
+        })
+        deleteFragment(options)
+      })
+
+      TableCursor.unselect(newEditor)
+
+      if (firstCellPath && Node.has(newEditor, firstCellPath)) {
+        const start = Editor.start(newEditor, firstCellPath)
+
+        Transforms.select(newEditor, start)
+      }
+
+      return
+    }
+
+    deleteFragment(options)
   }
 
   /**

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -474,6 +474,79 @@ test.describe('Basic Editor', () => {
     expect(afterWidth).toBeGreaterThan(metrics.beforeWidth + 8)
   })
 
+  test('regression #574: cutting batch-selected table cells should keep table shape and only clear selected cells', async ({ page }) => {
+    const pageErrors: string[] = []
+
+    page.on('pageerror', err => {
+      pageErrors.push(err?.stack || err?.message || String(err))
+    })
+
+    await page.evaluate(() => {
+      const editor = (window as any).wangEditorExampleBridge?.editor
+
+      if (!editor) {
+        throw new Error('editor not ready')
+      }
+
+      editor.setHtml(`
+        <table style="width: 100%;">
+          <tbody>
+            <tr><td>A</td><td>B</td></tr>
+            <tr><td>C</td><td>D</td></tr>
+          </tbody>
+        </table>
+      `)
+    })
+
+    await page.evaluate(() => {
+      const editor = (window as any).wangEditorExampleBridge?.editor
+
+      if (!editor) {
+        throw new Error('editor not ready')
+      }
+
+      const tableIndex = editor.children.findIndex((node: any) => node?.type === 'table')
+
+      if (tableIndex < 0) {
+        throw new Error('table node not found')
+      }
+
+      editor.select({
+        anchor: { path: [tableIndex, 0, 0, 0], offset: 0 },
+        focus: { path: [tableIndex, 0, 1, 0], offset: 1 },
+      })
+    })
+    await page.waitForTimeout(150)
+
+    const selectedCount = await page.locator('[data-testid="editor-textarea"] td.w-e-selected, [data-testid="editor-textarea"] th.w-e-selected').count()
+
+    expect(selectedCount).toBeGreaterThanOrEqual(2)
+
+    await page.keyboard.press('Control+X')
+    await page.waitForTimeout(120)
+
+    const tableState = await page.evaluate(() => {
+      const rows = Array.from(document.querySelectorAll('[data-testid="editor-textarea"] table tr'))
+      const matrix = rows.map(row => {
+        const cells = Array.from(row.querySelectorAll('td,th')) as HTMLElement[]
+
+        return cells.map(cell => (cell.textContent || '').replace(/\s+/g, ''))
+      })
+
+      return {
+        rowCount: rows.length,
+        colCounts: rows.map(row => row.querySelectorAll('td,th').length),
+        matrix,
+      }
+    })
+
+    expect(pageErrors).toEqual([])
+    expect(tableState.rowCount).toBe(2)
+    expect(tableState.colCounts).toEqual([2, 2])
+    expect(tableState.matrix[0]).toEqual(['', ''])
+    expect(tableState.matrix[1]).toEqual(['C', 'D'])
+  })
+
   test('pastes plain text', async ({ page }) => {
     await pasteText(page, 'pasted text')
 


### PR DESCRIPTION
## Summary
Fixes #574: cutting batch-selected table cells (Ctrl+X) could merge/remove cells and corrupt table structure.

## Root Cause
Batch table selection was tracked in `EDITOR_TO_SELECTION`, but deletion could still run over a cross-cell expanded range and trigger Slate `merge_node` across adjacent table cells.

## Changes
- Override table plugin `deleteFragment` for batch-selected cells.
- Iterate selected cell paths, select each cell content range independently, and call original `deleteFragment` per cell.
- Clear table cursor selection after processing and restore caret to first selected cell.
- Add unit regression in `packages/table-module/__tests__/plugin.test.ts`.
- Add Playwright regression in `tests/e2e/editor.spec.ts`.
- Add changeset for `@wangeditor-next/table-module` patch release.

## Verification
- `pnpm vitest run packages/table-module/__tests__/plugin.test.ts`
- `pnpm e2e --grep "regression #574"`
- `pnpm eslint packages/table-module/src/module/plugin.ts packages/table-module/__tests__/plugin.test.ts tests/e2e/editor.spec.ts`

## Risk
- Behavior change is scoped to `deleteFragment` when batch table selection exists.
- Non-table and single-cell selection paths still use original `deleteFragment`.

## Rollback
- Revert commit `3b468b6e` to restore previous behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a table editing issue where cutting multiple selected cells could corrupt the table structure or cause cells to merge unexpectedly. Cell contents are now properly cleared while preserving the complete table structure and cell integrity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/823?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->