### PR TITLE
fix(core): keep caret visible on rapid enter scroll

### DIFF
--- a/.changeset/nice-horses-share.md
+++ b/.changeset/nice-horses-share.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/core': patch
+---
+
+Fix caret auto-scroll alignment during rapid enter typing so Vue 3 wrapper editing keeps the caret visible at the viewport bottom.

--- a/packages/core/src/text-area/syncSelection.ts
+++ b/packages/core/src/text-area/syncSelection.ts
@@ -165,8 +165,35 @@ export function editorSelectionToDOM(textarea: TextArea, editor: IDomEditor, foc
         scrollMode: 'if-needed',
         boundary: config.scroll ? editorElement.parentElement || body : body, // issue 4215
         block: 'end',
-        behavior: 'smooth',
+        // Keep caret tracking deterministic during fast typing/enter bursts.
+        // Smooth scrolling can lag behind and leave the caret above viewport bottom.
+        behavior: 'auto',
       })
+
+      // Some wrapper runtimes can still leave the collapsed caret slightly
+      // outside of the scroll viewport after rapid enter bursts. Force a
+      // final correction so caret is always visible (issue #388).
+      if (config.scroll) {
+        const scrollContainer = editorElement.parentElement as HTMLElement | null
+
+        if (scrollContainer) {
+          const keepCaretVisible = () => {
+            const latestRect = newDomRange!.getBoundingClientRect()
+            const containerRect = scrollContainer.getBoundingClientRect()
+            const overflowBottom = latestRect.bottom - containerRect.bottom
+            const overflowTop = containerRect.top - latestRect.top
+
+            if (overflowBottom > 0) {
+              scrollContainer.scrollTop += overflowBottom + 1
+            } else if (overflowTop > 0) {
+              scrollContainer.scrollTop -= overflowTop + 1
+            }
+          }
+
+          keepCaretVisible()
+          requestAnimationFrame(keepCaretVisible)
+        }
+      }
       // @ts-ignore
       delete leafEl.getBoundingClientRect
     }

--- a/tests/e2e/framework-regression.spec.ts
+++ b/tests/e2e/framework-regression.spec.ts
@@ -1279,4 +1279,114 @@ test.describe('Framework parity regression', () => {
     expect(compositionSnapshot.text).toContain('# 你')
     expect(pageErrors).toEqual([])
   })
+
+  test('vue3-wrapper: regression #388 enter-at-bottom should keep scroll pinned', async ({ page }) => {
+    const pageErrors: string[] = []
+
+    page.on('pageerror', err => {
+      pageErrors.push(err?.stack || err?.message || String(err))
+    })
+
+    await openTarget(page, {
+      name: 'vue3-wrapper',
+      url: 'http://127.0.0.1:3103/',
+    })
+
+    await page.evaluate(() => {
+      const editor = (window as any).vue3Editor
+
+      if (!editor) {
+        throw new Error('vue3 editor not ready')
+      }
+
+      const lines = Array.from({ length: 120 }, (_, index) => {
+        return `<p>scroll-line-${String(index).padStart(3, '0')}</p>`
+      }).join('')
+
+      editor.setHtml(lines)
+
+      const lastIndex = Math.max((editor.children?.length || 1) - 1, 0)
+      const lastText = String(editor.children?.[lastIndex]?.children?.[0]?.text || '')
+
+      editor.select({
+        anchor: { path: [lastIndex, 0], offset: lastText.length },
+        focus: { path: [lastIndex, 0], offset: lastText.length },
+      })
+      editor.focus()
+
+      const container = document.querySelector('[data-testid="editor-textarea"]')
+      const scroller = container?.querySelector('.w-e-scroll') as HTMLElement | null
+
+      if (scroller) {
+        scroller.scrollTop = scroller.scrollHeight
+      }
+    })
+
+    await page
+      .locator('[data-testid="editor-textarea"] [data-slate-node="text"]')
+      .last()
+      .click({ force: true })
+
+    await Array.from({ length: 36 }).reduce<Promise<void>>(sequence => {
+      return sequence.then(() => page.keyboard.press('Enter'))
+    }, Promise.resolve())
+
+    await page.waitForTimeout(500)
+
+    const metrics = await page.evaluate(() => {
+      const container = document.querySelector('[data-testid="editor-textarea"]')
+      const scroller = container?.querySelector('.w-e-scroll') as HTMLElement | null
+
+      if (!scroller) {
+        throw new Error('scroll container missing')
+      }
+
+      const viewportBottom = scroller.scrollTop + scroller.clientHeight
+      const gapToBottom = scroller.scrollHeight - viewportBottom
+      const scrollerRect = scroller.getBoundingClientRect()
+      const selection = window.getSelection()
+
+      let caretTop = -1
+      let caretBottom = -1
+
+      if (selection && selection.rangeCount > 0) {
+        const range = selection.getRangeAt(0).cloneRange()
+
+        range.collapse(true)
+        const rangeRect = range.getBoundingClientRect()
+
+        if (rangeRect && !(rangeRect.top === 0 && rangeRect.bottom === 0)) {
+          caretTop = rangeRect.top
+          caretBottom = rangeRect.bottom
+        } else if (selection.anchorNode) {
+          const anchorElem = selection.anchorNode.nodeType === Node.TEXT_NODE
+            ? selection.anchorNode.parentElement
+            : selection.anchorNode as Element
+          const anchorRect = anchorElem?.getBoundingClientRect()
+
+          if (anchorRect) {
+            caretTop = anchorRect.top
+            caretBottom = anchorRect.bottom
+          }
+        }
+      }
+
+      const caretInView = caretBottom >= scrollerRect.top - 1 && caretTop <= scrollerRect.bottom + 1
+
+      return {
+        gapToBottom,
+        scrollTop: scroller.scrollTop,
+        scrollHeight: scroller.scrollHeight,
+        clientHeight: scroller.clientHeight,
+        caretTop,
+        caretBottom,
+        scrollerTop: scrollerRect.top,
+        scrollerBottom: scrollerRect.bottom,
+        caretInView,
+      }
+    })
+
+    expect(metrics.caretInView, JSON.stringify(metrics)).toBe(true)
+    expect(pageErrors).toEqual([])
+  })
 })


### PR DESCRIPTION
## Summary
- fix caret auto-scroll alignment in selection sync for rapid Enter typing
- add Vue3 wrapper e2e regression for issue #388
- add changeset for `@wangeditor-next/core`

## Root Cause
During rapid Enter bursts near the bottom of a scroll-enabled editor, `scroll-into-view-if-needed` could finish with the collapsed caret still slightly outside the viewport in some wrapper/runtime flows.

## Fix
- keep current selection sync flow
- after `scrollIntoView`, add a deterministic caret-visibility correction against the scroll container viewport
- run one extra `requestAnimationFrame` pass to catch post-layout drift

## Regression Coverage
- `tests/e2e/framework-regression.spec.ts`
  - `vue3-wrapper: regression #388 enter-at-bottom should keep scroll pinned`

## Verification
- `PLAYWRIGHT_SKIP_BUILD=1 pnpm playwright test tests/e2e/framework-regression.spec.ts -g "regression #388|regression #675"`
- `pnpm vitest run packages/core/__tests__/text-area/syncSelection.test.ts packages/core/__tests__/text-area/syncSelection-firefox.test.ts`

Closes #388


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the caret was not staying visible during rapid typing and Enter key presses in the editor.

* **Tests**
  * Added E2E regression test for Vue 3 wrapper editor scroll behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/846?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->