### PR TITLE
fix(core): preserve nested style overrides when parsing html

### DIFF
--- a/.changeset/tiny-pants-sing.md
+++ b/.changeset/tiny-pants-sing.md
@@ -1,0 +1,9 @@
+---
+'@wangeditor-next/core': patch
+'@wangeditor-next/basic-modules': patch
+'@wangeditor-next/editor': patch
+---
+
+Fix nested span style parsing so explicit child style values correctly override inherited parent marks during HTML import.
+
+This resolves issue #608 where a mixed bold span (`font-weight:700` parent with `font-weight:400` child) was imported as fully bold text instead of preserving the non-bold subrange.

--- a/packages/basic-modules/__tests__/text-style/parse-style-html.test.ts
+++ b/packages/basic-modules/__tests__/text-style/parse-style-html.test.ts
@@ -159,6 +159,23 @@ describe('parse style html', () => {
     ])
   })
 
+  it('it should keep explicit non-bold style scoped when parent span is bold', () => {
+    const nestedEditor = createEditor({
+      html: '<p><span style="font-weight: 700;">A<span style="font-weight: 400;">B</span>C</span></p>',
+    })
+
+    expect(nestedEditor.children).toEqual([
+      {
+        type: 'paragraph',
+        children: [
+          { text: 'A', bold: true },
+          { text: 'B' },
+          { text: 'C', bold: true },
+        ],
+      },
+    ])
+  })
+
   it('it should ignore formatting newlines around nested superscript html imports', () => {
     const nestedEditor = createEditor({
       html: '<p><span>\nH<span style="vertical-align: super;">2</span>O\n</span></p>',

--- a/packages/basic-modules/src/modules/text-style/parse-style-html.ts
+++ b/packages/basic-modules/src/modules/text-style/parse-style-html.ts
@@ -50,7 +50,11 @@ export function parseStyleHtml(
   const textNode = node as StyledText
 
   // bold
-  if (isMatch($text, 'b,strong') || isBoldStyle($text)) {
+  const fontWeight = getStyleValue($text, 'font-weight')
+
+  if (fontWeight) {
+    textNode.bold = isBoldStyle($text)
+  } else if (isMatch($text, 'b,strong')) {
     textNode.bold = true
   }
 

--- a/packages/core/src/parse-html/parse-elem-html.ts
+++ b/packages/core/src/parse-html/parse-elem-html.ts
@@ -30,19 +30,42 @@ function normalizeTextNodeContent(text: string, childNode: Node): string {
   return text
 }
 
-function parseChildNode($childElem, parentStyle, editor) {
-  const childNode = $childElem[0]
+type DescendantRecord = Record<string, unknown>
+
+function mergeParentStyle(parentStyle: Descendant, node: Descendant): Descendant {
+  const merged: DescendantRecord = {
+    ...(parentStyle as DescendantRecord),
+    ...(node as DescendantRecord),
+  }
+
+  Object.keys(node as DescendantRecord).forEach(key => {
+    // `false` means the child explicitly clears a parent style mark.
+    if ((node as DescendantRecord)[key] === false) {
+      delete merged[key]
+    }
+  })
+
+  return merged as Descendant
+}
+
+function parseChildNode(
+  $childElem: Dom7Array,
+  parentStyle: Descendant,
+  editor: IDomEditor,
+): Descendant[] | null {
+  const childNode = $childElem[0] as unknown as Node
 
   if (isDOMElement(childNode)) {
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     const elem = parseElemHtml($childElem, editor)
+    const styleWithoutText: DescendantRecord = { ...(parentStyle as DescendantRecord) }
 
     // Element 节点不应该继承传入的 { text: '' } 默认值，该值会导致slate识别错误
-    delete parentStyle.text
+    delete styleWithoutText.text
 
     return Array.isArray(elem)
-      ? elem.map(v => ({ ...parentStyle, ...v }))
-      : [{ ...parentStyle, ...elem }]
+      ? elem.map(v => mergeParentStyle(styleWithoutText as Descendant, v))
+      : [mergeParentStyle(styleWithoutText as Descendant, elem)]
   }
 
   if (isDOMComment(childNode)) { return null } // 过滤掉注释节点
@@ -51,7 +74,7 @@ function parseChildNode($childElem, parentStyle, editor) {
     ? { text: normalizeTextNodeContent(childNode.textContent || '', childNode) }
     : parseTextElemHtml($childElem, editor)
 
-  return [{ ...parentStyle, ...text }]
+  return [mergeParentStyle(parentStyle, text)]
 }
 
 /**
@@ -84,7 +107,7 @@ function parseElemHtml($elem: Dom7Array, editor: IDomEditor): Descendant | Desce
     if (hasNonTextChild) {
       const parentStyle = parseTextElemHtmlToStyle($($elem[0]), editor)
 
-      return childNodes.flatMap(child => {
+      return childNodes.flatMap((child): Descendant[] => {
         const parsed = parseChildNode($(child), parentStyle, editor)
 
         return parsed || []
@@ -116,7 +139,7 @@ function parseElemHtml($elem: Dom7Array, editor: IDomEditor): Descendant | Desce
     if (hasNonTextChild) {
       const parentStyle = parseTextElemHtmlToStyle($($elem[0]), editor)
 
-      return childNodes.flatMap(child => {
+      return childNodes.flatMap((child): Descendant[] => {
         const parsed = parseChildNode($(child), parentStyle, editor)
 
         return parsed || []

--- a/tests/e2e/framework-regression.spec.ts
+++ b/tests/e2e/framework-regression.spec.ts
@@ -351,6 +351,77 @@ test.describe('Framework parity regression', () => {
       expect(pageErrors).toEqual([])
     })
 
+    test(`${target.name}: regression #608 mixed bold span should keep non-bold subrange`, async ({ page }) => {
+      const pageErrors: string[] = []
+
+      page.on('pageerror', err => {
+        pageErrors.push(err?.stack || err?.message || String(err))
+      })
+
+      await openTarget(page, target)
+
+      await page.evaluate(async () => {
+        const globalWindow = window as any
+        const editor = globalWindow.wangEditorExampleBridge?.editor
+          || globalWindow.vue2Editor
+          || globalWindow.vue3Editor
+          || globalWindow.reactEditor
+
+        if (!editor) {
+          throw new Error('editor not ready')
+        }
+
+        editor.setHtml('<p><span style="font-weight: 700;">前缀<span style="font-weight: 400;">中间</span>后缀</span></p><p><br></p>')
+
+        await new Promise<void>(resolve => {
+          setTimeout(() => resolve(), 80)
+        })
+      })
+
+      const snapshot = await page.evaluate(() => {
+        const globalWindow = window as any
+        const editor = globalWindow.wangEditorExampleBridge?.editor
+          || globalWindow.vue2Editor
+          || globalWindow.vue3Editor
+          || globalWindow.reactEditor
+
+        if (!editor) {
+          throw new Error('editor not ready')
+        }
+
+        const richParagraph = (editor.children || []).find((node: any) => {
+          if (!node || node.type !== 'paragraph') { return false }
+          const text = (node.children || [])
+            .map((child: any) => String(child?.text || ''))
+            .join('')
+            .trim()
+
+          return text.length > 0
+        })
+        const richParagraphChildren = richParagraph?.children || []
+        const modelSegments = richParagraphChildren.map((node: any) => {
+          return {
+            text: String(node?.text || ''),
+            bold: node?.bold === true,
+          }
+        })
+        const html = editor.getHtml?.() || ''
+
+        return {
+          modelSegments,
+          html,
+        }
+      })
+
+      expect(snapshot.modelSegments).toEqual([
+        { text: '前缀', bold: true },
+        { text: '中间', bold: false },
+        { text: '后缀', bold: true },
+      ])
+      expect(snapshot.html).toMatch(/<p><strong>前缀<\/strong>中间<strong>后缀<\/strong><\/p>/)
+      expect(pageErrors).toEqual([])
+    })
+
     test(`${target.name}: table multi-cell bold should affect only selected cells`, async ({ page }) => {
       const pageErrors: string[] = []
 


### PR DESCRIPTION
## Summary
- fix nested text-style merge in HTML parsing so explicit child style can override inherited parent style
- specifically handle Office-like span trees where parent is `font-weight:700` and child is `font-weight:400`
- add regression coverage for #608 in unit test and cross-framework e2e (html-core/vue2/vue3/react)
- add changeset for `@wangeditor-next/core`, `@wangeditor-next/basic-modules`, and `@wangeditor-next/editor`

## Root Cause
During HTML import, parent text styles were merged into child nodes with a plain object spread. When child style parser returned `bold: false` for explicit `font-weight: 400`, that value was later treated like a normal mark field and effectively lost semantic meaning as an override signal.

## Validation
- `pnpm test -- packages/basic-modules/__tests__/text-style/parse-style-html.test.ts`
- `PLAYWRIGHT_SKIP_BUILD=1 pnpm e2e --grep "regression #608"`
- `pnpm turbo run build --filter=@wangeditor-next/editor`

Closes #608


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * HTML import now preserves explicit child span formatting when parent spans have conflicting bold styles, fixing mixed-bold import cases.

* **Tests**
  * Added unit and end-to-end regression tests to ensure nested bold/non-bold span behavior remains correct and no page errors occur.

* **Chores**
  * Prepared a patch release metadata entry for the affected packages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/833?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->