### PR TITLE
fix(core): normalize ordered-list reserve-marker selection mapping

### DIFF
--- a/.changeset/fair-planes-guess.md
+++ b/.changeset/fair-planes-guess.md
@@ -1,0 +1,7 @@
+---
+'@wangeditor-next/core': patch
+---
+
+Fix list selection mapping when the browser selection lands on ordered-list reserve markers (`data-w-e-reserve`).
+
+Treat reserve-marker targets as selectable during `selectionchange` sync, and resolve reserve-marker DOM points to nearby Slate text points so `editor.getSelectionText()` stays in sync with visible list-row selections.

--- a/packages/core/__tests__/editor/dom-editor.test.ts
+++ b/packages/core/__tests__/editor/dom-editor.test.ts
@@ -340,6 +340,29 @@ describe('Core DomEditor', () => {
     expect(slatePoint).toEqual({ path: [0, 0], offset: 5 })
   })
 
+  test('toSlatePoint keeps backward semantics for reserve markers when only next leaf is available', async () => {
+    editor.insertText('hello')
+    await flushPromises()
+
+    const paragraph = DomEditor.toDOMNode(editor, editor.children[0] as CustomElement)
+    const textNodeWrapper = paragraph.querySelector('[data-slate-node="text"]') as HTMLElement
+    const leaf = paragraph.querySelector('[data-slate-leaf]') as HTMLElement
+    const reserve = document.createElement('span')
+
+    reserve.setAttribute('contenteditable', 'false')
+    reserve.setAttribute('data-w-e-reserve', 'true')
+    reserve.textContent = '1.'
+    textNodeWrapper.insertBefore(reserve, leaf)
+
+    const slatePoint = DomEditor.toSlatePoint(editor, [reserve.firstChild as Node, 2], {
+      exactMatch: false,
+      suppressThrow: false,
+      searchDirection: 'backward',
+    })
+
+    expect(slatePoint).toEqual({ path: [0, 0], offset: 5 })
+  })
+
   test('hasRange', () => {
     editor.insertText('hello')
     editor.selectAll()

--- a/packages/core/__tests__/text-area/helpers.test.ts
+++ b/packages/core/__tests__/text-area/helpers.test.ts
@@ -114,6 +114,26 @@ describe('text-area helpers', () => {
     expect(hasSelectableTarget(editor, target)).toBe(true)
   })
 
+  it('treats reserve-marker targets as selectable even when not editable', () => {
+    const editor = { getConfig: () => ({ readOnly: false }) } as any
+    const target = {
+      nodeType: 3,
+      parentElement: {
+        nodeType: 1,
+        closest: vi.fn((selector: string) => {
+          if (selector === '[data-w-e-reserve]') { return {} }
+          return null
+        }),
+      },
+    } as any
+
+    vi.spyOn(DomEditor, 'hasDOMNode').mockImplementation((_editor, _target, options) => {
+      return !options?.editable
+    })
+
+    expect(hasSelectableTarget(editor, target)).toBe(true)
+  })
+
   it('returns false when editor is readonly', () => {
     const editor = { getConfig: () => ({ readOnly: true }) } as any
     const target = { nodeType: 1 } as any

--- a/packages/core/src/editor/dom-editor.ts
+++ b/packages/core/src/editor/dom-editor.ts
@@ -629,6 +629,16 @@ export const DomEditor = {
           })
         }
       } else if (nonEditableNode) {
+        const isReserveNode = Boolean(nonEditableNode.closest('[data-w-e-reserve]'))
+
+        // `data-w-e-reserve` (for example list-item prefix markers) is a
+        // non-editable decoration before real slate text. Prefer mapping
+        // forward so drag/select from the marker lands on the following text.
+        if (!searchDirection && isReserveNode) {
+          searchDirection = 'forward'
+        }
+
+        let resolvedDirection = searchDirection
         const getLeafNodes = (node: DOMElement | null | undefined) => {
           return node
             ? Array.from(node.querySelectorAll('[data-slate-leaf]'))
@@ -654,7 +664,17 @@ export const DomEditor = {
           }
         }
 
-        if (!leafNode && (searchDirection === 'forward' || !searchDirection)) {
+        if (
+          !leafNode
+          && (
+            searchDirection === 'forward'
+            || !searchDirection
+            // Keep trying for reserve markers even when the requested
+            // direction is backward. Reserve markers are rendered before real
+            // text and otherwise cannot resolve a point.
+            || isReserveNode
+          )
+        ) {
           const leafNodes = [
             ...getLeafNodes(elementNode),
             ...getLeafNodes(elementNode?.nextElementSibling as DOMElement | null),
@@ -663,7 +683,9 @@ export const DomEditor = {
           for (const currentLeaf of leafNodes) {
             if (isAfter(nonEditableNode, currentLeaf)) {
               leafNode = currentLeaf
-              searchDirection = 'forward'
+              resolvedDirection = searchDirection === 'backward' && isReserveNode
+                ? 'backward'
+                : 'forward'
               break
             }
           }
@@ -673,7 +695,7 @@ export const DomEditor = {
           textNode = leafNode.closest('[data-slate-node="text"]')!
           domNode = leafNode
 
-          if (searchDirection === 'forward') {
+          if (resolvedDirection === 'forward') {
             offset = 0
           } else {
             offset = domNode.textContent!.length

--- a/packages/core/src/text-area/helpers.ts
+++ b/packages/core/src/text-area/helpers.ts
@@ -7,7 +7,14 @@ import { Editor, Element } from 'slate'
 
 import { DomEditor } from '../editor/dom-editor'
 import { IDomEditor } from '../editor/interface'
-import { DOMNode, DOMRange, isDOMNode } from '../utils/dom'
+import {
+  DOMElement,
+  DOMNode,
+  DOMRange,
+  isDOMElement,
+  isDOMNode,
+  isDOMText,
+} from '../utils/dom'
 
 /**
  * Check if two DOM range objects are equal.
@@ -62,7 +69,22 @@ export function isTargetInsideNonReadonlyVoid(
  * Check if the target can participate in editor selection.
  */
 export function hasSelectableTarget(editor: IDomEditor, target: EventTarget | null): boolean {
-  return hasEditableTarget(editor, target) || isTargetInsideNonReadonlyVoid(editor, target)
+  if (hasEditableTarget(editor, target)) { return true }
+  if (!hasTarget(editor, target)) { return false }
+
+  let targetEl: DOMElement | null = null
+
+  if (isDOMElement(target)) {
+    targetEl = target
+  } else if (isDOMText(target)) {
+    targetEl = target.parentElement
+  }
+
+  if (targetEl?.closest('[data-w-e-reserve]')) {
+    return true
+  }
+
+  return isTargetInsideNonReadonlyVoid(editor, target)
 }
 
 /**

--- a/tests/e2e/framework-regression.spec.ts
+++ b/tests/e2e/framework-regression.spec.ts
@@ -281,6 +281,143 @@ test.describe('Framework parity regression', () => {
       expect(pageErrors).toEqual([])
     })
 
+    test(`${target.name}: regression #441 ordered list selection text should match visual range`, async ({ page }) => {
+      const pageErrors: string[] = []
+
+      page.on('pageerror', err => {
+        pageErrors.push(err?.stack || err?.message || String(err))
+      })
+
+      await openTarget(page, target)
+      await clearEditor(page)
+
+      const listMenuSupport = await page.evaluate(() => {
+        const menuKeys = Array.from(
+          document.querySelectorAll('[data-testid="editor-toolbar"] [data-menu-key]'),
+        ).map(el => el.getAttribute('data-menu-key') || '')
+
+        return {
+          hasNumberedList: menuKeys.includes('numberedList'),
+          hasOrderedList: menuKeys.includes('orderedList'),
+        }
+      })
+
+      let orderedListMenuKey = ''
+
+      if (listMenuSupport.hasNumberedList) {
+        orderedListMenuKey = 'numberedList'
+      } else if (listMenuSupport.hasOrderedList) {
+        orderedListMenuKey = 'orderedList'
+      }
+
+      test.skip(
+        !orderedListMenuKey,
+        `${target.name} demo toolbar does not expose ordered-list menu`,
+      )
+
+      const orderedListMenu = await ensureMenuEnabled(page, orderedListMenuKey)
+
+      await orderedListMenu.click({ force: true })
+      await page.keyboard.type('parent-item')
+      await page.keyboard.press('Enter')
+      await page.keyboard.type('child-item')
+      await page.evaluate(() => {
+        const globalWindow = window as any
+        const editor = globalWindow.wangEditorExampleBridge?.editor
+          || globalWindow.vue2Editor
+          || globalWindow.vue3Editor
+          || globalWindow.reactEditor
+
+        if (!editor) {
+          throw new Error('editor not ready')
+        }
+
+        const secondListItemIndex = (editor.children || []).findIndex((node: any, index: number) => {
+          return index > 0 && node?.type === 'list-item'
+        })
+
+        if (secondListItemIndex < 0) {
+          throw new Error('second list item not found')
+        }
+
+        editor.select({
+          anchor: { path: [secondListItemIndex, 0], offset: 0 },
+          focus: { path: [secondListItemIndex, 0], offset: 0 },
+        })
+        editor.handleTab?.()
+      })
+      await page.waitForTimeout(200)
+
+      const didSelectPrefix = await page.evaluate(() => {
+        const textArea = document.querySelector('[data-testid="editor-textarea"]') as HTMLElement | null
+        const textNodes = Array.from(textArea?.querySelectorAll('[data-slate-string]') || []) as HTMLElement[]
+        const parentText = textNodes.find(el => (el.textContent || '').trim() === 'parent-item')
+
+        if (!parentText) { return false }
+
+        const row = parentText.closest('div[style*="display: flex"]') as HTMLElement | null
+
+        if (!row) { return false }
+        const prefixNode = row.querySelector('[data-w-e-reserve]') as HTMLElement | null
+
+        if (!prefixNode || !prefixNode.firstChild) { return false }
+
+        const selection = window.getSelection()
+
+        if (!selection) { return false }
+
+        const range = document.createRange()
+
+        range.setStart(prefixNode.firstChild, 0)
+        range.setEnd(prefixNode.firstChild, prefixNode.textContent?.length || 0)
+        selection.removeAllRanges()
+        selection.addRange(range)
+        document.dispatchEvent(new Event('selectionchange'))
+
+        return true
+      })
+
+      expect(didSelectPrefix).toBe(true)
+      await page.waitForTimeout(120)
+
+      const snapshot = await page.evaluate(() => {
+        const globalWindow = window as any
+        const editor = globalWindow.wangEditorExampleBridge?.editor
+          || globalWindow.vue2Editor
+          || globalWindow.vue3Editor
+          || globalWindow.reactEditor
+
+        if (!editor) {
+          throw new Error('editor not ready')
+        }
+
+        const listItems = (editor.children || []).filter((node: any) => node?.type === 'list-item')
+        const levels = listItems.map((node: any) => {
+          return {
+            level: Number(node?.level ?? -1),
+            text: String(node?.children?.[0]?.text || ''),
+          }
+        })
+        const selection = window.getSelection()
+
+        return {
+          levels,
+          domSelectionText: selection?.toString() || '',
+          editorSelectionText: editor.getSelectionText?.() || '',
+          selection: editor.selection || null,
+        }
+      })
+
+      expect(snapshot.levels.some(item => item.level === 1 && item.text.includes('child-item'))).toBe(true)
+      expect(
+        snapshot.editorSelectionText.length,
+        JSON.stringify(snapshot),
+      ).toBeGreaterThan(0)
+      expect(snapshot.domSelectionText).toBe('1.')
+      expect(snapshot.editorSelectionText.replace(/\s+/g, '')).toBe('parent-item')
+      expect(pageErrors).toEqual([])
+    })
+
     test(`${target.name}: regression #610 image insertion should keep active font marks`, async ({ page }) => {
       const pageErrors: string[] = []
 


### PR DESCRIPTION
## Summary
- fix DOM->Slate selection mapping when browser selection lands on ordered-list reserve markers (`data-w-e-reserve`)
- treat reserve-marker targets as selectable in selectionchange sync so Slate selection is updated instead of being skipped
- keep backward mapping semantics even when reserve markers need forward leaf lookup fallback

## Regression
- add core unit test for reserve-marker backward mapping in `DomEditor.toSlatePoint`
- add core helper unit test for reserve-marker selectable target detection
- add framework e2e regression for issue #441 in `tests/e2e/framework-regression.spec.ts`

## Verification
- `pnpm vitest run packages/core/__tests__/editor/dom-editor.test.ts`
- `pnpm vitest run packages/core/__tests__/text-area/helpers.test.ts`
- `pnpm vitest run packages/core/__tests__/text-area/syncSelection.test.ts`
- `PLAYWRIGHT_SKIP_BUILD=1 pnpm e2e --grep "regression #441 ordered list selection text should match visual range" --project=chromium`

Fixes #441


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed list selection behavior in ordered lists, particularly when the browser selection lands on list markers. This ensures `editor.getSelectionText()` correctly reflects visible selections and maintains proper alignment with list-item selections across nested lists.

* **Tests**
  * Added comprehensive regression and unit test coverage for ordered-list selection edge cases and marker interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/840?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->