### PR TITLE
fix(ci): pass NPM_TOKEN to changesets publish action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,7 @@ jobs:
             ${{ github.ref_name == 'master' && 'chore(release): publish a new release version' || 'chore(release): publish a new pre-release version' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # Create one consolidated GitHub Release that aggregates all published


### PR DESCRIPTION
## Summary
- pass NPM_TOKEN to changesets/action so it uses npm token auth instead of falling back to OIDC trusted publishing
- keep NODE_AUTH_TOKEN for npm CLI auth in publish command

## Why
Recent release runs failed with "No NPM_TOKEN found, but OIDC is available" and npm E404 on scoped package publish.

## Verification
- inspected failed run 26137177698 logs showing OIDC fallback path
- confirmed repository secret NPM_TOKEN exists


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow infrastructure configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/847?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->