### PR TITLE
fix(plugin-markdown): skip markdown trigger during IME composition

### DIFF
--- a/.changeset/witty-shrimps-think.md
+++ b/.changeset/witty-shrimps-think.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/plugin-markdown': patch
+---
+
+Fix markdown auto-trigger behavior during IME composition to avoid Vue2 wrapper cursor/selection glitches while typing with Chinese input methods.

--- a/apps/demo-html/examples/framework-vue2-markdown.html
+++ b/apps/demo-html/examples/framework-vue2-markdown.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>wangEditor Vue2 markdown regression demo</title>
+  <link href="https://cdn.bootcdn.net/ajax/libs/normalize/8.0.1/normalize.min.css" rel="stylesheet">
+  <link href="./css/editor.css" rel="stylesheet">
+  <link href="../dist/css/style.css" rel="stylesheet">
+  <style>
+    .page {
+      margin: 16px;
+      max-width: 980px;
+    }
+
+    .shell {
+      border: 1px solid #d9e2f2;
+      border-radius: 8px;
+      overflow: hidden;
+      margin-top: 12px;
+    }
+
+    .output {
+      margin-top: 12px;
+      font-size: 12px;
+      background: #f7f9fc;
+      border: 1px solid #e5ebf5;
+      border-radius: 8px;
+      padding: 8px;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+  </style>
+</head>
+<body>
+  <div id="app"></div>
+
+  <script src="https://unpkg.com/vue@2.7.16/dist/vue.js"></script>
+  <script src="../dist/index.js"></script>
+  <script>
+    window.editor = window.wangEditor
+  </script>
+  <script src="../plugin-markdown-dist/index.js"></script>
+  <script src="https://unpkg.com/@wangeditor-next/editor-for-vue2@1.0.2/dist/index.js"></script>
+  <script>
+    const markdownModule = window.WangEditorMarkDownPlugin?.default || window.WangEditorMarkDownPlugin
+
+    if (markdownModule && !window.__wangeditorVue2MarkdownRegistered) {
+      window.editor.Boot.registerModule(markdownModule)
+      window.__wangeditorVue2MarkdownRegistered = true
+    }
+
+    const { Editor, Toolbar } = window.WangEditorForVue
+
+    new Vue({
+      el: '#app',
+      components: {
+        Editor,
+        Toolbar,
+      },
+      data() {
+        return {
+          html: '<p>输入 ### + 空格触发标题后，切换中文输入法继续输入。</p>',
+          editor: null,
+          toolbarConfig: {
+            toolbarKeys: [
+              'headerSelect',
+              'bold',
+              'italic',
+              '|',
+              'undo',
+              'redo',
+            ],
+          },
+          editorConfig: {
+            placeholder: '请输入内容...',
+          },
+        }
+      },
+      methods: {
+        handleCreated(editorInstance) {
+          this.editor = Object.seal(editorInstance)
+          window.vue2MarkdownEditor = editorInstance
+        },
+        handleChange(editorInstance) {
+          this.html = editorInstance.getHtml()
+        },
+      },
+      beforeDestroy() {
+        if (this.editor == null) { return }
+        this.editor.destroy()
+      },
+      template: `
+        <div class="page">
+          <h2>Vue2 Wrapper Markdown Demo</h2>
+          <p>该示例用于回归 #675：Vue2 + markdown + 中文输入法组合。</p>
+
+          <div class="shell">
+            <div data-testid="editor-toolbar">
+              <Toolbar :editor="editor" :defaultConfig="toolbarConfig" mode="default" />
+            </div>
+            <div data-testid="editor-textarea">
+              <Editor
+                v-model="html"
+                :defaultConfig="editorConfig"
+                mode="default"
+                @onCreated="handleCreated"
+                @onChange="handleChange"
+              />
+            </div>
+          </div>
+
+          <pre class="output" data-testid="editor-html">{{ html }}</pre>
+        </div>
+      `,
+    })
+  </script>
+</body>
+</html>

--- a/apps/demo-html/examples/index.html
+++ b/apps/demo-html/examples/index.html
@@ -45,6 +45,7 @@
     <li><a href="./new-menu.html">New menu 新注册菜单</a></li>
     <li><a href="./table-line-break.html">表格换行符测试</a></li>
     <li><a href="./framework-vue2.html">Vue2 wrapper regression demo</a></li>
+    <li><a href="./framework-vue2-markdown.html">Vue2 wrapper markdown regression demo</a></li>
     <li><a href="./insert-menu.html">插入、替换菜单</a></li>
   </ul>
 </body>

--- a/apps/demo-html/serve.js
+++ b/apps/demo-html/serve.js
@@ -6,6 +6,7 @@ const port = Number(process.env.PORT || 8881)
 const examplesDir = path.join(__dirname, 'examples')
 const editorDistDir = path.join(__dirname, '../../packages/editor/dist')
 const coreDistDir = path.join(__dirname, '../../packages/core/dist')
+const markdownDistDir = path.join(__dirname, '../../packages/plugin-markdown/dist')
 
 const contentTypes = {
   '.css': 'text/css; charset=utf-8',
@@ -54,6 +55,10 @@ function resolvePath(urlPath) {
     return { filePath: path.join(coreDistDir, urlPath.replace('/core-dist/', '')) }
   }
 
+  if (urlPath.startsWith('/plugin-markdown-dist/')) {
+    return { filePath: path.join(markdownDistDir, urlPath.replace('/plugin-markdown-dist/', '')) }
+  }
+
   return { notFound: true }
 }
 
@@ -85,6 +90,8 @@ const server = http.createServer((req, res) => {
     baseDir = editorDistDir
   } else if (requestUrl.pathname.startsWith('/core-dist/')) {
     baseDir = coreDistDir
+  } else if (requestUrl.pathname.startsWith('/plugin-markdown-dist/')) {
+    baseDir = markdownDistDir
   }
   if (!isSafePath(baseDir, filePath) || !fs.existsSync(filePath) || fs.statSync(filePath).isDirectory()) {
     res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' })

--- a/packages/plugin-markdown/__tests__/plugin.test.ts
+++ b/packages/plugin-markdown/__tests__/plugin.test.ts
@@ -1,3 +1,4 @@
+import { DomEditor } from '@wangeditor-next/editor'
 import { Editor } from 'slate'
 
 import createEditor from '../../../tests/utils/create-editor'
@@ -26,5 +27,20 @@ describe('plugin-markdown', () => {
     editor.insertBreak()
 
     expect(editor.children[0].type).toBe('divider')
+  })
+
+  it('skips markdown trigger while composing', () => {
+    const editor = createMarkdownEditor()
+    const textarea = DomEditor.getTextarea(editor)
+
+    editor.select(Editor.start(editor, []))
+    editor.insertText('#')
+
+    textarea.isComposing = true
+    editor.insertText(' ')
+    textarea.isComposing = false
+
+    expect(editor.children[0].type).toBe('paragraph')
+    expect(Editor.string(editor, [0])).toBe('# ')
   })
 })

--- a/packages/plugin-markdown/src/module/plugin.ts
+++ b/packages/plugin-markdown/src/module/plugin.ts
@@ -66,10 +66,23 @@ function withMarkdown<T extends IDomEditor>(editor: T) {
   const { insertBreak, insertText } = editor
   const newEditor = editor
 
+  const isComposing = () => {
+    try {
+      return DomEditor.getTextarea(editor).isComposing
+    } catch {
+      return false
+    }
+  }
+
   // 输入空格时，尝试转换 markdown
   newEditor.insertText = text => {
     const { selection } = editor
 
+    // Align with Slate/Plate autoformat behavior: never run markdown trigger
+    // while IME composition is active.
+    if (isComposing()) {
+      return insertText(text)
+    }
     if (selection == null) {
       return insertText(text)
     }
@@ -125,6 +138,9 @@ function withMarkdown<T extends IDomEditor>(editor: T) {
   newEditor.insertBreak = () => {
     const { selection } = editor
 
+    if (isComposing()) {
+      return insertBreak()
+    }
     if (selection == null) {
       return insertBreak()
     }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, devices } from '@playwright/test'
 
-let webServerCommand = 'pnpm turbo build --filter=@wangeditor-next/editor && pnpm --filter @wangeditor-next/demo-html run serve'
+let webServerCommand = 'pnpm turbo build --filter=@wangeditor-next/editor --filter=@wangeditor-next/plugin-markdown && pnpm --filter @wangeditor-next/demo-html run serve'
 const reactDemoDevCommand = 'pnpm --filter @wangeditor-next/demo-react exec vite --host 127.0.0.1 --port 3102 --strictPort'
 const vue3DemoDevCommand = 'pnpm --filter @wangeditor-next/demo-vue3 exec vite --force --host 127.0.0.1 --port 3103 --strictPort'
 const reactDemoPreviewCommand = 'pnpm --filter @wangeditor-next/demo-react run build && pnpm --filter @wangeditor-next/demo-react exec vite preview --host 127.0.0.1 --port 3102 --strictPort'
@@ -11,7 +11,7 @@ let vue3DemoCommand = vue3DemoDevCommand
 if (process.env.PLAYWRIGHT_SKIP_BUILD) {
   webServerCommand = 'pnpm --filter @wangeditor-next/demo-html run serve'
 } else if (process.env.CI) {
-  webServerCommand = 'pnpm turbo build --force --filter=@wangeditor-next/editor && pnpm --filter @wangeditor-next/demo-html run serve'
+  webServerCommand = 'pnpm turbo build --force --filter=@wangeditor-next/editor --filter=@wangeditor-next/plugin-markdown && pnpm --filter @wangeditor-next/demo-html run serve'
 }
 
 if (process.env.CI && process.env.PLAYWRIGHT_WRAPPER_PREVIEW === '1') {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,7 +9,9 @@ let reactDemoCommand = reactDemoDevCommand
 let vue3DemoCommand = vue3DemoDevCommand
 
 if (process.env.PLAYWRIGHT_SKIP_BUILD) {
-  webServerCommand = 'pnpm --filter @wangeditor-next/demo-html run serve'
+  // CI e2e sets PLAYWRIGHT_SKIP_BUILD=1 and prebuilds only part of packages.
+  // Keep this lightweight but ensure plugin-markdown dist exists for markdown demos.
+  webServerCommand = 'pnpm turbo build --filter=@wangeditor-next/plugin-markdown && pnpm --filter @wangeditor-next/demo-html run serve'
 } else if (process.env.CI) {
   webServerCommand = 'pnpm turbo build --force --filter=@wangeditor-next/editor --filter=@wangeditor-next/plugin-markdown && pnpm --filter @wangeditor-next/demo-html run serve'
 }

--- a/tests/e2e/framework-regression.spec.ts
+++ b/tests/e2e/framework-regression.spec.ts
@@ -1217,4 +1217,66 @@ test.describe('Framework parity regression', () => {
       expect(pageErrors).toEqual([])
     })
   }
+
+  test('vue2-wrapper-markdown: regression #675 should skip markdown trigger during composition', async ({ page }) => {
+    const pageErrors: string[] = []
+
+    page.on('pageerror', err => {
+      pageErrors.push(err?.stack || err?.message || String(err))
+    })
+
+    await openTarget(page, {
+      name: 'vue2-wrapper-markdown',
+      url: '/examples/framework-vue2-markdown.html',
+    })
+
+    await clearEditor(page)
+    await page.keyboard.type('# ')
+
+    const normalTriggerSnapshot = await page.evaluate(() => {
+      const editor = (window as any).vue2MarkdownEditor
+
+      if (!editor) {
+        throw new Error('vue2 markdown editor not ready')
+      }
+
+      return {
+        firstType: editor.children?.[0]?.type || '',
+        html: editor.getHtml?.() || '',
+      }
+    })
+
+    expect(normalTriggerSnapshot.firstType).toBe('header1')
+    expect(normalTriggerSnapshot.html).toContain('<h1>')
+
+    await clearEditor(page)
+    await page.keyboard.type('#')
+
+    const compositionSnapshot = await page.evaluate(() => {
+      const globalWindow = window as any
+      const editor = globalWindow.vue2MarkdownEditor
+
+      if (!editor) {
+        throw new Error('vue2 markdown editor not ready')
+      }
+
+      const textarea = globalWindow.editor.DomEditor.getTextarea(editor)
+
+      textarea.isComposing = true
+      editor.insertText(' ')
+      editor.insertText('你')
+      textarea.isComposing = false
+
+      return {
+        firstType: editor.children?.[0]?.type || '',
+        html: editor.getHtml?.() || '',
+        text: editor.getText?.() || '',
+      }
+    })
+
+    expect(compositionSnapshot.firstType).toBe('paragraph')
+    expect(compositionSnapshot.html).toContain('<p># 你</p>')
+    expect(compositionSnapshot.text).toContain('# 你')
+    expect(pageErrors).toEqual([])
+  })
 })


### PR DESCRIPTION
## Summary
- skip markdown auto-trigger (`#`, `+`, `---`, etc.) while IME composition is active in `plugin-markdown`
- add a dedicated Vue2 + markdown regression demo page for reproducible verification
- add Playwright regression (`#675`) and plugin unit regression coverage
- ensure Playwright web server builds `@wangeditor-next/plugin-markdown` so demo always uses local latest plugin code

## Root Cause
`plugin-markdown` autoformat logic ran during composition windows. With Vue2 wrapper + Chinese IME, composition candidate actions (especially space/enter driven transitions) could hit markdown trigger paths and mutate block structure unexpectedly, which then led to caret/text disorder.

## Fix
- add composition guard in markdown plugin (`DomEditor.getTextarea(editor).isComposing`)
- bypass markdown transforms during composition and delegate to original insert handlers

## Regression Coverage
- `packages/plugin-markdown/__tests__/plugin.test.ts`
  - new case: skip markdown trigger while composing
- `tests/e2e/framework-regression.spec.ts`
  - new case: `vue2-wrapper-markdown: regression #675 should skip markdown trigger during composition`

## Demo
- `/examples/framework-vue2-markdown.html`

## Risk
- behavior change is scoped to composition period only
- normal non-IME markdown triggers remain unchanged (covered in unit + e2e)

## Rollback
- revert commit `2e669b95` to restore previous markdown trigger behavior

Closes #675


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed markdown auto-trigger during IME composition in Vue 2, preventing unwanted heading conversion while composing.

* **New Features**
  * Added a standalone demo page showcasing Vue 2 + markdown with Chinese IME behavior.

* **Tests**
  * Added E2E and unit tests covering IME composition behavior for the markdown flow.

* **Chores / Tooling**
  * Updated local serve/build config and test runner setup to include the markdown demo and plugin assets.

* **Documentation**
  * Added a changeset entry documenting the patch release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/844?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->