### PR TITLE
test(e2e): cover table setHtml in-table focus regression

### DIFF
--- a/tests/e2e/framework-regression.spec.ts
+++ b/tests/e2e/framework-regression.spec.ts
@@ -227,5 +227,128 @@ test.describe('Framework parity regression', () => {
       expect(resized || clampedAtMinWidth).toBe(true)
       expect(pageErrors).toEqual([])
     })
+
+    test(`${target.name}: setHtml in-table focus should keep single table and stable output`, async ({ page }) => {
+      const pageErrors: string[] = []
+
+      page.on('pageerror', err => {
+        pageErrors.push(err?.stack || err?.message || String(err))
+      })
+
+      await openTarget(page, target)
+
+      const firstHtml = `
+        <table border="1" cellspacing="0" width="100%">
+          <tbody>
+            <tr>
+              <td style="font-size: 14px; color: #fed865; vertical-align: middle; text-align: center; background-color: #44739f;">A1</td>
+              <td>B1</td>
+            </tr>
+          </tbody>
+        </table>
+        <p><br></p>
+      `
+      const secondHtml = `
+        <table border="1" cellspacing="0" width="100%">
+          <tbody>
+            <tr>
+              <td style="font-size: 14px; color: #fed865; vertical-align: middle; text-align: center; background-color: #44739f;">A2</td>
+              <td>B2</td>
+            </tr>
+          </tbody>
+        </table>
+        <p><br></p>
+      `
+
+      await page.evaluate(({ html }) => {
+        const globalWindow = window as any
+        const editor = globalWindow.wangEditorExampleBridge?.editor
+          || globalWindow.vue2Editor
+          || globalWindow.vue3Editor
+          || globalWindow.reactEditor
+
+        if (!editor) {
+          throw new Error('editor not ready')
+        }
+
+        const normalizeHtml = (value: string) => value.replace(/\s+/g, ' ').trim()
+
+        editor.setHtml(html)
+        const afterFirstSet = normalizeHtml(editor.getHtml())
+
+        editor.setHtml(html)
+        const afterSecondSet = normalizeHtml(editor.getHtml())
+
+        globalWindow.setHtmlStableFlag = afterFirstSet === afterSecondSet
+        globalWindow.setHtmlTableCountAfterFirst = (afterFirstSet.match(/<table/gi) || []).length
+        globalWindow.setHtmlTableCountAfterSecond = (afterSecondSet.match(/<table/gi) || []).length
+
+        const tableIndex = editor.children.findIndex((node: any) => node?.type === 'table')
+
+        if (tableIndex < 0) {
+          throw new Error('table node not found')
+        }
+
+        editor.select({
+          anchor: { path: [tableIndex, 0, 0, 0], offset: 0 },
+          focus: { path: [tableIndex, 0, 0, 0], offset: 1 },
+        })
+      }, { html: firstHtml })
+
+      await page.waitForTimeout(120)
+
+      await page.evaluate(({ html }) => {
+        const globalWindow = window as any
+        const editor = globalWindow.wangEditorExampleBridge?.editor
+          || globalWindow.vue2Editor
+          || globalWindow.vue3Editor
+          || globalWindow.reactEditor
+
+        if (!editor) {
+          throw new Error('editor not ready')
+        }
+
+        editor.setHtml(html)
+      }, { html: secondHtml })
+
+      await page.waitForTimeout(160)
+
+      const snapshot = await page.evaluate(() => {
+        const globalWindow = window as any
+        const editor = globalWindow.wangEditorExampleBridge?.editor
+          || globalWindow.vue2Editor
+          || globalWindow.vue3Editor
+          || globalWindow.reactEditor
+        const root = document.querySelector('[data-testid="editor-textarea"]') as HTMLElement | null
+        const tableElements = Array.from(root?.querySelectorAll('table') || [])
+        const nestedTableElements = Array.from(root?.querySelectorAll('table table') || [])
+        const firstCell = tableElements[0]?.querySelector('tr td, tr th') as HTMLElement | null
+        const modelTableCount = (editor?.children || []).filter((node: any) => node?.type === 'table').length
+        const currentHtml = editor?.getHtml?.() || ''
+
+        return {
+          stableBetweenRepeatedSetHtml: !!globalWindow.setHtmlStableFlag,
+          tableCountAfterFirstSet: Number(globalWindow.setHtmlTableCountAfterFirst || 0),
+          tableCountAfterSecondSet: Number(globalWindow.setHtmlTableCountAfterSecond || 0),
+          currentHtmlTableCount: (currentHtml.match(/<table/gi) || []).length,
+          modelTableCount,
+          domTableCount: tableElements.length,
+          nestedTableCount: nestedTableElements.length,
+          firstCellText: (firstCell?.textContent || '').replace(/\s+/g, ''),
+          firstCellStyle: firstCell?.getAttribute('style') || '',
+        }
+      })
+
+      expect(snapshot.stableBetweenRepeatedSetHtml).toBe(true)
+      expect(snapshot.tableCountAfterFirstSet).toBe(1)
+      expect(snapshot.tableCountAfterSecondSet).toBe(1)
+      expect(snapshot.currentHtmlTableCount).toBe(1)
+      expect(snapshot.modelTableCount).toBe(1)
+      expect(snapshot.domTableCount).toBe(1)
+      expect(snapshot.nestedTableCount).toBe(0)
+      expect(snapshot.firstCellText).toBe('A2')
+      expect(snapshot.firstCellStyle).toContain('background-color')
+      expect(pageErrors).toEqual([])
+    })
   }
 })

