### PR TITLE
fix(core): 修复 toolbarKeys 对象写法导致 fontSize 下拉丢失 (#692)

### DIFF
--- a/.changeset/new-hats-compete.md
+++ b/.changeset/new-hats-compete.md
@@ -1,0 +1,10 @@
+---
+'@wangeditor-next/core': patch
+'@wangeditor-next/editor': patch
+---
+
+Fix toolbar object config compatibility for single menus such as `fontSize`.
+
+`toolbarKeys` items like `{ key: 'fontSize', title: '文字大小' }` are now treated
+as single-menu configs (instead of menu groups) when `menuKeys` is absent, so
+`MENU_CONF.fontSize.fontSizeList` and the select dropdown keep working together.

--- a/packages/core/__tests__/menus/bar-items.test.ts
+++ b/packages/core/__tests__/menus/bar-items.test.ts
@@ -227,6 +227,68 @@ describe('bar item lifecycle', () => {
     toolbar.destroy()
   })
 
+  test('Toolbar treats toolbarKeys object without menuKeys as a single select menu', async () => {
+    const editor = createEditorStub()
+    const container = document.createElement('div')
+    let toolbar: Toolbar | null = null
+
+    document.body.appendChild(container)
+
+    editor.getMenuConfig = vi.fn((key: string) => {
+      if (key !== 'fontSize') { return {} }
+
+      return {
+        fontSizeList: ['12px', '16px', { name: '24px', value: '24px' }],
+      }
+    })
+    MENU_ITEM_FACTORIES.fontSize = vi.fn(() => ({
+      title: '字号',
+      tag: 'select',
+      getValue: () => '',
+      getOptions: (currentEditor: any) => {
+        const { fontSizeList = [] } = currentEditor.getMenuConfig('fontSize')
+        const options = [{ text: '默认', value: '' }]
+
+        fontSizeList.forEach((size: string | { name: string; value: string }) => {
+          if (typeof size === 'string') {
+            options.push({ text: size, value: size })
+            return
+          }
+
+          options.push({ text: size.name, value: size.value })
+        })
+
+        return options
+      },
+      isActive: () => false,
+      isDisabled: () => false,
+      exec: vi.fn(),
+    })) as any
+
+    try {
+      toolbar = new Toolbar(container, {
+        toolbarKeys: [{ key: 'fontSize', title: '文字大小' }],
+      })
+      TOOLBAR_TO_EDITOR.set(toolbar as any, editor)
+      await flushMicrotasks()
+
+      expect(container.querySelector('.w-e-bar-item-group')).toBeNull()
+      const menuButton = container.querySelector('[data-menu-key="fontSize"]') as HTMLButtonElement
+
+      expect(menuButton).not.toBeNull()
+      menuButton.click()
+      await flushMicrotasks()
+
+      const optionTexts = Array.from(container.querySelectorAll('.w-e-select-list li'))
+        .map(elem => elem.textContent?.trim() || '')
+
+      expect(optionTexts).toEqual(['默认', '12px', '16px', '24px'])
+    } finally {
+      toolbar?.destroy()
+      delete MENU_ITEM_FACTORIES.fontSize
+    }
+  })
+
   test('HoverBar updates state for new selections and skips re-render for the same inline path', async () => {
     vi.useFakeTimers()
     const editor = createEditorStub()

--- a/packages/core/src/config/interface.ts
+++ b/packages/core/src/config/interface.ts
@@ -295,15 +295,23 @@ export interface IEditorConfig {
 
 export interface IInsertKeysConfig {
   index: number
-  keys: string | Array<string | IMenuGroup>
-  replaceFn?: (config: string | IMenuGroup) => string | IMenuGroup
+  keys: string | IToolbarMenuKey[]
+  replaceFn?: (config: IToolbarMenuKey) => IToolbarMenuKey
 }
+
+export interface IToolbarMenuItemConf {
+  key: string
+  title?: string
+  iconSvg?: string
+}
+
+export type IToolbarMenuKey = string | IMenuGroup | IToolbarMenuItemConf
 
 /**
  * toolbar config
  */
 export interface IToolbarConfig {
-  toolbarKeys: Array<string | IMenuGroup>
+  toolbarKeys: IToolbarMenuKey[]
   insertKeys: IInsertKeysConfig | Array<IInsertKeysConfig>
   excludeKeys: Array<string> // 排除哪些菜单
   modalAppendToBody: boolean // modal append 到 body ，而非 $textAreaContainer 内

--- a/packages/core/src/menus/bar/Toolbar.ts
+++ b/packages/core/src/menus/bar/Toolbar.ts
@@ -6,7 +6,13 @@
 import clonedeep from 'lodash.clonedeep'
 import debounce from 'lodash.debounce'
 
-import { EditorEvents, IInsertKeysConfig, IToolbarConfig } from '../../config/interface'
+import {
+  EditorEvents,
+  IInsertKeysConfig,
+  IToolbarConfig,
+  IToolbarMenuItemConf,
+  IToolbarMenuKey,
+} from '../../config/interface'
 import { IDomEditor } from '../../editor/interface'
 import { i18nListenLanguage } from '../../i18n'
 import $, { Dom7Array, DOMElement } from '../../utils/dom'
@@ -21,6 +27,7 @@ import {
 import { MENU_ITEM_FACTORIES } from '../register'
 
 type MenuType = IButtonMenu | ISelectMenu | IDropPanelMenu | IModalMenu
+type IToolbarSingleMenuOverride = Pick<IToolbarMenuItemConf, 'title' | 'iconSvg'>
 
 class Toolbar {
   $box: Dom7Array
@@ -115,10 +122,10 @@ class Toolbar {
       const adjustedIndex = menu.index + cumulativeOffset
 
       if (menu.replaceFn && toolbarKeysWithInsertedKeys[adjustedIndex]) {
-        const callbackKeys: string | IMenuGroup = menu.replaceFn(toolbarKeysWithInsertedKeys[adjustedIndex])
+        const callbackKeys: IToolbarMenuKey = menu.replaceFn(toolbarKeysWithInsertedKeys[adjustedIndex])
 
         if (!callbackKeys) {
-          throw new Error('This function needs to return the menu configuration：string | IMenuGroup')
+          throw new Error('This function needs to return the menu configuration: IToolbarMenuKey')
         }
         toolbarKeysWithInsertedKeys[adjustedIndex] = callbackKeys
       }
@@ -170,10 +177,27 @@ class Toolbar {
         return
       }
 
-      // 菜单组
-      this.registerGroup(key)
-      prevKey = 'group'
+      if (this.isMenuGroup(key)) {
+        // 菜单组
+        this.registerGroup(key)
+        prevKey = 'group'
+        return
+      }
+
+      // 单菜单配置对象（例如 { key: 'fontSize', title: '文字大小' }）
+      this.registerSingleMenuByConf(key)
+      prevKey = key.key
     })
+  }
+
+  private isMenuGroup(menu: IToolbarMenuKey): menu is IMenuGroup {
+    return typeof menu !== 'string' && Array.isArray((menu as IMenuGroup).menuKeys)
+  }
+
+  private registerSingleMenuByConf(menuConf: IToolbarMenuItemConf) {
+    const { key, title, iconSvg } = menuConf
+
+    this.registerSingleItem(key, this, { title, iconSvg })
   }
 
   // 注册菜单组
@@ -197,7 +221,11 @@ class Toolbar {
   }
 
   // 注册单个 toolbarItem
-  private registerSingleItem(key: string, container: GroupButton | Toolbar) {
+  private registerSingleItem(
+    key: string,
+    container: GroupButton | Toolbar,
+    toolbarOverride: IToolbarSingleMenuOverride = {},
+  ) {
     const editor = this.getEditorInstance()
     const inGroup = container instanceof GroupButton // 要添加到 groupButton
 
@@ -228,6 +256,13 @@ class Toolbar {
 
     if (menuConf && menuConf.iconSvg !== undefined) {
       menu.iconSvg = menuConf.iconSvg
+    }
+
+    if (toolbarOverride.iconSvg !== undefined) {
+      menu.iconSvg = toolbarOverride.iconSvg
+    }
+    if (toolbarOverride.title !== undefined) {
+      (menu as unknown as { title?: string }).title = toolbarOverride.title
     }
 
     const toolbarItem = createBarItem(key, menu, inGroup)

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -250,6 +250,70 @@ test.describe('Basic Editor', () => {
     expect(consoleErrors).toEqual([])
   })
 
+  test('regression #692: toolbar object config should keep fontSize select options', async ({ page }) => {
+    const pageErrors: string[] = []
+
+    page.on('pageerror', err => {
+      pageErrors.push(err?.stack || err?.message || String(err))
+    })
+
+    await page.evaluate(() => {
+      const globalWindow = window as any
+      const bridge = globalWindow.wangEditorExampleBridge
+      const editorContainer = document.querySelector('#editor-text-area')
+      const toolbarContainer = document.querySelector('#editor-toolbar')
+
+      bridge?.toolbar?.destroy()
+      bridge?.editor?.destroy()
+
+      if (!editorContainer || !toolbarContainer) {
+        throw new Error('editor containers are missing')
+      }
+
+      const editor = globalWindow.wangEditor.createEditor({
+        selector: '#editor-text-area',
+        html: '<p>font-size-regression</p>',
+        config: {
+          MENU_CONF: {
+            fontSize: {
+              fontSizeList: ['12px', '16px', '24px', '40px'],
+            },
+          },
+        },
+      })
+      const toolbar = globalWindow.wangEditor.createToolbar({
+        editor,
+        selector: '#editor-toolbar',
+        config: {
+          toolbarKeys: [{ key: 'fontSize', title: '文字大小' }],
+        },
+      })
+
+      globalWindow.wangEditorExampleBridge = {
+        editor,
+        toolbar,
+      }
+    })
+
+    await focusEditor(page)
+
+    const fontSizeMenu = getToolbarMenu(page, 'fontSize')
+
+    await expect(fontSizeMenu).toHaveClass(/select-button/)
+    await expect(page.locator('#editor-toolbar .w-e-bar-item-group')).toHaveCount(0)
+
+    await fontSizeMenu.click()
+
+    const selectList = page.locator('.w-e-select-list:visible').last()
+
+    await expect(selectList).toBeVisible()
+
+    const optionTexts = (await selectList.locator('li').allTextContents()).map(item => item.trim())
+
+    expect(optionTexts).toEqual(expect.arrayContaining(['12px', '16px', '24px', '40px']))
+    expect(pageErrors).toEqual([])
+  })
+
   test('regression #502: insertLink modal should stay in visible editor area after scroll-to-top', async ({ page }) => {
     const pageErrors: string[] = []
 


### PR DESCRIPTION
## 背景
Issue #692 反馈在 toolbar 使用对象写法（如 `{ key: 'fontSize', title: '文字大小' }`）时，字号菜单下拉丢失，且会与 `MENU_CONF.fontSize.fontSizeList` 冲突。

## 修复
- 在 `Toolbar` 中新增区分逻辑：
  - 对象且包含 `menuKeys` -> 仍按菜单组处理
  - 对象但不含 `menuKeys` -> 按单菜单配置处理
- 允许单菜单对象配置透传 `title/iconSvg` 覆盖值
- 扩展 toolbar 配置类型：新增 `IToolbarMenuItemConf` / `IToolbarMenuKey`

## 回归测试
- 新增 core 单测：`Toolbar treats toolbarKeys object without menuKeys as a single select menu`
- 新增 Playwright 回归：`regression #692: toolbar object config should keep fontSize select options`

## 验证
- `pnpm exec eslint packages/core/src/config/interface.ts packages/core/src/menus/bar/Toolbar.ts packages/core/__tests__/menus/bar-items.test.ts tests/e2e/editor.spec.ts`
- `pnpm test -- packages/core/__tests__/menus/bar-items.test.ts packages/core/__tests__/config/toolbar-config.test.ts`
- `PLAYWRIGHT_SKIP_BUILD=1 pnpm e2e --grep "regression #692: toolbar object config should keep fontSize select options" --project=chromium`
- `pnpm build`

Closes #692


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed toolbar menu configuration when using single menu items defined with object-style configurations including custom titles and icon overrides. Dropdown controls in the toolbar now properly render their configured options with correct labels, and menu-specific settings such as font size lists function correctly and integrate properly with all select dropdown controls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/842?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->