### PR TITLE
fix(core): resolve #502 modal drift and #541 extra blank paragraphs

### DIFF
--- a/packages/core/src/editor/plugins/with-content.ts
+++ b/packages/core/src/editor/plugins/with-content.ts
@@ -469,16 +469,47 @@ export const withContent = <T extends Editor>(editor: T) => {
         const $el = $(el)
         const parsedRes = parseElemHtml($el, e) as Element
 
-        if (Array.isArray(parsedRes)) {
-          parsedRes.forEach(parsedEl => insertElemToEditor(e, parsedEl))
-          insertedElemNum += 1 // 记录数量
-        } else {
-          insertElemToEditor(e, parsedRes)
-          insertedElemNum += 1 // 记录数量
-        }
+        const parsedElems = Array.isArray(parsedRes) ? parsedRes : [parsedRes]
+
+        parsedElems.forEach(parsedEl => insertElemToEditor(e, parsedEl))
+        insertedElemNum += parsedElems.length // 记录数量
 
         // 如果当前选中 void node ，则选区移动一下
         if (DomEditor.isSelectedVoidNode(e)) { e.move(1) }
+
+        const insertedInlineLikeElem = parsedElems.some(parsedEl => {
+          if (!Element.isElement(parsedEl)) { return false }
+          if (e.isInline(parsedEl)) { return true }
+
+          return parsedEl.children.some(child => {
+            return Element.isElement(child) && e.isInline(child)
+          })
+        })
+
+        // 如果本次插入的块内含 inline（如 link），选区会停在 inline 内部；
+        // 下一次插入 block 会发生 split 并产生多余空段落。这里显式把选区移到 inline 后的 text。
+        if (insertedInlineLikeElem && e.selection) {
+          const selectedInlineNodes = Editor.nodes(e, {
+            at: e.selection,
+            match: node => Element.isElement(node) && e.isInline(node),
+            universal: true,
+          })
+          const firstInlineEntry = selectedInlineNodes.next().value
+
+          if (firstInlineEntry) {
+            const [, inlinePath] = firstInlineEntry
+            const afterInlinePath = Path.next(inlinePath)
+
+            if (Editor.hasPath(e, afterInlinePath)) {
+              Transforms.select(e, {
+                anchor: { path: afterInlinePath, offset: 0 },
+                focus: { path: afterInlinePath, offset: 0 },
+              })
+            } else {
+              e.move(1)
+            }
+          }
+        }
 
         return
       }

--- a/packages/core/src/menus/helpers/position.ts
+++ b/packages/core/src/menus/helpers/position.ts
@@ -12,6 +12,10 @@ import { promiseResolveThen } from '../../utils/util'
 import { NODE_TO_ELEMENT } from '../../utils/weak-maps'
 import { IPositionStyle } from '../interface'
 
