### PR TITLE
fix(core): 修复首行大字号上标文本被裁切 (#282)

### DIFF
--- a/.changeset/green-bats-jam.md
+++ b/.changeset/green-bats-jam.md
@@ -1,0 +1,10 @@
+---
+'@wangeditor-next/core': patch
+'@wangeditor-next/editor': patch
+---
+
+Fix clipped first-line rendering when large-font superscript or subscript appears
+at the top of the editor content.
+
+`sup` and `sub` in the editor area now inherit line-height, preventing browser
+default `line-height: 0` behavior from being cut by the scroll container.

--- a/packages/core/src/assets/common.less
+++ b/packages/core/src/assets/common.less
@@ -10,6 +10,12 @@
   p, li, td, th, blockquote {
     line-height: 1.5;
   }
+
+  // Avoid first-line clipping when superscript/subscript appears with large fonts.
+  // Browser default styles often set sup/sub line-height to 0, which can be cut by .w-e-scroll.
+  sup, sub {
+    line-height: inherit;
+  }
 }
 
 .w-e-toolbar * {

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -192,6 +192,45 @@ test.describe('Basic Editor', () => {
     expect(domPointErrors).toEqual([])
   })
 
+  test('regression #282: first-line superscript with large font should not be clipped', async ({ page }) => {
+    await page.evaluate(() => {
+      const editor = (window as any).wangEditorExampleBridge?.editor
+
+      if (!editor) {
+        throw new Error('editor missing')
+      }
+
+      editor.setHtml('<p><span style="font-size: 40px;"><sup><strong>sfdsf</strong></sup></span></p>')
+    })
+
+    await page.waitForTimeout(120)
+
+    const snapshot = await page.evaluate(() => {
+      const textarea = document.querySelector('[data-testid="editor-textarea"]')
+      const scroll = textarea?.querySelector('.w-e-scroll')
+      const strong = textarea?.querySelector('strong')
+      const sup = textarea?.querySelector('sup')
+
+      if (!scroll || !strong || !sup) {
+        throw new Error('required elements not found')
+      }
+
+      const scrollRect = scroll.getBoundingClientRect()
+      const strongRect = strong.getBoundingClientRect()
+      const clippedTop = strongRect.top + 0.5 < scrollRect.top
+
+      return {
+        clippedTop,
+        scrollTop: scrollRect.top,
+        textTop: strongRect.top,
+        supLineHeight: window.getComputedStyle(sup).lineHeight,
+      }
+    })
+
+    expect(snapshot.clippedTop).toBe(false)
+    expect(snapshot.supLineHeight).not.toBe('0px')
+  })
+
   test('regression #609: insertData with complex html should not break editing', async ({ page }) => {
     const pageErrors: string[] = []
     const consoleErrors: string[] = []


### PR DESCRIPTION
## 背景
Issue #282 反馈：当首行内容为大字号上标（如 `font-size: 40px` + `sup`）时，文字顶部会被裁切。

本地复现后确认当前 `master` 仍存在该问题，核心原因是浏览器默认 `sup/sub` 行高过小（接近 `0`），而编辑区滚动容器 `.w-e-scroll` 为 `overflow: auto`，导致首行上方被裁切。

## 修复
- 在编辑区样式中让 `sup/sub` 继承行高：
  - `packages/core/src/assets/common.less`
  - `.w-e-text-container sup, .w-e-text-container sub { line-height: inherit; }`

该改动仅影响编辑区内 `sup/sub` 的行高计算，不改变导入导出结构。

## 回归测试
- 新增 Playwright 回归：
  - `tests/e2e/editor.spec.ts`
  - `regression #282: first-line superscript with large font should not be clipped`
- 断言点：首行 `strong` 顶部不再高于 `.w-e-scroll` 可视区域顶部，且 `sup` 的计算行高不为 `0px`。

## 验证
- `pnpm exec eslint tests/e2e/editor.spec.ts`
- `pnpm turbo build --filter=@wangeditor-next/editor`
- `PLAYWRIGHT_SKIP_BUILD=1 pnpm e2e --grep "regression #282: first-line superscript with large font should not be clipped" --project=chromium`

Closes #282


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a rendering issue where superscripts and subscripts with large fonts would be clipped at the top of the editor content, improving visual display of styled text.

* **Tests**
  * Added a regression test to verify that superscripts and subscripts render correctly without clipping when using large font sizes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/843?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->