### PR TITLE
fix(table-module): resolve first-node table delete flow

### DIFF
--- a/.changeset/bright-cars-count.md
+++ b/.changeset/bright-cars-count.md
@@ -1,0 +1,9 @@
+---
+'@wangeditor-next/core': patch
+'@wangeditor-next/table-module': patch
+'@wangeditor-next/editor': patch
+---
+
+Fix first-node table lifecycle by removing the prepended empty paragraph workaround and making `clear()` reliably reset content when table is the first top-level node.
+
+Add regressions for issue #47 to ensure first inserted table can be removed via select-all delete/cut and that setHtml fully replaces previous table content.

--- a/packages/core/__tests__/editor/plugins/with-content.test.ts
+++ b/packages/core/__tests__/editor/plugins/with-content.test.ts
@@ -307,6 +307,35 @@ describe('editor content API', () => {
     expect(editor.getText()).toBe('')
   })
 
+  it('clear should reset editor when the first top-level node is a table', () => {
+    const editor = createEditor({
+      content: [
+        {
+          type: 'table',
+          children: [
+            {
+              type: 'table-row',
+              children: [
+                {
+                  type: 'table-cell',
+                  children: [{ text: 'A' }],
+                } as any,
+              ],
+            } as any,
+          ],
+        } as any,
+        {
+          type: 'paragraph',
+          children: [{ text: '' }],
+        } as any,
+      ],
+    })
+
+    editor.clear()
+
+    expect(editor.children).toEqual([{ type: 'paragraph', children: [{ text: '' }] }])
+  })
+
   it('undo', () => {
     const editor = createEditor()
 

--- a/packages/core/src/editor/plugins/with-content.ts
+++ b/packages/core/src/editor/plugins/with-content.ts
@@ -358,12 +358,11 @@ export const withContent = <T extends Editor>(editor: T) => {
       },
     ]
 
-    Transforms.delete(e, {
-      at: {
-        anchor: Editor.start(e, []),
-        focus: Editor.end(e, []),
-      },
-    })
+    // 逐个删除顶层节点，避免首节点为 table 等复杂结构时
+    // 全文 range 删除出现残留节点（导致 setHtml 追加而非覆盖）。
+    for (let i = e.children.length - 1; i >= 0; i -= 1) {
+      Transforms.removeNodes(e, { at: [i] })
+    }
 
     if (e.children.length === 0) {
       Transforms.insertNodes(e, initialEditorValue)

--- a/packages/table-module/__tests__/menu/insert-table.test.ts
+++ b/packages/table-module/__tests__/menu/insert-table.test.ts
@@ -243,4 +243,35 @@ describe('Table Module Insert Table Menu', () => {
       expect.any(Object),
     )
   })
+
+  test('should insert table as first node without prepending an empty paragraph', () => {
+    const insertTableMenu = new InsertTable()
+    const editor = createEditor()
+
+    editor.children = [] as any
+    vi.spyOn(core.DomEditor, 'isSelectedEmptyParagraph').mockReturnValue(false)
+
+    const insertNodesFn = vi.fn()
+
+    vi.spyOn(slate.Transforms, 'insertNodes').mockImplementation(insertNodesFn)
+
+    const tablePanel = insertTableMenu.getPanelContentElem(editor)
+    const tdEl = $(tablePanel).find('td')[0]
+
+    tdEl.dispatchEvent(
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      }),
+    )
+
+    expect(insertNodesFn).toHaveBeenCalledTimes(1)
+    expect(insertNodesFn).toHaveBeenCalledWith(
+      editor,
+      expect.objectContaining({
+        type: 'table',
+      }),
+      expect.any(Object),
+    )
+  })
 })

--- a/packages/table-module/src/module/menu/InsertTable.ts
+++ b/packages/table-module/src/module/menu/InsertTable.ts
@@ -190,13 +190,6 @@ class InsertTable implements IDropPanelMenu {
       Transforms.removeNodes(editor, { mode: 'highest' })
     }
 
