### PR TITLE
test(e2e): add regression coverage for issue #564 malformed html crash

### DIFF
--- a/tests/e2e/framework-regression.spec.ts
+++ b/tests/e2e/framework-regression.spec.ts
@@ -195,6 +195,52 @@ test.describe('Framework parity regression', () => {
       expect(pageErrors).toEqual([])
     })
 
+    test(`${target.name}: regression #564 malformed span+p html should not throw`, async ({ page }) => {
+      const pageErrors: string[] = []
+
+      page.on('pageerror', err => {
+        pageErrors.push(err?.stack || err?.message || String(err))
+      })
+
+      await openTarget(page, target)
+
+      const malformedHtml = '<p><span style="color: rgb(0, 0, 0); font-size: medium; font-family: -webkit-standard;">这是一</span><span style="color: rgb(0, 0, 0); font-size: medium; font-family: -webkit-standard;"><p><br></p></span><span style="color: rgb(0, 0, 0); font-size: medium; font-family: -webkit-standard;">这是二</span><span style="color: rgb(0, 0, 0); font-size: medium; font-family: -webkit-standard;"><p><br></p></span><span style="color: rgb(0, 0, 0); font-size: medium; font-family: -webkit-standard;">这是三</span><span style="color: rgb(0, 0, 0); font-size: medium; font-family: -webkit-standard;"><p><br></p></span><span style="color: rgb(0, 0, 0); font-size: medium; font-family: -webkit-standard;"><p><br></p></span><span style="color: rgb(0, 0, 0); font-size: medium; font-family: -webkit-standard;">这是四</span></p>'
+
+      const snapshot = await page.evaluate(({ html }) => {
+        const globalWindow = window as any
+        const editor = globalWindow.wangEditorExampleBridge?.editor
+          || globalWindow.vue2Editor
+          || globalWindow.vue3Editor
+          || globalWindow.reactEditor
+
+        if (!editor) {
+          throw new Error('editor not ready')
+        }
+
+        editor.setHtml(html)
+        const output = editor.getHtml()
+        const hasInlineNestedParagraph = /<span[^>]*>\s*<p/i.test(output)
+        const root = document.querySelector('[data-testid="editor-textarea"]')
+        const nestedParagraphInSpanCount = root?.querySelectorAll('span p').length ?? 0
+
+        editor.focus()
+        editor.insertText('1')
+        editor.deleteBackward('character')
+
+        return {
+          output,
+          outputAfterEdit: editor.getHtml(),
+          hasInlineNestedParagraph,
+          nestedParagraphInSpanCount,
+        }
+      }, { html: malformedHtml })
+
+      expect(snapshot.hasInlineNestedParagraph).toBe(false)
+      expect(snapshot.nestedParagraphInSpanCount).toBe(0)
+      expect(snapshot.outputAfterEdit).toBe(snapshot.output)
+      expect(pageErrors).toEqual([])
+    })
+
     test(`${target.name}: table resize flow should be consistent`, async ({ page }) => {
       const pageErrors: string[] = []
 


### PR DESCRIPTION
## Summary
- add framework parity regression for #564 malformed HTML shape (`span > p`) across:
  - html-core
  - vue2-wrapper
  - vue3-wrapper
  - react-wrapper
- verify malformed input is normalized and does not crash after edit

## Why
Issue #564 reports a crash path in wrapper usage after malformed HTML is fed into editor and then edited.
Current `master` no longer reproduces that crash, but we should keep a regression test to prevent reintroduction.

## Verification
- `PLAYWRIGHT_SKIP_BUILD=1 pnpm e2e --grep "regression #564"`
- 4/4 passed on Chromium

Closes #564


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression tests to verify editor stability and correct HTML output handling across different configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/831?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->