### PR TITLE
fix(table): make tableFullWidth truly responsive (fix #848)

### DIFF
--- a/.changeset/fix-table-full-width-responsive.md
+++ b/.changeset/fix-table-full-width-responsive.md
@@ -1,0 +1,6 @@
+---
+'@wangeditor-next/table-module': patch
+'@wangeditor-next/editor': patch
+---
+
+fix(table): make `tableFullWidth` switch table nodes to responsive `width: 100%` mode instead of one-time pixel recalculation, and add regression coverage for width round-trip plus container-resize behavior.

--- a/packages/table-module/__tests__/elem-to-html.test.ts
+++ b/packages/table-module/__tests__/elem-to-html.test.ts
@@ -142,6 +142,20 @@ describe('TableModule module', () => {
       )
     })
 
+    test('tableToHtmlConf should keep 100% width even when columnWidths are present', () => {
+      const element = {
+        type: 'table',
+        width: '100%',
+        columnWidths: [120, 80],
+        children: [],
+      }
+      const res = tableToHtmlConf.elemToHtml(element, '<tr><td>123</td><td>456</td></tr>')
+
+      expect(res).toBe(
+        '<table style="width: 100%;table-layout: fixed;height:auto"><colgroup contentEditable="false"><col width=120></col><col width=80></col></colgroup><tbody><tr><td>123</td><td>456</td></tr></tbody></table>',
+      )
+    })
+
     test('tableToHtmlConf should return html table string with full width style if element is set fullWith value true', () => {
       const element = {
         type: 'table',

--- a/packages/table-module/__tests__/menu/full-width.test.ts
+++ b/packages/table-module/__tests__/menu/full-width.test.ts
@@ -115,7 +115,6 @@ describe('Table Module Full Width Menu', () => {
       type: 'table',
       children: [],
     }) as any)
-    vi.spyOn(core.DomEditor, 'toDOMNode').mockImplementation(() => document.createElement('table'))
 
     const fn = vi.fn()
 
@@ -123,10 +122,10 @@ describe('Table Module Full Width Menu', () => {
 
     fullWidthMenu.exec(editor, true)
 
-    expect(fn).toBeCalled()
+    expect(fn).toHaveBeenCalledWith(editor, { width: '100%' }, { mode: 'highest' })
   })
 
-  test('exec scales column widths to container width and keeps the last column remainder', () => {
+  test('exec should switch table width to 100% without rewriting columnWidths', () => {
     const fullWidthMenu = new FullWidth()
     const editor = createEditor()
     const tableNode = {
@@ -134,17 +133,10 @@ describe('Table Module Full Width Menu', () => {
       columnWidths: [100, 200],
       children: [],
     } as any
-    const tableDom = document.createElement('div')
-    const container = document.createElement('div')
-
-    container.className = 'table-container'
-    Object.defineProperty(container, 'clientWidth', { value: 400 })
-    tableDom.append(container)
 
     setEditorSelection(editor)
     vi.spyOn(fullWidthMenu, 'isDisabled').mockReturnValue(false)
     vi.spyOn(core.DomEditor, 'getSelectedNodeByType').mockReturnValue(tableNode)
-    vi.spyOn(core.DomEditor, 'toDOMNode').mockReturnValue(tableDom)
     const setNodesSpy = vi.spyOn(slate.Transforms, 'setNodes').mockImplementation(() => {})
 
     fullWidthMenu.exec(editor, '')
@@ -152,40 +144,23 @@ describe('Table Module Full Width Menu', () => {
     expect(setNodesSpy).toHaveBeenCalledWith(
       editor,
       {
-        width: 'auto',
-        columnWidths: [133, 266],
+        width: '100%',
       },
       { mode: 'highest' },
     )
   })
 
-  test('exec enforces minWidth and shrinks oversized columns proportionally', () => {
+  test('exec should set 100% width when table has no columnWidths', () => {
     const fullWidthMenu = new FullWidth()
-    const editor = createEditor({
-      config: {
-        MENU_CONF: {
-          insertTable: {
-            minWidth: 120,
-          },
-        },
-      },
-    })
+    const editor = createEditor()
     const tableNode = {
       type: 'table',
-      columnWidths: [60, 60],
       children: [],
     } as any
-    const tableDom = document.createElement('div')
-    const container = document.createElement('div')
-
-    container.className = 'table-container'
-    Object.defineProperty(container, 'clientWidth', { value: 200 })
-    tableDom.append(container)
 
     setEditorSelection(editor)
     vi.spyOn(fullWidthMenu, 'isDisabled').mockReturnValue(false)
     vi.spyOn(core.DomEditor, 'getSelectedNodeByType').mockReturnValue(tableNode)
-    vi.spyOn(core.DomEditor, 'toDOMNode').mockReturnValue(tableDom)
     const setNodesSpy = vi.spyOn(slate.Transforms, 'setNodes').mockImplementation(() => {})
 
     fullWidthMenu.exec(editor, '')
@@ -193,8 +168,7 @@ describe('Table Module Full Width Menu', () => {
     expect(setNodesSpy).toHaveBeenCalledWith(
       editor,
       {
-        width: 'auto',
-        columnWidths: [120, 120],
+        width: '100%',
       },
       { mode: 'highest' },
     )

--- a/packages/table-module/__tests__/parse-html.test.ts
+++ b/packages/table-module/__tests__/parse-html.test.ts
@@ -9,6 +9,7 @@ import { registerParseElemHtmlConf } from '../../core/src/parse-html'
 import { registerParseStyleHtmlHandler } from '../../core/src/parse-html/index'
 import parseElemHtmlFromCore from '../../core/src/parse-html/parse-elem-html'
 import wangEditorTableModule from '../src/index'
+import { tableToHtmlConf } from '../src/module/elem-to-html'
 import {
   parseCellHtmlConf,
   parseRowHtmlConf,
@@ -666,6 +667,105 @@ describe('table - parse html', () => {
       height: 124,
       children,
       columnWidths: [90],
+    })
+  })
+
+  it('table - class mode full width attrs should parse as responsive width', () => {
+    const $table = $(
+      [
+        '<table class="w-e-table-layout-fixed" width="100%" data-w-e-table-height="auto">',
+        '<colgroup><col width="120"></col><col width="180"></col></colgroup>',
+        '<tr><td width="auto">A</td><td width="auto">B</td></tr>',
+        '</table>',
+      ].join(''),
+    )
+    const children = [
+      {
+        type: 'table-row',
+        children: [
+          { ...TABLE_CELL_BASE_PROPS, children: [{ text: 'A' }] },
+          { ...TABLE_CELL_BASE_PROPS, children: [{ text: 'B' }] },
+        ],
+      },
+    ]
+
+    expect(parseTableHtmlConf.parseElemHtml($table[0], children as any, editor)).toEqual({
+      type: 'table',
+      width: '100%',
+      height: 0,
+      children,
+      columnWidths: [120, 180],
+    })
+  })
+
+  it('table width 100% should keep round-trip from html -> slate -> html in class mode', () => {
+    const $table = $(
+      [
+        '<table class="w-e-table-layout-fixed" width="100%" data-w-e-table-height="auto">',
+        '<colgroup><col width="120"></col><col width="180"></col></colgroup>',
+        '<tr><td width="auto">A</td><td width="auto">B</td></tr>',
+        '</table>',
+      ].join(''),
+    )
+    const children = [
+      {
+        type: 'table-row',
+        children: [
+          { ...TABLE_CELL_BASE_PROPS, children: [{ text: 'A' }] },
+          { ...TABLE_CELL_BASE_PROPS, children: [{ text: 'B' }] },
+        ],
+      },
+    ]
+    const parsedTable = parseTableHtmlConf.parseElemHtml($table[0], children as any, editor)
+    const exported = tableToHtmlConf.elemToHtml(
+      parsedTable as any,
+      '<tr><td>A</td><td>B</td></tr>',
+      {
+        getConfig() {
+          return { textStyleMode: 'class' }
+        },
+      } as any,
+    )
+
+    expect(parsedTable.width).toBe('100%')
+    expect(exported).toContain('width="100%"')
+    expect(exported).toContain('<col width=120></col>')
+    expect(exported).toContain('<col width=180></col>')
+  })
+
+  it('table width 100% should keep round-trip from slate -> html -> slate', () => {
+    const tableNode = {
+      type: 'table',
+      width: '100%',
+      height: 'auto',
+      columnWidths: [160, 240],
+      children: [
+        {
+          type: 'table-row',
+          children: [
+            { ...TABLE_CELL_BASE_PROPS, children: [{ text: 'A' }] },
+            { ...TABLE_CELL_BASE_PROPS, children: [{ text: 'B' }] },
+          ],
+        },
+      ],
+    }
+    const exported = tableToHtmlConf.elemToHtml(
+      tableNode as any,
+      '<tr><td>A</td><td>B</td></tr>',
+      {
+        getConfig() {
+          return { textStyleMode: 'class' }
+        },
+      } as any,
+    )
+    const $table = $(exported)
+    const parsedBack = parseTableHtmlConf.parseElemHtml($table[0], tableNode.children as any, editor)
+
+    expect(exported).toContain('width="100%"')
+    expect(parsedBack).toMatchObject({
+      type: 'table',
+      width: '100%',
+      columnWidths: [160, 240],
     })
   })
 

--- a/packages/table-module/src/module/menu/FullWidth.ts
+++ b/packages/table-module/src/module/menu/FullWidth.ts
@@ -50,69 +50,13 @@ class TableFullWidth implements IButtonMenu {
 
     if (!tableNode) { return }
 
-    const { columnWidths = [] } = tableNode
-
-    // 获取当前选中的表格的DOM元素,再查找table-container容器元素，防止文档多表格时，获取到其他表格的容器元素
-    const tableDom = DomEditor.toDOMNode(editor, tableNode)
-    const containerElement = tableDom.querySelector('.table-container')
-
-    if (!containerElement || columnWidths.length === 0) {
-      // 如果找不到容器或没有列宽信息，则使用原来的逻辑，先使用auto预留以后实现按比例实现缩放功能
-      const props: Partial<TableElement> = {
-        width: 'auto',
-      }
-
-      Transforms.setNodes(editor, props, { mode: 'highest' })
-      return
+    // 主流编辑器在“适应宽度”语义下使用 100% 响应式模式，而不是一次性重算像素列宽。
+    // 列宽数据仍然保留，用于后续拖拽列宽时进行比例/最小宽度计算。
+    const props: Partial<TableElement> = {
+      width: '100%',
     }
 
-    const containerWidth = containerElement.clientWidth
-    const currentTotalWidth = columnWidths.reduce((a, b) => a + b, 0)
-
-    // 计算等比例调整后的列宽
-    const adjustedColumnWidths = columnWidths.map(width => {
-      const ratio = width / currentTotalWidth
-
-      return Math.floor(ratio * containerWidth)
-    })
-
-    // 确保最小宽度限制（与 insertTable 配置一致，默认 60px）
-    const { minWidth: configuredMinWidth = 60 } = editor.getMenuConfig('insertTable') as any
-    const minWidth = parseInt(String(configuredMinWidth), 10) || 60
-    const adjustedWithMinWidth = adjustedColumnWidths.map(width => Math.max(minWidth, width))
-
-    // 如果调整后的总宽度超过容器宽度，按比例缩小
-    const adjustedTotalWidth = adjustedWithMinWidth.reduce((a, b) => a + b, 0)
-
-    if (adjustedTotalWidth > containerWidth) {
-      const scaleFactor = containerWidth / adjustedTotalWidth
-      const finalColumnWidths = adjustedWithMinWidth.map(width => Math.max(minWidth, Math.floor(width * scaleFactor)))
-
-      // 应用新的列宽和宽度设置
-      const props: Partial<TableElement> = {
-        width: 'auto',
-        columnWidths: finalColumnWidths,
-      }
-
-      Transforms.setNodes(editor, props, { mode: 'highest' })
-    } else {
-      // 如果调整后的总宽度小于容器宽度，将剩余宽度加到最后一列
-      const finalColumnWidths = [...adjustedWithMinWidth]
-      const remainingWidth = containerWidth - adjustedTotalWidth - 1
-
-      if (remainingWidth > 0 && finalColumnWidths.length > 0) {
-        // 将剩余宽度加到最后一列
-        finalColumnWidths[finalColumnWidths.length - 1] += remainingWidth
-      }
-
-      // 应用新的列宽和宽度设置
-      const props: Partial<TableElement> = {
-        width: 'auto',
-        columnWidths: finalColumnWidths,
-      }
-
-      Transforms.setNodes(editor, props, { mode: 'highest' })
-    }
+    Transforms.setNodes(editor, props, { mode: 'highest' })
   }
 }
 

--- a/tests/e2e/framework-regression.spec.ts
+++ b/tests/e2e/framework-regression.spec.ts
@@ -149,6 +149,39 @@ async function dragLastTableFirstBorder(page: Page, deltaX: number): Promise<boo
   return true
 }
 
+async function setTextareaWidthAndMeasureLastTable(
+  page: Page,
+  widthPx: number,
+): Promise<{ containerWidth: number; tableWidth: number; tableStyleWidth: string }> {
+  return page.evaluate(({ width }) => {
+    const textarea = document.querySelector('[data-testid="editor-textarea"]') as HTMLElement | null
+
+    if (!textarea) {
+      throw new Error('editor textarea not found')
+    }
+
+    textarea.style.width = `${width}px`
+    textarea.style.maxWidth = `${width}px`
+    textarea.style.transition = 'none'
+
+    const tables = Array.from(textarea.querySelectorAll('table.table')) as HTMLElement[]
+    const table = tables[tables.length - 1] || null
+
+    if (!table) {
+      throw new Error('table not found')
+    }
+
+    const containerRect = textarea.getBoundingClientRect()
+    const tableRect = table.getBoundingClientRect()
+
+    return {
+      containerWidth: containerRect.width,
+      tableWidth: tableRect.width,
+      tableStyleWidth: table.style.width || '',
+    }
+  }, { width: widthPx })
+}
+
 test.describe('Framework parity regression', () => {
   test.describe.configure({ timeout: process.env.CI ? 240_000 : 90_000 })
 
@@ -716,6 +749,74 @@ test.describe('Framework parity regression', () => {
       expect(dragged).toBe(true)
       expect(beforeFirst).toBeGreaterThan(0)
       expect(resized || clampedAtMinWidth).toBe(true)
+      expect(pageErrors).toEqual([])
+    })
+
+    test(`${target.name}: regression #848 tableFullWidth should stay responsive after container resize`, async ({ page }) => {
+      const pageErrors: string[] = []
+
+      page.on('pageerror', err => {
+        pageErrors.push(err?.stack || err?.message || String(err))
+      })
+
+      await openTarget(page, target)
+      await clearEditor(page)
+      await create2x2Table(page)
+
+      await page
+        .locator('[data-testid="editor-textarea"] table.table')
+        .last()
+        .locator('tr:nth-child(1) > *:nth-child(1)')
+        .click({ force: true })
+
+      const fullWidthMenu = page.locator('[data-menu-key="tableFullWidth"]:visible').first()
+      const hasFullWidthMenu = await fullWidthMenu.count()
+
+      test.skip(!hasFullWidthMenu, `${target.name} demo does not expose tableFullWidth menu`)
+
+      await expect(fullWidthMenu).not.toHaveClass(/disabled/)
+      await fullWidthMenu.click({ force: true })
+      await page.waitForTimeout(220)
+
+      const widthMode = await page.evaluate(() => {
+        const globalWindow = window as any
+        const editor = globalWindow.wangEditorExampleBridge?.editor
+          || globalWindow.vue2Editor
+          || globalWindow.vue3Editor
+          || globalWindow.reactEditor
+
+        if (!editor) {
+          throw new Error('editor not ready')
+        }
+
+        const tableNode = (editor.children || []).find((node: any) => node?.type === 'table')
+
+        return String(tableNode?.width || '')
+      })
+
+      expect(widthMode).toBe('100%')
+
+      const wide = await setTextareaWidthAndMeasureLastTable(page, 820)
+
+      await page.waitForTimeout(100)
+      const narrow = await setTextareaWidthAndMeasureLastTable(page, 520)
+
+      await page.waitForTimeout(100)
+      const widened = await setTextareaWidthAndMeasureLastTable(page, 760)
+
+      expect(wide.tableStyleWidth).toBe('100%')
+      expect(narrow.tableStyleWidth).toBe('100%')
+      expect(widened.tableStyleWidth).toBe('100%')
+
+      expect(narrow.tableWidth).toBeLessThan(wide.tableWidth - 80)
+      expect(widened.tableWidth).toBeGreaterThan(narrow.tableWidth + 80)
+
+      const wideRatio = wide.tableWidth / Math.max(wide.containerWidth, 1)
+      const narrowRatio = narrow.tableWidth / Math.max(narrow.containerWidth, 1)
+      const widenedRatio = widened.tableWidth / Math.max(widened.containerWidth, 1)
+
+      expect(Math.abs(wideRatio - narrowRatio)).toBeLessThan(0.15)
+      expect(Math.abs(narrowRatio - widenedRatio)).toBeLessThan(0.15)
       expect(pageErrors).toEqual([])
     })
 


### PR DESCRIPTION
## Summary
- change `tableFullWidth` behavior from one-time px recalculation to responsive mode by setting table node `width: '100%'`
- keep `columnWidths` for resize math (ratio/min-width logic), but stop rewriting px widths during full-width action
- align behavior with mainstream slate/prosemirror-style editors where "full width" means responsive container tracking

## Changes
- core behavior update
  - `packages/table-module/src/module/menu/FullWidth.ts`
- unit regressions
  - `packages/table-module/__tests__/menu/full-width.test.ts`
  - `packages/table-module/__tests__/elem-to-html.test.ts`
  - `packages/table-module/__tests__/parse-html.test.ts`
- e2e regression (cross framework: html-core/vue2/vue3/react)
  - `tests/e2e/framework-regression.spec.ts`
- changeset
  - `.changeset/fix-table-full-width-responsive.md`

## Verification
- `pnpm --filter @wangeditor-next/table-module test -- __tests__/menu/full-width.test.ts __tests__/elem-to-html.test.ts __tests__/parse-html.test.ts`
- `pnpm exec playwright test tests/e2e/framework-regression.spec.ts -g "848"`
- `pnpm build`

## Risk List
- behavioral change: `tableFullWidth` now switches to persistent responsive mode (`width='100%'`) rather than snapshot-based px fitting
- existing content exporting/parsing paths are covered by added round-trip tests, but integrators relying on old snapshot semantics should validate downstream custom logic

## Rollback Strategy
- revert this PR (or specifically revert `FullWidth.ts` behavior) to restore old px recalculation semantics
- remove/adjust new regression expectations tied to responsive mode if rollback is required


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed table Full Width mode to apply responsive 100% width that adapts to container resizing, rather than using fixed pixel calculations. Column width settings are now preserved.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/851?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #848
