### PR TITLE
fix: allow list-item to insert image/video (#704)

### DIFF
--- a/.changeset/calm-poems-float.md
+++ b/.changeset/calm-poems-float.md
@@ -1,0 +1,6 @@
+---
+'@wangeditor-next/basic-modules': patch
+'@wangeditor-next/video-module': patch
+---
+
+Allow image and video insert/upload menus to stay enabled when the cursor is inside a list item.

--- a/packages/basic-modules/__tests__/image/helper.test.ts
+++ b/packages/basic-modules/__tests__/image/helper.test.ts
@@ -150,5 +150,9 @@ describe('image helper', () => {
     editor.select(startLocation)
     Transforms.setNodes(editor, { type: 'header1' })
     expect(isInsertImageMenuDisabled(editor)).toBeTruthy()
+
+    editor.select(startLocation)
+    Transforms.setNodes(editor, { type: 'list-item' })
+    expect(isInsertImageMenuDisabled(editor)).toBeFalsy()
   })
 })

--- a/packages/basic-modules/src/modules/image/helper.ts
+++ b/packages/basic-modules/src/modules/image/helper.ts
@@ -28,7 +28,6 @@ export function isInsertImageMenuDisabled(editor: IDomEditor): boolean {
       if (type === 'code') { return true } // 代码块
       if (type === 'pre') { return true } // 代码块
       if (type === 'link') { return true } // 链接
-      if (type === 'list-item') { return true } // list
       if (type.startsWith('header')) { return true } // 标题
       if (type === 'blockquote') { return true } // 引用
       if (Element.isElement(n) && Editor.isVoid(editor, n)) { return true } // void

--- a/packages/video-module/__tests__/menu/insert-video-menu.test.ts
+++ b/packages/video-module/__tests__/menu/insert-video-menu.test.ts
@@ -52,6 +52,14 @@ describe('videoModule module', () => {
       expect(insertVideoMenu.isDisabled(editor)).toBe(false)
     })
 
+    test('InsertVideoMenu should remain enabled when current selection is in list-item', () => {
+      setEditorSelection(editor)
+
+      vi.spyOn(slate.Range, 'isCollapsed').mockReturnValue(true)
+      vi.spyOn(core.DomEditor, 'getSelectedElems').mockReturnValue([{ type: 'list-item' }] as any)
+      expect(insertVideoMenu.isDisabled(editor)).toBe(false)
+    })
+
     test('InsertVideoMenu invoke getModalPositionNode should return null', () => {
       expect(insertVideoMenu.getModalPositionNode(editor)).toBeNull()
     })

--- a/packages/video-module/__tests__/menu/upload-video-menu.test.ts
+++ b/packages/video-module/__tests__/menu/upload-video-menu.test.ts
@@ -52,6 +52,14 @@ describe('videoModule module', () => {
       expect(uploadVideoMenu.isDisabled(baseEditor)).toBe(false)
     })
 
+    test('UploadVideoMenu should remain enabled when current selection is in list-item', () => {
+      setEditorSelection(baseEditor)
+
+      vi.spyOn(slate.Range, 'isCollapsed').mockReturnValue(true)
+      vi.spyOn(core.DomEditor, 'getSelectedElems').mockReturnValue([{ type: 'list-item' }] as any)
+      expect(uploadVideoMenu.isDisabled(baseEditor)).toBe(false)
+    })
+
     test('UploadVideoMenu invoke customBrowseAndUpload if editor give customBrowseAndUpload option', () => {
       const fn = vi.fn()
       const editor = createEditor({

--- a/packages/video-module/src/module/menu/InsertVideoMenu.ts
+++ b/packages/video-module/src/module/menu/InsertVideoMenu.ts
@@ -70,7 +70,6 @@ class InsertVideoMenu implements IModalMenu {
       const type = DomEditor.getNodeType(elem)
 
       if (type === 'pre') { return true }
-      if (type === 'list-item') { return true }
       if (editor.isVoid(elem)) { return true }
       return false
     })

--- a/packages/video-module/src/module/menu/UploadVideoMenu.ts
+++ b/packages/video-module/src/module/menu/UploadVideoMenu.ts
@@ -72,7 +72,6 @@ class UploadVideoMenu implements IButtonMenu {
       const type = DomEditor.getNodeType(elem)
 
       if (type === 'pre') { return true }
-      if (type === 'list-item') { return true }
       if (editor.isVoid(elem)) { return true }
       return false
     })

--- a/tests/e2e/framework-regression.spec.ts
+++ b/tests/e2e/framework-regression.spec.ts
@@ -352,6 +352,163 @@ test.describe('Framework parity regression', () => {
       expect(pageErrors).toEqual([])
     })
 
+    test(`${target.name}: regression #704 list item should allow inserting image and video`, async ({ page }) => {
+      const pageErrors: string[] = []
+
+      page.on('pageerror', err => {
+        pageErrors.push(err?.stack || err?.message || String(err))
+      })
+
+      await openTarget(page, target)
+      await clearEditor(page)
+
+      const menuSupport = await page.evaluate(() => {
+        const menuKeys = Array.from(
+          document.querySelectorAll('[data-testid="editor-toolbar"] [data-menu-key]'),
+        ).map(el => el.getAttribute('data-menu-key') || '')
+
+        return {
+          hasBulletedList: menuKeys.includes('bulletedList'),
+          hasGroupImage: menuKeys.includes('group-image'),
+          hasInsertImage: menuKeys.includes('insertImage'),
+          hasGroupVideo: menuKeys.includes('group-video'),
+          hasInsertVideo: menuKeys.includes('insertVideo'),
+        }
+      })
+
+      test.skip(
+        !menuSupport.hasBulletedList
+          || (!menuSupport.hasGroupImage && !menuSupport.hasInsertImage)
+          || (!menuSupport.hasGroupVideo && !menuSupport.hasInsertVideo),
+        `${target.name} demo toolbar does not expose required list/image/video menus`,
+      )
+
+      await page.evaluate(() => {
+        const globalWindow = window as any
+        const editor = globalWindow.wangEditorExampleBridge?.editor
+          || globalWindow.vue2Editor
+          || globalWindow.vue3Editor
+          || globalWindow.reactEditor
+
+        if (!editor) {
+          throw new Error('editor not ready')
+        }
+
+        editor.setHtml('<ul><li>list item</li></ul>')
+
+        const listIndex = editor.children.findIndex((node: any) => node?.type === 'list-item')
+
+        if (listIndex < 0) {
+          throw new Error('list-item node not found')
+        }
+
+        const listTextNode = listIndex >= 0 ? (editor.children[listIndex]?.children?.[0] || {}) : {}
+        const textLength = String(listTextNode.text || '').length
+        const offset = Math.min(Math.max(textLength, 1), 4)
+
+        editor.select({
+          anchor: { path: [listIndex, 0], offset },
+          focus: { path: [listIndex, 0], offset },
+        })
+      })
+
+      if (menuSupport.hasGroupImage) {
+        const groupImage = await ensureMenuEnabled(page, 'group-image')
+
+        await groupImage.hover()
+        const groupPanel = groupImage.locator('..').locator('.w-e-bar-item-menus-container')
+
+        await groupPanel.waitFor({ state: 'visible' })
+        await groupPanel.locator('[data-menu-key="insertImage"]').click({ force: true })
+      } else {
+        const imageMenu = await ensureMenuEnabled(page, 'insertImage')
+
+        await imageMenu.click({ force: true })
+      }
+
+      const imageModal = page.locator('.w-e-modal:visible').last()
+
+      await expect(imageModal).toBeVisible()
+      await imageModal.locator('input[type="text"]').first().fill('https://example.com/regression-704.png')
+      await imageModal.locator('.button-container button').first().click()
+      await page.waitForTimeout(200)
+
+      await page.evaluate(() => {
+        const globalWindow = window as any
+        const editor = globalWindow.wangEditorExampleBridge?.editor
+          || globalWindow.vue2Editor
+          || globalWindow.vue3Editor
+          || globalWindow.reactEditor
+
+        if (!editor) {
+          throw new Error('editor not ready')
+        }
+
+        const listIndex = editor.children.findIndex((node: any) => node?.type === 'list-item')
+
+        if (listIndex < 0) {
+          throw new Error('list-item node not found after image insertion')
+        }
+
+        const listTextNode = listIndex >= 0 ? (editor.children[listIndex]?.children?.[0] || {}) : {}
+        const textLength = String(listTextNode.text || '').length
+        const offset = Math.min(Math.max(textLength, 1), 4)
+
+        editor.select({
+          anchor: { path: [listIndex, 0], offset },
+          focus: { path: [listIndex, 0], offset },
+        })
+      })
+
+      if (menuSupport.hasGroupVideo) {
+        const groupVideo = await ensureMenuEnabled(page, 'group-video')
+
+        await groupVideo.hover()
+        const groupPanel = groupVideo.locator('..').locator('.w-e-bar-item-menus-container')
+
+        await groupPanel.waitFor({ state: 'visible' })
+        await groupPanel.locator('[data-menu-key="insertVideo"]').click({ force: true })
+      } else {
+        const videoMenu = await ensureMenuEnabled(page, 'insertVideo')
+
+        await videoMenu.click({ force: true })
+      }
+
+      const videoModal = page.locator('.w-e-modal:visible').last()
+
+      await expect(videoModal).toBeVisible()
+      await videoModal.locator('input[type="text"]').first().fill('https://example.com/regression-704.mp4')
+      await videoModal.locator('.button-container button').first().click()
+      await page.waitForTimeout(260)
+
+      const snapshot = await page.evaluate(() => {
+        const globalWindow = window as any
+        const editor = globalWindow.wangEditorExampleBridge?.editor
+          || globalWindow.vue2Editor
+          || globalWindow.vue3Editor
+          || globalWindow.reactEditor
+
+        if (!editor) {
+          throw new Error('editor not ready')
+        }
+
+        const listItemCount = (editor.children || []).filter((node: any) => node?.type === 'list-item').length
+
+        return {
+          imageCount: (editor.getElemsByTypePrefix?.('image') || []).length,
+          videoCount: (editor.getElemsByTypePrefix?.('video') || []).length,
+          listItemCount,
+          html: editor.getHtml?.() || '',
+        }
+      })
+
+      expect(snapshot.listItemCount).toBeGreaterThanOrEqual(1)
+      expect(snapshot.imageCount).toBeGreaterThanOrEqual(1)
+      expect(snapshot.videoCount).toBeGreaterThanOrEqual(1)
+      expect(snapshot.html).toContain('regression-704')
+      expect(pageErrors).toEqual([])
+    })
+
     test(`${target.name}: table resize flow should be consistent`, async ({ page }) => {
       const pageErrors: string[] = []
 


### PR DESCRIPTION
## Summary\n- remove list-item hard-disable checks from image insert menu\n- remove list-item hard-disable checks from video insert/upload menus\n- add regression coverage for list-item media insertion in unit tests and playwright e2e\n- add changeset for basic-modules and video-module patch release\n\n## Verification\n- pnpm test -- packages/basic-modules/__tests__/image/helper.test.ts packages/video-module/__tests__/menu/insert-video-menu.test.ts packages/video-module/__tests__/menu/upload-video-menu.test.ts\n- pnpm e2e --grep "regression #704"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image and video insert/upload menus now remain enabled when the cursor is positioned inside a list item.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/836?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->