### PR TITLE
fix: keep fast table column drag effective (#505)

### DIFF
--- a/.changeset/green-birds-sit.md
+++ b/.changeset/green-birds-sit.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/table-module': patch
+---
+
+Flush pending throttled column-resize movement on mouseup so fast drag operations reliably apply the final column width.

--- a/packages/table-module/__tests__/column-resize.test.ts
+++ b/packages/table-module/__tests__/column-resize.test.ts
@@ -240,6 +240,54 @@ describe('column resize module', () => {
     expect(document.body.style.cursor).toBe('')
   })
 
+  test('fast drag flushes trailing resize update on mouseup', () => {
+    const table = {
+      ...createTable([80, 120, 100]),
+      resizingIndex: 1,
+    }
+    const tableDom = document.createElement('div')
+    const innerTable = document.createElement('div')
+
+    innerTable.className = 'table'
+    vi.spyOn(innerTable, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      width: 300,
+      height: 120,
+      bottom: 120,
+      right: 300,
+      toJSON: () => ({}),
+    } as DOMRect)
+    tableDom.appendChild(innerTable)
+
+    vi.spyOn(editor, 'getMenuConfig').mockReturnValue({ minWidth: 90 } as any)
+    vi.spyOn(core.DomEditor, 'findPath').mockReturnValue([0] as slate.Path)
+    vi.spyOn(slate.Editor, 'node').mockReturnValue([table as slate.Node, [0]])
+    vi.spyOn(core.DomEditor, 'toDOMNode').mockReturnValue(tableDom)
+    const setNodesSpy = vi.spyOn(slate.Transforms, 'setNodes').mockImplementation(() => {})
+
+    handleCellBorderMouseDown(editor, table)
+
+    const resizeHandle = document.createElement('div')
+
+    resizeHandle.className = 'column-resizer-item'
+    document.body.appendChild(resizeHandle)
+    resizeHandle.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, clientX: 200 }))
+    // First move initializes throttle window.
+    window.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: 200 }))
+    // Second move is queued as trailing call and must be flushed on mouseup.
+    window.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: 260 }))
+    window.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+
+    expect(setNodesSpy).toHaveBeenCalledWith(
+      editor,
+      { columnWidths: [80, 180, 100] } as TableElement,
+      { at: [0] },
+    )
+  })
+
   test('dragging falls back to simple width changes when table DOM is missing', async () => {
     const table = {
       ...createTable([80, 120, 100]),

--- a/packages/table-module/src/module/column-resize.ts
+++ b/packages/table-module/src/module/column-resize.ts
@@ -254,6 +254,13 @@ const onMouseMove = throttle((event: Event) => {
 }, 100)
 
 function onMouseUp(_event: Event) {
+  // Flush any throttled trailing mousemove before clearing drag state.
+  // Fast drags can queue the last movement; without flush the final width change is lost.
+  if (isMouseDownForResize) {
+    onMouseMove.flush()
+  }
+  onMouseMove.cancel()
+
   isSelectionOperation = false
   isMouseDownForResize = false
   editorWhenMouseDown = null

--- a/tests/e2e/framework-regression.spec.ts
+++ b/tests/e2e/framework-regression.spec.ts
@@ -385,6 +385,85 @@ test.describe('Framework parity regression', () => {
       expect(pageErrors).toEqual([])
     })
 
+    test(`${target.name}: regression #505 fast drag should keep effective resize`, async ({ page }) => {
+      const pageErrors: string[] = []
+
+      page.on('pageerror', err => {
+        pageErrors.push(err?.stack || err?.message || String(err))
+      })
+
+      await openTarget(page, target)
+      await clearEditor(page)
+      await page.keyboard.type('outside anchor')
+      await create2x2Table(page)
+      await page
+        .locator('[data-testid="editor-textarea"] table.table')
+        .last()
+        .locator('tr:nth-child(1) > *:nth-child(1)')
+        .click({ force: true })
+
+      const before = await getLastTableWidths(page)
+      const table = page.locator('[data-testid="editor-textarea"] table.table').last()
+      const tableRect = await table.boundingBox()
+      const hotzone = page
+        .locator('[data-testid="editor-textarea"] .column-resizer')
+        .last()
+        .locator('.column-resizer-item')
+        .first()
+        .locator('.resizer-line-hotzone')
+
+      if (tableRect && before.length > 0) {
+        await page.mouse.move(tableRect.x + before[0], tableRect.y + 20)
+        await page.waitForTimeout(120)
+      }
+
+      const fastDragApplied = await page.evaluate(() => {
+        const hotzoneEl = document.querySelector(
+          '[data-testid="editor-textarea"] .column-resizer .column-resizer-item:first-child .resizer-line-hotzone',
+        ) as HTMLElement | null
+
+        if (!hotzoneEl) { return false }
+
+        const rect = hotzoneEl.getBoundingClientRect()
+        const x = Math.round(rect.left + rect.width / 2)
+        const y = Math.round(rect.top + rect.height / 2)
+
+        hotzoneEl.dispatchEvent(new MouseEvent('mousedown', {
+          bubbles: true,
+          clientX: x,
+          clientY: y,
+        }))
+        // Trigger a no-op movement first so the next movement is throttled trailing.
+        window.dispatchEvent(new MouseEvent('mousemove', {
+          bubbles: true,
+          clientX: x,
+          clientY: y,
+        }))
+        window.dispatchEvent(new MouseEvent('mousemove', {
+          bubbles: true,
+          clientX: x + 120,
+          clientY: y,
+        }))
+        window.dispatchEvent(new MouseEvent('mouseup', {
+          bubbles: true,
+          clientX: x + 120,
+          clientY: y,
+        }))
+
+        return true
+      })
+      const afterFastDrag = await getLastTableWidths(page)
+
+      const beforeFirst = before[0] || 0
+      const afterFastFirst = afterFastDrag[0] || 0
+
+      expect(fastDragApplied).toBe(true)
+      await expect(hotzone).toHaveClass(/visible/)
+      expect(beforeFirst).toBeGreaterThan(0)
+      expect(afterFastFirst).toBeGreaterThan(beforeFirst)
+      expect(pageErrors).toEqual([])
+    })
+
     test(`${target.name}: setHtml in-table focus should keep single table and stable output`, async ({ page }) => {
       const pageErrors: string[] = []
 


### PR DESCRIPTION
## Summary
- root-cause fix: flush trailing throttled column-resize move on mouseup before clearing resize state
- add table-module unit regression for fast drag sequence (mousedown -> move(0) -> move(delta) -> mouseup)
- add Playwright framework regression #505 to cover fast drag behavior across html/vue2/vue3/react wrappers
- add changeset for @wangeditor-next/table-module patch release\n\n## Verification
- pnpm test -- packages/table-module/__tests__/column-resize.test.ts\n- PLAYWRIGHT_SKIP_BUILD=1 pnpm e2e --grep "regression #505 fast drag should keep effective resize"\n- PLAYWRIGHT_SKIP_BUILD=1 pnpm e2e --grep "table resize flow should be consistent"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed column resize behavior during rapid drag operations to ensure width changes are properly applied when releasing the mouse.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/839?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->