### PR TITLE
fix(core): 修复 #625 与旧版共存时 DOM 映射冲突

### DIFF
--- a/.changeset/fix-issue-625-dom-mapping.md
+++ b/.changeset/fix-issue-625-dom-mapping.md
@@ -1,0 +1,6 @@
+---
+'@wangeditor-next/core': patch
+'@wangeditor-next/editor': patch
+---
+
+fix: scope Slate DOM mapping lookup to the active editor root so duplicated legacy ids do not break DOM-to-Slate resolution when wangEditor and wangEditor-next coexist.

--- a/packages/core/src/render/element/renderElement.tsx
+++ b/packages/core/src/render/element/renderElement.tsx
@@ -9,9 +9,9 @@ import { jsx, VNode } from 'snabbdom'
 
 import { DomEditor } from '../../editor/dom-editor'
 import { IDomEditor } from '../../editor/interface'
-import { getElementById } from '../../utils/dom'
 import { promiseResolveThen } from '../../utils/util'
 import {
+  EDITOR_TO_ELEMENT,
   ELEMENT_TO_NODE,
   KEY_TO_ELEMENT,
   NODE_TO_ELEMENT,
@@ -115,8 +115,10 @@ function renderElement(elemNode: SlateElement, editor: IDomEditor): VNode {
 
   // 更新 element 相关的 weakMap
   promiseResolveThen(() => {
-    // 异步，否则拿不到 DOM 节点
-    const dom = getElementById(domId)
+    // 异步，否则拿不到 DOM 节点。
+    // 优先在当前 editor root 内查找，避免同页多编辑器（或旧版 wangEditor）重复 id 冲突。
+    const editorRoot = EDITOR_TO_ELEMENT.get(editor)
+    const dom = editorRoot?.querySelector<HTMLElement>(`#${domId}`)
 
     if (dom == null) { return }
     KEY_TO_ELEMENT.set(key, dom)

--- a/packages/core/src/render/text/renderText.tsx
+++ b/packages/core/src/render/text/renderText.tsx
@@ -12,9 +12,13 @@ import { jsx, VNode } from 'snabbdom'
 
 import { DomEditor } from '../../editor/dom-editor'
 import { IDomEditor } from '../../editor/interface'
-import { getElementById } from '../../utils/dom'
 import { promiseResolveThen } from '../../utils/util'
-import { ELEMENT_TO_NODE, KEY_TO_ELEMENT, NODE_TO_ELEMENT } from '../../utils/weak-maps'
+import {
+  EDITOR_TO_ELEMENT,
+  ELEMENT_TO_NODE,
+  KEY_TO_ELEMENT,
+  NODE_TO_ELEMENT,
+} from '../../utils/weak-maps'
 import { genTextId } from '../helper'
 import genTextVnode from './genVnode'
 import addTextVnodeStyle from './renderStyle'
@@ -52,8 +56,10 @@ function renderText(textNode: SlateText, parent: Ancestor, editor: IDomEditor): 
 
   // 更新 weak-map
   promiseResolveThen(() => {
-    // 异步，否则拿不到 DOM
-    const dom = getElementById(textId)
+    // 异步，否则拿不到 DOM。
+    // 优先在当前 editor root 内查找，避免同页重复 id 导致映射到错误节点。
+    const editorRoot = EDITOR_TO_ELEMENT.get(editor)
+    const dom = editorRoot?.querySelector<HTMLElement>(`#${textId}`)
 
     if (dom == null) { return }
     KEY_TO_ELEMENT.set(key, dom)

--- a/packages/core/src/text-area/update-view.ts
+++ b/packages/core/src/text-area/update-view.ts
@@ -3,8 +3,9 @@
  * @author wangfupeng
  */
 
-import { h, VNode } from 'snabbdom'
 import { Element } from 'slate'
+import { h, VNode } from 'snabbdom'
+
 import { IDomEditor } from '../editor/interface'
 import { node2Vnode } from '../render/node2Vnode'
 import $, { Dom7Array, getDefaultView, getElementById } from '../utils/dom'
@@ -117,6 +118,9 @@ function updateView(textarea: TextArea, editor: IDomEditor) {
     $scroll.append($textArea)
     textarea.$textArea = $textArea // 存储下编辑区域的 DOM 节点
     textareaElem = $textArea[0]
+    EDITOR_TO_ELEMENT.set(editor, textareaElem)
+    NODE_TO_ELEMENT.set(editor, textareaElem)
+    ELEMENT_TO_NODE.set(textareaElem, editor)
 
     // 再生成 patch 函数，并执行
     const patchFn = genPatchFn()
@@ -138,7 +142,9 @@ function updateView(textarea: TextArea, editor: IDomEditor) {
   }
 
   if (textareaElem == null) {
-    textareaElem = getElementById(elemId)
+    const scopedRoot = $scroll[0] as HTMLElement | undefined
+
+    textareaElem = scopedRoot?.querySelector(`#${elemId}`) || getElementById(elemId)
 
     // 通过 getElementById 获取的有可能是 null （销毁、重建时，可能会发生这种情况）
     if (textareaElem == null) { return }
@@ -164,7 +170,9 @@ function updateView(textarea: TextArea, editor: IDomEditor) {
   if (isFirstPatch) {
     const window = getDefaultView(textareaElem)
 
-    window && EDITOR_TO_WINDOW.set(editor, window)
+    if (window) {
+      EDITOR_TO_WINDOW.set(editor, window)
+    }
   }
 
   EDITOR_TO_ELEMENT.set(editor, textareaElem) // 存储 editor -> elem 对应关系

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -1063,6 +1063,44 @@ test.describe('Basic Editor', () => {
   })
 })
 
+test('regression #625: duplicated legacy ids should not break DOM-to-Slate mapping', async ({ page }) => {
+  const pageErrors: string[] = []
+
+  page.on('pageerror', err => {
+    pageErrors.push(err?.stack || err?.message || String(err))
+  })
+
+  await page.goto('/examples/default-mode.html')
+  await page.evaluate(() => {
+    const legacyRoot = document.createElement('div')
+
+    legacyRoot.id = 'legacy-editor-mock'
+    legacyRoot.innerHTML = [
+      '<div id="w-e-textarea-1" data-slate-editor data-slate-node="value">',
+      '  <p id="w-e-element-header1-0" data-slate-node="element">',
+      '    <span id="w-e-text-1" data-slate-node="text">',
+      '      <span data-slate-leaf><span data-slate-string>legacy</span></span>',
+      '    </span>',
+      '  </p>',
+      '</div>',
+    ].join('')
+    document.body.prepend(legacyRoot)
+  })
+
+  await page.getByTestId('btn-create').click()
+  await expect(getEditable(page)).toBeVisible()
+
+  await page.locator('[data-testid="editor-textarea"] [data-slate-string]').first().click()
+  await page.keyboard.press('ArrowRight')
+  await page.keyboard.type('hello-next')
+  await page.waitForTimeout(120)
+
+  const domNodeErrors = pageErrors.filter(msg => msg.includes('Cannot resolve a Slate node from DOM node'))
+
+  expect(domNodeErrors).toEqual([])
+  await expect(page.getByTestId('editor-html')).toContainText('hello-next')
+})
+
 test.describe('Multi Editors', () => {
   test('edits each editor independently', async ({ page }) => {
     await page.goto('/examples/multi-editors.html')


### PR DESCRIPTION
## 背景\n- 修复 issue #625：同页同时使用旧版 wangEditor 与 wangEditor-next 时，重复 DOM id 可能导致 DOM->Slate 映射异常。\n\n## 变更\n- 将 text/element 节点映射查询限定在当前 editor root 内，避免跨编辑器命中同名 id。\n- 首次 patch 时提前绑定 editor root 映射。\n- 新增 Playwright 回归用例覆盖重复 legacy id 场景。\n- 添加 changeset（core/editor patch）。\n\n## 验证\n- 
> @wangeditor-next/core@1.8.3 test /home/yaolongfei/workspace/wangEditor-next/packages/core
> vitest run "__tests__/editor/dom-editor.test.ts"


 RUN  v3.2.4 /home/yaolongfei/workspace/wangEditor-next/packages/core

 ✓ __tests__/editor/dom-editor.test.ts (31 tests) 329ms

 Test Files  1 passed (1)
      Tests  31 passed (31)
   Start at  15:10:10
   Duration  2.79s (transform 758ms, setup 115ms, collect 1.11s, tests 329ms, environment 445ms, prepare 317ms)\n- 
Running 1 test using 1 worker

  ✓  1 [chromium] › tests/e2e/editor.spec.ts:1066:5 › regression #625: duplicated legacy ids should not break DOM-to-Slate mapping (1.2s)

  1 passed (9.2s)\n\nFixes #625

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed DOM-to-Slate node mapping failures that occurred when using multiple editor instances simultaneously, improving reliability when mixing editor versions.

* **Tests**
  * Added regression test to ensure DOM mapping functions correctly with duplicate legacy DOM element IDs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/849?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->