-    if (editor.children.length === 0) {
-      // table 作为第一个 children 时会导致无法正常删除
-      // 在当前位置插入空行，当前元素下移
-      const newElem = { type: 'paragraph', children: [{ text: '' }] }
-
-      Transforms.insertNodes(editor, newElem, { mode: 'highest' })
-    }
     // 插入表格
     const tableNode = genTableNode(editor, rowNum, colNum)
 

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -518,9 +518,23 @@ test.describe('Basic Editor', () => {
     })
     await page.waitForTimeout(150)
 
-    const selectedCount = await page.locator('[data-testid="editor-textarea"] td.w-e-selected, [data-testid="editor-textarea"] th.w-e-selected').count()
+    const selectionState = await page.evaluate(() => {
+      const editor = (window as any).wangEditorExampleBridge?.editor
 
-    expect(selectedCount).toBeGreaterThanOrEqual(2)
+      if (!editor) {
+        throw new Error('editor not ready')
+      }
+
+      const tableSelection = editor.getTableSelection?.() || []
+
+      return {
+        rows: tableSelection.length,
+        cells: tableSelection.flat().length,
+      }
+    })
+
+    expect(selectionState.rows).toBeGreaterThanOrEqual(1)
+    expect(selectionState.cells).toBeGreaterThanOrEqual(2)
 
     await page.keyboard.press('Control+X')
     await page.waitForTimeout(120)