--- a/tests/e2e/framework-regression.spec.ts
+++ b/tests/e2e/framework-regression.spec.ts
@@ -350,5 +350,112 @@ test.describe('Framework parity regression', () => {
       expect(snapshot.firstCellStyle).toContain('background-color')
       expect(pageErrors).toEqual([])
     })
+
+    test(`${target.name}: table multi-cell bold should affect only selected cells`, async ({ page }) => {
+      const pageErrors: string[] = []
+
+      page.on('pageerror', err => {
+        pageErrors.push(err?.stack || err?.message || String(err))
+      })
+
+      await openTarget(page, target)
+
+      await page.evaluate(() => {
+        const globalWindow = window as any
+        const editor = globalWindow.wangEditorExampleBridge?.editor
+          || globalWindow.vue2Editor
+          || globalWindow.vue3Editor
+          || globalWindow.reactEditor
+
+        if (!editor) {
+          throw new Error('editor not ready')
+        }
+
+        editor.setHtml(`
+          <table style="width: 100%;">
+            <tbody>
+              <tr><td>A</td><td>B</td></tr>
+              <tr><td>C</td><td>D</td></tr>
+            </tbody>
+          </table>
+          <p><br></p>
+        `)
+
+        const tableIndex = editor.children.findIndex((node: any) => node?.type === 'table')
+
+        if (tableIndex < 0) {
+          throw new Error('table node not found')
+        }
+
+        editor.select({
+          anchor: { path: [tableIndex, 0, 0, 0], offset: 0 },
+          focus: { path: [tableIndex, 0, 1, 0], offset: 1 },
+        })
+      })
+
+      await page.waitForTimeout(150)
+
+      const selectionState = await page.evaluate(() => {
+        const globalWindow = window as any
+        const editor = globalWindow.wangEditorExampleBridge?.editor
+          || globalWindow.vue2Editor
+          || globalWindow.vue3Editor
+          || globalWindow.reactEditor
+
+        if (!editor) {
+          throw new Error('editor not ready')
+        }
+
+        const tableSelection = editor.getTableSelection?.() || []
+
+        return {
+          tableSelectionRows: tableSelection.length,
+          selectedCells: tableSelection.flat().length,
+        }
+      })
+      const boldMenu = getToolbarMenu(page, 'bold').first()
+
+      expect(selectionState.tableSelectionRows).toBeGreaterThanOrEqual(1)
+      expect(selectionState.selectedCells).toBeGreaterThanOrEqual(2)
+      await expect(boldMenu).not.toHaveClass(/disabled/)
+
+      await boldMenu.click()
+      await page.waitForTimeout(180)
+
+      const markState = await page.evaluate(() => {
+        const globalWindow = window as any
+        const editor = globalWindow.wangEditorExampleBridge?.editor
+          || globalWindow.vue2Editor
+          || globalWindow.vue3Editor
+          || globalWindow.reactEditor
+
+        if (!editor) {
+          throw new Error('editor not ready')
+        }
+
+        const tableIndex = editor.children.findIndex((node: any) => node?.type === 'table')
+
+        if (tableIndex < 0) {
+          throw new Error('table node not found after bold')
+        }
+
+        const getCellTextNode = (row: number, col: number) => {
+          return editor.children?.[tableIndex]?.children?.[row]?.children?.[col]?.children?.[0] || {}
+        }
+
+        return {
+          aBold: !!getCellTextNode(0, 0).bold,
+          bBold: !!getCellTextNode(0, 1).bold,
+          cBold: !!getCellTextNode(1, 0).bold,
+          dBold: !!getCellTextNode(1, 1).bold,
+        }
+      })
+
+      expect(markState.aBold).toBe(true)
+      expect(markState.bBold).toBe(true)
+      expect(markState.cBold).toBe(false)
+      expect(markState.dBold).toBe(false)
+      expect(pageErrors).toEqual([])
+    })
   }
 })


### PR DESCRIPTION
## Summary
Add framework-parity regressions for historical table issues (#133, #148, #561).

## Why
- #133 / #148 describe table corruption around repeated `setHtml` and `setHtml` while caret is inside table cells.
- #561 asks for editing text style across batch-selected table cells.

These scenarios are now passing on current `master`, but lacked automated cross-framework guardrails.

## Changes
In `tests/e2e/framework-regression.spec.ts`, add and run across all targets:
- html-core (`/examples/default-mode.html`)
- vue2 wrapper (`/examples/framework-vue2.html`)
- vue3 wrapper (`http://127.0.0.1:3103/`)
- react wrapper (`http://127.0.0.1:3102/`)

New regressions:
1. `setHtml in-table focus should keep single table and stable output`
- repeated `setHtml` output stays stable
- one table remains in model/html/dom
- no nested `table table`
- table cell style survives overwrite

2. `table multi-cell bold should affect only selected cells`
- batch select two cells
- click bold toolbar menu
- assert marks apply to selected cells only

## Verification
- `pnpm eslint tests/e2e/framework-regression.spec.ts`
- `pnpm e2e --grep "setHtml in-table focus should keep single table and stable output"`
- `pnpm e2e --grep "table multi-cell bold should affect only selected cells"`
- `pnpm e2e --grep "Framework parity regression"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end regression test to verify table-focused editing remains stable when HTML is reset.
  * Confirms a single table is preserved (no nested tables), a targeted cell update is applied, cell styling (background-color) is retained, and no page errors occur.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/824?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->