### PR TITLE
fix(ci): stop using secrets context in release workflow if conditions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
     strategy:
       matrix:
         node-version: ['22.13.0']
+    env:
+      DOCS_REPO_DISPATCH_TOKEN: ${{ secrets.DOCS_REPO_DISPATCH_TOKEN }}
 
     steps:
       # 检出代码库
@@ -123,16 +125,16 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Trigger docs site deployment for released editor version
-        if: steps.changesets.outputs.published == 'true' && github.ref_name == 'master' && secrets.DOCS_REPO_DISPATCH_TOKEN != ''
+        if: steps.changesets.outputs.published == 'true' && github.ref_name == 'master' && env.DOCS_REPO_DISPATCH_TOKEN != ''
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.DOCS_REPO_DISPATCH_TOKEN }}
+          token: ${{ env.DOCS_REPO_DISPATCH_TOKEN }}
           repository: wangeditor-next/docs
           event-type: editor-release-published
           client-payload: >-
             {"version":"${{ steps.editor_version.outputs.version }}","sourceRepo":"${{ github.repository }}","sourceSha":"${{ github.sha }}","sourceRunId":"${{ github.run_id }}"}
 
       - name: Warn when docs dispatch token is missing
-        if: steps.changesets.outputs.published == 'true' && github.ref_name == 'master' && secrets.DOCS_REPO_DISPATCH_TOKEN == ''
+        if: steps.changesets.outputs.published == 'true' && github.ref_name == 'master' && env.DOCS_REPO_DISPATCH_TOKEN == ''
         run: |
           echo "::warning::DOCS_REPO_DISPATCH_TOKEN is not set. Skip triggering wangeditor-next/docs deployment."


### PR DESCRIPTION
## Summary
- avoid referencing secrets context directly in step if conditions in release.yml
- use job-level env mapping for DOCS_REPO_DISPATCH_TOKEN and check env variable in conditions

## Why
Release workflow started failing as a workflow-file issue, which blocked automatic npm publish after merge of release commits.

## Impact
After this merges to master, release workflow can be parsed and continue to automatic Changesets publish as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored documentation deployment workflow configuration while maintaining existing release functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/825?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->