+function clampToNonNegative(value: number): number {
+  return value < 0 ? 0 : value
+}
+
 /**
  * 获取 textContainer 尺寸和定位
  * @param editor editor
@@ -76,18 +80,20 @@ export function getPositionBySelection(editor: IDomEditor): Partial<IPositionSty
   // 判断水平位置： modal/bar 显示在选区左侧，还是右侧？
   if (relativeLeft > containerWidth / 2) {
     // 选区 left 大于 containerWidth/2 （选区在 container 的右侧），则 modal/bar 显示在选区左侧
-    const r = containerWidth - relativeLeft
+    const r = clampToNonNegative(containerWidth - relativeLeft)
 
     positionStyle.right = `${r + 5}px` // 5px 间隔
   } else {
     // 否则（选区在 container 的左侧），modal/bar 显示在选区右侧
-    positionStyle.left = `${relativeLeft + 5}px` // 5px 间隔
+    const l = clampToNonNegative(relativeLeft)
+
+    positionStyle.left = `${l + 5}px` // 5px 间隔
   }
 
   // 判断垂直的位置： modal/bar 显示在选区上面，还是下面？
   if (relativeTop > containerHeight / 2) {
     // 选区 top  > containerHeight/2 （选区在 container 的下半部分），则 modal/bar 显示在选区的上面
-    const b = containerHeight - relativeTop
+    const b = clampToNonNegative(containerHeight - relativeTop)
 
     positionStyle.bottom = `${b + 5}px` // 5px 间隔
   } else {
@@ -168,10 +174,12 @@ export function getPositionByNode(
 
   if (type === 'bar') {
     // bar - 1. left 对齐 elem.left ；2. 尽量显示在 elem 上方
-    positionStyle.left = `${relativeLeft}px`
+    positionStyle.left = `${clampToNonNegative(relativeLeft)}px`
     if (relativeTop > 40) {
       // top > 40 则显示在上方
-      positionStyle.bottom = `${containerHeight - relativeTop + 5}px` // 5px 间隙
+      const b = clampToNonNegative(containerHeight - relativeTop)
+
+      positionStyle.bottom = `${b + 5}px` // 5px 间隙
     } else {
       // 否则，显示在下方
       positionStyle.top = `${relativeTop + elemHeight + 5}px` // 5px 间隙
@@ -186,15 +194,19 @@ export function getPositionByNode(
     // 水平
     if (!isVoidElem) {
       // 非 void node - left 和 elem left 对齐
-      positionStyle.left = `${relativeLeft}px`
+      positionStyle.left = `${clampToNonNegative(relativeLeft)}px`
     } else if (isInlineElem) {
       // inline void node 需要计算
       if (relativeLeft > (containerWidth - elemWidth) / 2) {
         // elem 在 container 的右侧，则 modal 显示在 elem 左侧
-        positionStyle.right = `${containerWidth - relativeLeft + 5}px`
+        const r = clampToNonNegative(containerWidth - relativeLeft)
+
+        positionStyle.right = `${r + 5}px`
       } else {
         // 否则 elem 在 container 左侧，则 modal 显示在 elem 右侧
-        positionStyle.left = `${relativeLeft + elemWidth + 5}px`
+        const l = clampToNonNegative(relativeLeft + elemWidth)
+
+        positionStyle.left = `${l + 5}px`
       }
     } else {
       // block void node 水平靠左即可
@@ -211,7 +223,9 @@ export function getPositionByNode(
       // 非 void node ，计算 top
     } else if (relativeTop > (containerHeight - elemHeight) / 2) {
       // elem 在 container 的下半部分，则 modal 显示在 elem 上方
-      positionStyle.bottom = `${containerHeight - relativeTop + 5}px`
+      const b = clampToNonNegative(containerHeight - relativeTop)
+
+      positionStyle.bottom = `${b + 5}px`
     } else {
       // elem 在 container 的上半部分，则 modal 显示在 elem 下方
       let t = relativeTop + elemHeight

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -192,6 +192,166 @@ test.describe('Basic Editor', () => {
     expect(domPointErrors).toEqual([])
   })
 
+  test('regression #609: insertData with complex html should not break editing', async ({ page }) => {
+    const pageErrors: string[] = []
+    const consoleErrors: string[] = []
+
+    page.on('pageerror', err => {
+      pageErrors.push(err?.message || String(err))
+    })
+
+    page.on('console', msg => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text())
+      }
+    })
+
+    const complexHtml = [
+      '<p>111111111111111111111111111111</p>',
+      '<table style="width:100%;table-layout:fixed"><tbody>',
+      '  <tr>',
+      '    <td style="text-align:center;vertical-align:top">Layout 布局</td>',
+      '    <td style="text-align:left">Dialog 对话框</td>',
+      '    <td style="display:none;text-align:center"></td>',
+      '  </tr>',
+      '  <tr>',
+      '    <td style="text-align:center">Container 容器</td>',
+      '    <td style="text-align:left"><span>在保留自然浏览状态的情况下，默认可中断前端弹窗操作。</span></td>',
+      '    <td style="display:none;text-align:right"></td>',
+      '  </tr>',
+      '</tbody></table>',
+      '<p>22222222222222222222222222222</p>',
+      '<p><img alt="tiny" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" /></p>',
+      '<p>3333333333333333333333333333333333333</p>',
+    ].join('')
+
+    await page.evaluate(value => {
+      const editor = (window as any).wangEditorExampleBridge?.editor
+
+      if (!editor) {
+        throw new Error('editor missing')
+      }
+
+      const transfer = new DataTransfer()
+
+      transfer.setData('text/plain', 'fallback')
+      transfer.setData('text/html', value)
+      editor.insertData(transfer)
+    }, complexHtml)
+
+    const editable = page.locator('[data-testid="editor-textarea"] [data-slate-editor]').first()
+
+    await editable.click()
+    await page.keyboard.type('after-insertData-check')
+
+    await expect(page.getByTestId('editor-html')).toContainText('after-insertData-check')
+
+    expect(pageErrors).toEqual([])
+    expect(consoleErrors).toEqual([])
+  })
+
+  test('regression #502: insertLink modal should stay in visible editor area after scroll-to-top', async ({ page }) => {
+    const pageErrors: string[] = []
+
+    page.on('pageerror', err => {
+      pageErrors.push(err?.message || String(err))
+    })
+
+    await page.evaluate(() => {
+      const editor = (window as any).wangEditorExampleBridge?.editor
+
+      if (!editor) {
+        throw new Error('editor missing')
+      }
+
+      const html = Array.from(
+        { length: 320 },
+        (_, i) => `<p>line-${String(i).padStart(3, '0')} abcdefghijklmnopqrstuvwxyz</p>`,
+      ).join('')
+
+      editor.setHtml(html)
+    })
+
+    const editable = page.locator('[data-testid="editor-textarea"] [contenteditable="true"]')
+
+    await editable.click()
+    await page.keyboard.press('Control+End')
+    await page.waitForTimeout(350)
+
+    await page.evaluate(() => {
+      const scroller = document.querySelector('[data-testid="editor-textarea"] .w-e-scroll') as HTMLElement | null
+
+      if (!scroller) {
+        throw new Error('scroller missing')
+      }
+      scroller.scrollTop = 0
+      window.scrollTo(0, 0)
+    })
+    await page.waitForTimeout(120)
+
+    const insertLinkMenu = await waitForMenuEnabled(page, 'insertLink')
+
+    await insertLinkMenu.click()
+    await expect(page.locator('.w-e-modal')).toBeVisible()
+
+    const metrics = await page.evaluate(() => {
+      const modal = document.querySelector('.w-e-modal')
+      const container = document.querySelector('[data-testid="editor-textarea"]')
+      const scroller = document.querySelector('[data-testid="editor-textarea"] .w-e-scroll') as HTMLElement | null
+      const modalRect = modal?.getBoundingClientRect()
+      const containerRect = container?.getBoundingClientRect()
+
+      return {
+        pageScrollY: window.scrollY,
+        scrollTop: scroller?.scrollTop ?? 0,
+        inContainerViewport: !!(modalRect && containerRect
+          && modalRect.top >= containerRect.top
+          && modalRect.bottom <= containerRect.bottom
+          && modalRect.left >= containerRect.left
+          && modalRect.right <= containerRect.right),
+      }
+    })
+
+    expect(metrics.pageScrollY).toBeLessThanOrEqual(1)
+    expect(metrics.scrollTop).toBe(0)
+    expect(metrics.inContainerViewport).toBe(true)
+    expect(pageErrors).toEqual([])
+  })
+
+  test('regression #541: dangerouslyInsertHtml should not append extra blank paragraphs', async ({ page }) => {
+    const metrics = await page.evaluate(() => {
+      const editor = (window as any).wangEditorExampleBridge?.editor
+
+      if (!editor) {
+        throw new Error('editor missing')
+      }
+
+      editor.clear()
+      const html = '<p><a>222</a></p><p>更新</p><p><a>222</a></p><p>更新</p><p><a>222</a></p><p>更新</p>'
+
+      editor.dangerouslyInsertHtml(html)
+
+      const output = editor.getHtml()
+      const wrapper = document.createElement('div')
+
+      wrapper.innerHTML = output
+      const paragraphs = Array.from(wrapper.querySelectorAll('p'))
+      const blankParagraphCount = paragraphs.filter(p => (p.textContent || '').trim() === '').length
+
+      return {
+        output,
+        paragraphCount: paragraphs.length,
+        blankParagraphCount,
+      }
+    })
+
+    expect(metrics.paragraphCount).toBe(6)
+    expect(metrics.blankParagraphCount).toBe(0)
+    expect(metrics.output).toBe(
+      '<p><a href="" target="">222</a></p><p>更新</p><p><a href="" target="">222</a></p><p>更新</p><p><a href="" target="">222</a></p><p>更新</p>',
+    )
+  })
+
   test('does not execute script when importing untrusted html', async ({ page }) => {
     const dialogs: string[] = []
 


### PR DESCRIPTION
## Summary
- fix #502 by clamping selection/node-based overlay coordinates so modal/hover bar stays inside the visible editor area even when selection is off-screen
- fix #541 by moving selection out of inline nodes after `dangerouslyInsertHtml` inserts inline-containing blocks, preventing subsequent block inserts from producing extra empty paragraphs
- add Playwright regressions for #502 and #541 (and keep #609 regression in the same e2e file)

## Reproduction / Verification
- reproduced #502 with long content + caret at end + scroll to top, then click `insertLink` (before fix, page jumped and modal was anchored to off-screen selection)
- reproduced #541 with:
  - `<p><a>222</a></p><p>更新</p><p><a>222</a></p><p>更新</p><p><a>222</a></p><p>更新</p>`
  - `dangerouslyInsertHtml` previously appended extra `<p><br></p>` paragraphs

## Tests
- `pnpm turbo build --filter=@wangeditor-next/core --filter=@wangeditor-next/editor`
- `PLAYWRIGHT_SKIP_BUILD=1 pnpm e2e --grep "regression #502|regression #541|regression #609"`
- `pnpm --filter @wangeditor-next/core test -- __tests__/editor/plugins/with-content.test.ts __tests__/menus/position.test.ts`

Closes #502
Closes #541


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML insertion to properly handle multiple elements and adjust selection positioning for inline content.
  * Fixed menu and modal positioning calculations to prevent negative offset values.

* **Tests**
  * Added 3 E2E regression tests covering HTML insertion with data transfer, modal positioning after scrolling, and paragraph handling in content insertion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/830?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->