@@ -580,6 +594,107 @@ test.describe('Basic Editor', () => {
     await page.locator('.w-e-panel-content-table td').first().click()
 
     await expect(page.getByTestId('editor-html')).toContainText('<table')
+  })
+
+  test('regression #47: first inserted table should be first node and removable by select-all delete/cut', async ({ page }) => {
+    await clearEditor(page)
+    await waitForMenuEnabled(page, 'insertTable')
+    await getToolbarMenu(page, 'insertTable').click()
+    await page.locator('.w-e-panel-content-table').waitFor({ state: 'visible' })
+    await page.locator('.w-e-panel-content-table td').first().click()
+    await page.waitForTimeout(120)
+
+    const afterInsertByMenu = await page.evaluate(() => {
+      const editor = (window as any).wangEditorExampleBridge?.editor
+
+      if (!editor) {
+        throw new Error('editor not ready')
+      }
+
+      return {
+        types: (editor.children || []).map((node: any) => node?.type || ''),
+        tableCount: (editor.children || []).filter((node: any) => node?.type === 'table').length,
+      }
+    })
+
+    expect(afterInsertByMenu.tableCount).toBe(1)
+    expect(afterInsertByMenu.types[0]).toBe('table')
+
+    await page.evaluate(() => {
+      const editor = (window as any).wangEditorExampleBridge?.editor
+
+      if (!editor) {
+        throw new Error('editor not ready')
+      }
+
+      editor.setHtml(`
+        <table style="width: 100%;">
+          <tbody>
+            <tr><td>A</td><td>B</td></tr>
+          </tbody>
+        </table>
+      `)
+    })
+    await page.waitForTimeout(120)
+
+    await page.locator('#w-e-textarea-1').click()
+    await page.keyboard.press('Control+A')
+    await page.keyboard.press('Backspace')
+    await page.waitForTimeout(120)
+
+    const afterBackspace = await page.evaluate(() => {
+      const editor = (window as any).wangEditorExampleBridge?.editor
+
+      if (!editor) {
+        throw new Error('editor not ready')
+      }
+
+      return {
+        tableCount: (editor.children || []).filter((node: any) => node?.type === 'table').length,
+        firstType: editor.children?.[0]?.type || '',
+      }
+    })
+
+    expect(afterBackspace.tableCount).toBe(0)
+    expect(afterBackspace.firstType).toBe('paragraph')
+
+    await page.evaluate(() => {
+      const editor = (window as any).wangEditorExampleBridge?.editor
+
+      if (!editor) {
+        throw new Error('editor not ready')
+      }
+
+      editor.setHtml(`
+        <table style="width: 100%;">
+          <tbody>
+            <tr><td>A</td><td>B</td></tr>
+          </tbody>
+        </table>
+      `)
+    })
+    await page.waitForTimeout(120)
+
+    await page.locator('#w-e-textarea-1').click()
+    await page.keyboard.press('Control+A')
+    await page.keyboard.press('Control+X')
+    await page.waitForTimeout(120)
+
+    const afterCut = await page.evaluate(() => {
+      const editor = (window as any).wangEditorExampleBridge?.editor
+
+      if (!editor) {
+        throw new Error('editor not ready')
+      }
+
+      return {
+        tableCount: (editor.children || []).filter((node: any) => node?.type === 'table').length,
+        firstType: editor.children?.[0]?.type || '',
+      }
+    })
+
+    expect(afterCut.tableCount).toBe(0)
+    expect(afterCut.firstType).toBe('paragraph')
   })
 
   test('uploads an image as base64', async ({ page }) => {


### PR DESCRIPTION
## Summary
Fix #47 by removing the first-table placeholder workaround and making first-node table content truly removable via select-all delete/cut.

## Root cause
Two behaviors combined into the long-standing issue:

1. `InsertTable` inserted an extra empty paragraph when table would become the first top-level node.
2. `core.clear()` used full-document range delete, which could leave residual nodes when first node was a table-like complex structure.

This made `setHtml` behave like append in edge cases and forced the placeholder workaround to hide the symptom.

## What changed
- `packages/table-module/src/module/menu/InsertTable.ts`
  - remove the "prepend empty paragraph" workaround when table is first node.
- `packages/core/src/editor/plugins/with-content.ts`
  - update `clear()` to remove top-level nodes one by one, then restore canonical empty paragraph.
- Tests
  - `packages/table-module/__tests__/menu/insert-table.test.ts`
    - assert first insertion no longer prepends paragraph.
  - `packages/core/__tests__/editor/plugins/with-content.test.ts`
    - assert `clear()` fully resets when first top-level node is table.
  - `tests/e2e/editor.spec.ts`
    - add regression #47: first inserted table is first node and removable by select-all backspace/cut.
    - stabilize #574 selection precondition assertion using `editor.getTableSelection()` instead of DOM class coupling.

## Compatibility and behavior notes
- Default user behavior improves: first inserted table can now be the real first block.
- Existing delete/cut flows remain the same from user perspective, but no longer depend on placeholder paragraph side effects.

## Risk checklist
- Potentially affected paths:
  - `clear()` semantics for non-paragraph first nodes.
  - table insertion when editor starts empty.
- Mitigation:
  - added unit tests for both core and table-module.
  - added browser regression for #47 and rechecked key table regressions (#574, row/col delete, insert table).

## Rollback strategy
- Revert commit `2b670421` to restore previous workaround behavior.

## Verification
- `pnpm vitest run packages/core/__tests__/editor/plugins/with-content.test.ts packages/table-module/__tests__/menu/insert-table.test.ts`
- `PLAYWRIGHT_SKIP_BUILD=1 pnpm e2e --grep "regression #47"`
- `PLAYWRIGHT_SKIP_BUILD=1 pnpm e2e --grep "regression #47|regression #574|inserts a table|deletes a table row|deletes a table column"`
- `pnpm eslint packages/core/src/editor/plugins/with-content.ts packages/core/__tests__/editor/plugins/with-content.test.ts packages/table-module/src/module/menu/InsertTable.ts packages/table-module/__tests__/menu/insert-table.test.ts tests/e2e/editor.spec.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed table handling when inserted as the first node in the editor.
  * Improved the `clear()` function to reliably reset content when the editor starts with a table.
  * Fixed `setHtml` to correctly replace existing table content rather than appending.
  * Ensured select-all delete and cut operations properly remove tables.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/829?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->