### PR TITLE
fix(core): preserve svg namespace in vnode normalization

### DIFF
--- a/.changeset/bright-keys-jam.md
+++ b/.changeset/bright-keys-jam.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/core': patch
+---
+
+Preserve SVG namespace (`data.ns`) during vnode data normalization so custom renderers using `h('svg')` keep valid SVG rendering semantics.

--- a/packages/core/__tests__/utils/vdom.test.ts
+++ b/packages/core/__tests__/utils/vdom.test.ts
@@ -62,6 +62,44 @@ describe('vdom util fns', () => {
     expect(pProps.id).toBe('p1')
   })
 
+  it('preserves svg namespace when normalizing vnode data', () => {
+    const vnode = h(
+      'div',
+      {},
+      [
+        h(
+          'svg',
+          {
+            attrs: {
+              viewBox: '0 0 16 16',
+              width: '16',
+              height: '16',
+            },
+          },
+          [
+            h('path', {
+              attrs: {
+                d: 'M0 0L1 1',
+                fill: 'red',
+              },
+            }),
+          ],
+        ),
+      ],
+    )
+
+    const svgVNode = (vnode.children?.[0] || {}) as VNode
+    const pathVNode = (svgVNode.children?.[0] || {}) as VNode
+
+    expect(svgVNode.data?.ns).toBe('http://www.w3.org/2000/svg')
+    expect(pathVNode.data?.ns).toBe('http://www.w3.org/2000/svg')
+
+    normalizeVnodeData(vnode)
+
+    expect(svgVNode.data?.ns).toBe('http://www.w3.org/2000/svg')
+    expect(pathVNode.data?.ns).toBe('http://www.w3.org/2000/svg')
+  })
+
   it('add vnode props', () => {
     const vnode = h('div', {})
 

--- a/packages/core/src/utils/vdom.ts
+++ b/packages/core/src/utils/vdom.ts
@@ -5,17 +5,17 @@
 
 import camelCase from 'lodash.camelcase'
 import {
-  VNode,
-  init,
+  attributesModule,
   classModule,
+  Dataset,
+  datasetModule,
+  eventListenersModule,
+  init,
+  Props,
   propsModule,
   styleModule,
-  datasetModule,
+  VNode,
   VNodeStyle,
-  Props,
-  Dataset,
-  eventListenersModule,
-  attributesModule,
 } from 'snabbdom'
 
 export type PatchFn = (oldVnode: VNode | Element, vnode: VNode) => VNode
@@ -34,11 +34,54 @@ export function genPatchFn(): PatchFn {
     eventListenersModule, // attaches event listeners
     attributesModule,
   ])
+
   return patch
 }
 
 // vnode.data 保留属性，参考 snabbdom VNodeData
-const DATA_PRESERVE_KEYS = ['props', 'attrs', 'style', 'dataset', 'on', 'hook']
+const DATA_PRESERVE_KEYS = ['props', 'attrs', 'style', 'dataset', 'on', 'hook', 'ns']
+
+/**
+ * 给 vnode 添加 prop
+ * @param vnode vnode
+ * @param newProp { key: val }
+ */
+export function addVnodeProp(vnode: VNode, newProp: Props) {
+  if (vnode.data == null) { vnode.data = {} }
+  const data = vnode.data
+
+  if (data.props == null) { data.props = {} }
+
+  Object.assign(data.props, newProp)
+}
+
+/**
+ * 给 vnode 添加 dataset
+ * @param vnode vnode
+ * @param newDataset { key: val }
+ */
+export function addVnodeDataset(vnode: VNode, newDataset: Dataset) {
+  if (vnode.data == null) { vnode.data = {} }
+  const data = vnode.data
+
+  if (data.dataset == null) { data.dataset = {} }
+
+  Object.assign(data.dataset, newDataset)
+}
+
+/**
+ * 给 vnode 添加样式
+ * @param vnode vnode
+ * @param newStyle { key: val }
+ */
+export function addVnodeStyle(vnode: VNode, newStyle: VNodeStyle) {
+  if (vnode.data == null) { vnode.data = {} }
+  const data = vnode.data
+
+  if (data.style == null) { data.style = {} }
+
+  Object.assign(data.style, newStyle)
+}
 
 /**
  * 整理 vnode.data ，将暴露出来的零散属性（如 id className data-xxx）放在 data.props 或 data.dataset
@@ -47,6 +90,7 @@ const DATA_PRESERVE_KEYS = ['props', 'attrs', 'style', 'dataset', 'on', 'hook']
 export function normalizeVnodeData(vnode: VNode) {
   const { data = {}, children = [] } = vnode
   const dataKeys = Object.keys(data)
+
   dataKeys.forEach((key: string) => {
     const value = data[key]
 
@@ -57,11 +101,12 @@ export function normalizeVnodeData(vnode: VNode) {
     }
 
     // 忽略 data 保留属性
-    if (DATA_PRESERVE_KEYS.includes(key)) return
+    if (DATA_PRESERVE_KEYS.includes(key)) { return }
 
     // dataset
     if (key.startsWith('data-')) {
       let datasetKey = key.slice(5) // 截取掉最前面的 'data-'
+
       datasetKey = camelCase(datasetKey) // 转为驼峰写法
 
       // 存储到 data.dataset
@@ -80,47 +125,8 @@ export function normalizeVnodeData(vnode: VNode) {
   // 遍历 children
   if (children.length > 0) {
     children.forEach(child => {
-      if (typeof child === 'string') return
+      if (typeof child === 'string') { return }
       normalizeVnodeData(child)
     })
   }
-}
-
-/**
- * 给 vnode 添加 prop
- * @param vnode vnode
- * @param newProp { key: val }
- */
-export function addVnodeProp(vnode: VNode, newProp: Props) {
-  if (vnode.data == null) vnode.data = {}
-  const data = vnode.data
-  if (data.props == null) data.props = {}
-
-  Object.assign(data.props, newProp)
-}
-
-/**
- * 给 vnode 添加 dataset
- * @param vnode vnode
- * @param newDataset { key: val }
- */
-export function addVnodeDataset(vnode: VNode, newDataset: Dataset) {
-  if (vnode.data == null) vnode.data = {}
-  const data = vnode.data
-  if (data.dataset == null) data.dataset = {}
-
-  Object.assign(data.dataset, newDataset)
-}
-
-/**
- * 给 vnode 添加样式
- * @param vnode vnode
- * @param newStyle { key: val }
- */
-export function addVnodeStyle(vnode: VNode, newStyle: VNodeStyle) {
-  if (vnode.data == null) vnode.data = {}
-  const data = vnode.data
-  if (data.style == null) data.style = {}
-
-  Object.assign(data.style, newStyle)
 }


### PR DESCRIPTION
## Summary
- fix custom `renderElem` SVG rendering by preserving snabbdom SVG namespace metadata during vnode normalization
- keep `vnode.data.ns` in `normalizeVnodeData` instead of moving it into props

## Root Cause
`normalizeVnodeData` treated `data.ns` as a normal field and rewrote it into `props`, so SVG VNodes lost namespace semantics and were created/rendered incorrectly.

## Regression
- add unit test to assert SVG/path namespace is preserved before and after `normalizeVnodeData`
  - `packages/core/__tests__/utils/vdom.test.ts`

## Verification
- `pnpm vitest run packages/core/__tests__/utils/vdom.test.ts`

Fixes #687


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SVG element rendering to properly preserve namespace attributes during normalization, ensuring custom renderers that create SVG elements display correctly.

* **Tests**
  * Added test coverage for SVG namespace preservation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/841?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->