### PR TITLE
test(regression): cover styled emsp setHtml behavior (#339)

### DIFF
--- a/packages/basic-modules/__tests__/text-style/parse-style-html.test.ts
+++ b/packages/basic-modules/__tests__/text-style/parse-style-html.test.ts
@@ -206,4 +206,20 @@ describe('parse style html', () => {
     ])
     expect(nestedEditor.getText()).toBe(underlinedSpaces)
   })
+
+  it('it should preserve emsp inside styled span when setting html', () => {
+    const html = '<p>2.<span style="font-family: MS-Mincho;">111&emsp;222</span></p>'
+    const nestedEditor = createEditor({ html })
+
+    expect(nestedEditor.children).toEqual([
+      {
+        type: 'paragraph',
+        children: [
+          { text: '2.' },
+          { text: '111 222', fontFamily: 'MS-Mincho' },
+        ],
+      },
+    ])
+    expect(nestedEditor.getHtml()).toBe('<p>2.<span style="font-family: MS-Mincho;">111 222</span></p>')
+  })
 })

--- a/tests/e2e/framework-regression.spec.ts
+++ b/tests/e2e/framework-regression.spec.ts
@@ -241,6 +241,46 @@ test.describe('Framework parity regression', () => {
       expect(pageErrors).toEqual([])
     })
 
+    test(`${target.name}: regression #339 setHtml should keep emsp in styled span`, async ({ page }) => {
+      const pageErrors: string[] = []
+
+      page.on('pageerror', err => {
+        pageErrors.push(err?.stack || err?.message || String(err))
+      })
+
+      await openTarget(page, target)
+
+      const snapshot = await page.evaluate(() => {
+        const globalWindow = window as any
+        const editor = globalWindow.wangEditorExampleBridge?.editor
+          || globalWindow.vue2Editor
+          || globalWindow.vue3Editor
+          || globalWindow.reactEditor
+
+        if (!editor) {
+          throw new Error('editor not ready')
+        }
+
+        editor.setHtml('<p>2.<span style="font-family: MS-Mincho;">111&emsp;222</span></p>')
+
+        const children = editor.children || []
+        const paragraph = children[0] || {}
+        const styledNode = paragraph?.children?.[1] || {}
+        const html = editor.getHtml?.() || ''
+
+        return {
+          styledText: String(styledNode.text || ''),
+          styledFontFamily: String(styledNode.fontFamily || ''),
+          html,
+        }
+      })
+
+      expect(snapshot.styledText).toBe('111 222')
+      expect(snapshot.styledFontFamily).toBe('MS-Mincho')
+      expect(snapshot.html).toContain('111 222')
+      expect(pageErrors).toEqual([])
+    })
+
     test(`${target.name}: regression #610 image insertion should keep active font marks`, async ({ page }) => {
       const pageErrors: string[] = []
 


### PR DESCRIPTION
## Summary
- verified issue #339 on current `master`: `setHtml` preserves emsp (`\u2003`) inside styled spans
- added unit regression in `parse-style-html.test.ts` to lock styled-emsp parse + html output behavior
- added framework e2e regression in `framework-regression.spec.ts` to validate the same behavior across html-core / vue2 / vue3 / react wrappers

## Why
Issue #339 reports that `&emsp;` inside styled text degrades to normal space after `setHtml`.
Current code no longer reproduces this problem, so this PR focuses on preventing regression.

## Verification
- `pnpm test -- packages/basic-modules/__tests__/text-style/parse-style-html.test.ts`
- `PLAYWRIGHT_SKIP_BUILD=1 pnpm e2e --grep "regression #339"`

Closes #339


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed editor handling of em-space characters within styled text, ensuring proper preservation of both spacing and text formatting.

* **Tests**
  * Added regression test and test case to verify em-space character support in styled text remains functional.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/835?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->