### PR TITLE
feat(list-module): support ordered list start/type

### DIFF
--- a/.changeset/feat-list-module-issue-612-ol-start-type.md
+++ b/.changeset/feat-list-module-issue-612-ol-start-type.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/list-module': patch
+---
+
+feat(list): support ordered list `start` and `type` in list parsing, rendering, and HTML serialization.

--- a/packages/list-module/__tests__/elem-to-html.test.ts
+++ b/packages/list-module/__tests__/elem-to-html.test.ts
@@ -58,6 +58,44 @@ describe('module elem-to-html', () => {
     })
   })
 
+  test('ordered item toHtml with start/type', () => {
+    const orderedWithType1 = {
+      type: 'list-item',
+      ordered: true,
+      orderType: 'A',
+      start: 3,
+      children: [{ text: '' }],
+    }
+    const orderedWithType2 = {
+      type: 'list-item',
+      ordered: true,
+      orderType: 'A',
+      start: 3,
+      children: [{ text: '' }],
+    }
+    const localEditor = createEditor({
+      content: [orderedWithType1, orderedWithType2],
+    })
+
+    ELEM_TO_EDITOR.set(orderedWithType1, localEditor)
+    ELEM_TO_EDITOR.set(orderedWithType2, localEditor)
+
+    const { elemToHtml } = listItemToHtmlConf
+    const firstHtml = elemToHtml(orderedWithType1, childrenHtml)
+    const secondHtml = elemToHtml(orderedWithType2, childrenHtml)
+
+    expect(firstHtml).toEqual({
+      html: '<li><span>hello</span></li>',
+      prefix: '<ol type="A" start="3">',
+      suffix: '',
+    })
+    expect(secondHtml).toEqual({
+      html: '<li><span>hello</span></li>',
+      prefix: '',
+      suffix: '</ol>',
+    })
+  })
+
   test('unOrdered item toHtml', () => {
     const { elemToHtml } = listItemToHtmlConf
 
@@ -279,6 +317,62 @@ describe('module elem-to-html complex list', () => {
     expect(orderedHtml2).toEqual({
       html: '<li><span>hello</span></li>',
       prefix: '<ol>',
+      suffix: '</ol>',
+    })
+  })
+})
+
+describe('module elem-to-html ordered list boundaries', () => {
+  const orderedDecimal = {
+    type: 'list-item',
+    ordered: true,
+    children: [{ text: '' }],
+  }
+  const orderedUpperAlpha = {
+    type: 'list-item',
+    ordered: true,
+    orderType: 'A',
+    children: [{ text: '' }],
+  }
+  const orderedUpperRomanFrom2 = {
+    type: 'list-item',
+    ordered: true,
+    orderType: 'I',
+    start: 2,
+    children: [{ text: '' }],
+  }
+
+  let editor: ReturnType<typeof createEditor>
+
+  beforeEach(() => {
+    editor = createEditor({
+      content: [orderedDecimal, orderedUpperAlpha, orderedUpperRomanFrom2],
+    })
+
+    ELEM_TO_EDITOR.set(orderedDecimal, editor)
+    ELEM_TO_EDITOR.set(orderedUpperAlpha, editor)
+    ELEM_TO_EDITOR.set(orderedUpperRomanFrom2, editor)
+  })
+
+  test('split consecutive ordered lists by type/start config', () => {
+    const childrenHtml = '<span>hello</span>'
+    const { elemToHtml } = listItemToHtmlConf
+
+    expect(elemToHtml(orderedDecimal, childrenHtml)).toEqual({
+      html: '<li><span>hello</span></li>',
+      prefix: '<ol>',
+      suffix: '</ol>',
+    })
+
+    expect(elemToHtml(orderedUpperAlpha, childrenHtml)).toEqual({
+      html: '<li><span>hello</span></li>',
+      prefix: '<ol type="A">',
+      suffix: '</ol>',
+    })
+
+    expect(elemToHtml(orderedUpperRomanFrom2, childrenHtml)).toEqual({
+      html: '<li><span>hello</span></li>',
+      prefix: '<ol type="I" start="2">',
       suffix: '</ol>',
     })
   })

--- a/packages/list-module/__tests__/issue-612-roundtrip.test.ts
+++ b/packages/list-module/__tests__/issue-612-roundtrip.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @description issue #612 parse/toHtml round-trip test
+ */
+
+import { $ } from 'dom7'
+
+import createEditor from '../../../tests/utils/create-editor'
+import listItemToHtmlConf from '../src/module/elem-to-html'
+import { parseItemHtmlConf } from '../src/module/parse-elem-html'
+import { ELEM_TO_EDITOR } from '../src/utils/maps'
+
+describe('list issue #612 round-trip', () => {
+  it('should preserve ordered list start/type in parse <-> toHtml', () => {
+    const html = [
+      '<ol><li><p><strong>用信对象</strong></p></li></ol>',
+      '<ol type="A"><li><p>基本情况</p></li></ol>',
+      '<ol start="2" type="I"><li><p>管理水平</p></li></ol>',
+    ].join('')
+
+    const $wrapper = $(`<div>${html}</div>`)
+    const parseEditor = createEditor()
+
+    const parsedItems = Array.from($wrapper.find('li')).map(li => {
+      const $li = $(li)
+      const text = $li.text().trim()
+
+      return parseItemHtmlConf.parseElemHtml(li, [{ text }], parseEditor)
+    })
+
+    expect(parsedItems).toHaveLength(3)
+    expect(parsedItems[0]).toMatchObject({
+      type: 'list-item',
+      ordered: true,
+      level: 0,
+    })
+    expect(parsedItems[1]).toMatchObject({
+      type: 'list-item',
+      ordered: true,
+      level: 0,
+      orderType: 'A',
+    })
+    expect(parsedItems[2]).toMatchObject({
+      type: 'list-item',
+      ordered: true,
+      level: 0,
+      start: 2,
+      orderType: 'I',
+    })
+
+    const exportEditor = createEditor({
+      content: parsedItems as any,
+    })
+
+    const { elemToHtml } = listItemToHtmlConf
+    let exportedHtml = ''
+
+    parsedItems.forEach(item => {
+      ELEM_TO_EDITOR.set(item as any, exportEditor)
+      const text = item.children?.[0]?.text ?? ''
+      const res = elemToHtml(item as any, `<span>${text}</span>`)
+
+      exportedHtml += `${res.prefix || ''}${res.html}${res.suffix || ''}`
+    })
+
+    expect((exportedHtml.match(/<ol/g) || []).length).toBe(3)
+    expect(exportedHtml).toContain('<ol type="A">')
+    expect(exportedHtml).toContain('<ol type="I" start="2">')
+
+    const $roundTripWrapper = $(`<div>${exportedHtml}</div>`)
+    const roundTripItems = Array.from($roundTripWrapper.find('li')).map(li => {
+      const $li = $(li)
+      const text = $li.text().trim()
+
+      return parseItemHtmlConf.parseElemHtml(li, [{ text }], parseEditor)
+    })
+
+    expect(roundTripItems).toHaveLength(3)
+    expect(roundTripItems[1]).toMatchObject({
+      ordered: true,
+      level: 0,
+      orderType: 'A',
+    })
+    expect(roundTripItems[2]).toMatchObject({
+      ordered: true,
+      level: 0,
+      start: 2,
+      orderType: 'I',
+    })
+  })
+})

--- a/packages/list-module/__tests__/parse-html.test.ts
+++ b/packages/list-module/__tests__/parse-html.test.ts
@@ -49,6 +49,25 @@ describe('list - parse html', () => {
     })
   })
 
+  it('parse ordered list item with start and type', () => {
+    const $ol = $('<ol start="2" type="I"></ol>')
+    const $li = $('<li></li>')
+
+    $ol.append($li)
+    const children = [{ text: 'hello' }]
+
+    const elem = parseItemHtmlConf.parseElemHtml($li[0], children, editor)
+
+    expect(elem).toEqual({
+      type: 'list-item',
+      ordered: true,
+      level: 0,
+      start: 2,
+      orderType: 'I',
+      children,
+    })
+  })
+
   it('parse leveled list item', () => {
     const $ul = $('<ul></ul>')
     const $ol = $('<ol></ol>')

--- a/packages/list-module/__tests__/render-elem.test.ts
+++ b/packages/list-module/__tests__/render-elem.test.ts
@@ -40,6 +40,39 @@ describe('list module - render elem', () => {
     expect(prefixVnode.text).toBe('1.') // ordered list-item 有序号
   })
 
+  it('render ordered list item with custom type', () => {
+    const upperAlphaOrderedItem = {
+      type: 'list-item',
+      ordered: true,
+      orderType: 'A',
+      children: [{ text: '' }],
+    }
+    const localEditor = createEditor({
+      content: [upperAlphaOrderedItem],
+    })
+    const vnode: any = renderListItemConf.renderElem(upperAlphaOrderedItem, null, localEditor)
+    const prefixVnode = vnode.children[0] || {}
+
+    expect(prefixVnode.text).toBe('A.')
+  })
+
+  it('render ordered list item with start', () => {
+    const upperRomanOrderedItem = {
+      type: 'list-item',
+      ordered: true,
+      orderType: 'I',
+      start: 2,
+      children: [{ text: '' }],
+    }
+    const localEditor = createEditor({
+      content: [upperRomanOrderedItem],
+    })
+    const vnode: any = renderListItemConf.renderElem(upperRomanOrderedItem, null, localEditor)
+    const prefixVnode = vnode.children[0] || {}
+
+    expect(prefixVnode.text).toBe('II.')
+  })
+
   it('render unOrdered list item elem', () => {
     const vnode: any = renderListItemConf.renderElem(unOrderedItem, null, editor)
 
@@ -93,5 +126,27 @@ describe('list module - render elem', () => {
     const prefixVnode = vnode.children[0] || {}
 
     expect(prefixVnode.text).toBe('2.') // ordered list-item 有序号
+  })
+
+  it('restart ordered prefix when type/start config changes', () => {
+    const decimalOrderedItem = {
+      type: 'list-item',
+      ordered: true,
+      children: [{ text: '' }],
+    }
+    const romanOrderedItem = {
+      type: 'list-item',
+      ordered: true,
+      orderType: 'I',
+      start: 2,
+      children: [{ text: '' }],
+    }
+    const localEditor = createEditor({
+      content: [decimalOrderedItem, romanOrderedItem],
+    })
+    const vnode: any = renderListItemConf.renderElem(romanOrderedItem, null, localEditor)
+    const prefixVnode = vnode.children[0] || {}
+
+    expect(prefixVnode.text).toBe('II.')
   })
 })

--- a/packages/list-module/src/module/custom-types.ts
+++ b/packages/list-module/src/module/custom-types.ts
@@ -7,9 +7,13 @@ import { Text } from 'slate'
 
 // 【注意】需要把自定义的 Element 引入到最外层的 custom-types.d.ts
 
+export type OrderedListType = '1' | 'a' | 'A' | 'i' | 'I'
+
 export type ListItemElement = {
   type: 'list-item'
   ordered: boolean // 有序/无序
   level: number // 层级：0 1 2 ...
+  start?: number // ol start
+  orderType?: OrderedListType // ol type
   children: Text[]
 }

--- a/packages/list-module/src/module/elem-to-html.ts
+++ b/packages/list-module/src/module/elem-to-html.ts
@@ -9,7 +9,12 @@ import { Editor, Element, Path } from 'slate'
 import { ELEM_TO_EDITOR } from '../utils/maps'
 import { getListItemColor } from '../utils/util'
 import { ListItemElement } from './custom-types'
-import { hasSameOrderWithBrother } from './helpers'
+import {
+  getNormalizedOrderedListStart,
+  getNormalizedOrderedListType,
+  hasSameListConfig,
+  hasSameOrderWithBrother,
+} from './helpers'
 import { genListColorClassName, resolveListColorAction } from './style-class'
 
 /**
@@ -21,7 +26,12 @@ function getStartContainerTagNumber(elem: Element): number {
 
   if (editor == null) { return 0 }
 
-  const { type, ordered = false, level = 0 } = elem as ListItemElement
+  const listItemElem = elem as ListItemElement
+  const {
+    type,
+    ordered = false,
+    level = 0,
+  } = listItemElem
 
   const path = DomEditor.findPath(editor, elem)
 
@@ -45,7 +55,10 @@ function getStartContainerTagNumber(elem: Element): number {
   }
 
   // 上一个 elem 是 list-item
-  const { ordered: prevOrdered = false, level: prevLevel = 0 } = prevElem as ListItemElement
+  const {
+    ordered: prevOrdered = false,
+    level: prevLevel = 0,
+  } = prevElem as ListItemElement
 
   if (prevLevel < level) {
     // 上一个 level 小于当前 level ，需要拼接 <ol> 或 <ul>
@@ -57,7 +70,7 @@ function getStartContainerTagNumber(elem: Element): number {
   }
   if (prevLevel === level) {
     // 上一个 level 等于当前 level
-    if (prevOrdered === ordered) {
+    if (prevOrdered === ordered && hasSameListConfig(prevElem as ListItemElement, listItemElem)) {
       // ordered 一致，则不需要拼接 <ol> 或 <ul>
       return 0
     }
@@ -79,7 +92,12 @@ function getEndContainerTagNumber(elem: Element): number {
 
   if (editor == null) { return 0 }
 
-  const { type, ordered = false, level = 0 } = elem as ListItemElement
+  const listItemElem = elem as ListItemElement
+  const {
+    type,
+    ordered = false,
+    level = 0,
+  } = listItemElem
 
   const path = DomEditor.findPath(editor, elem)
 
@@ -103,7 +121,10 @@ function getEndContainerTagNumber(elem: Element): number {
   }
 
   // 下一个 elem 是 list-item
-  const { ordered: nextOrdered = false, level: nextLevel = 0 } = nextElem as ListItemElement
+  const {
+    ordered: nextOrdered = false,
+    level: nextLevel = 0,
+  } = nextElem as ListItemElement
 
   if (nextLevel < level) {
     // 下一个 level 小于当前 level，此处需要看上一个同级兄弟节点 ordered 是否一致，如果一致则不需要拼接，否则需要拼接
@@ -121,7 +142,7 @@ function getEndContainerTagNumber(elem: Element): number {
   }
   if (nextLevel === level) {
     // 下一个 level 等于当前 level
-    if (nextOrdered === ordered) {
+    if (nextOrdered === ordered && hasSameListConfig(nextElem as ListItemElement, listItemElem)) {
       // ordered 一致，则不需要拼接 </ol> 或 </ul>
       return 0
     }
@@ -137,6 +158,26 @@ function getEndContainerTagNumber(elem: Element): number {
 // ol ul 栈
 const CONTAINER_TAG_STACK: Array<string> = []
 
+function genContainerStartTag(elem: ListItemElement): string {
+  const { ordered = false } = elem
+
+  if (!ordered) { return '<ul>' }
+
+  const attrs: string[] = []
+  const orderType = getNormalizedOrderedListType(elem)
+  const orderStart = getNormalizedOrderedListStart(elem)
+
+  if (orderType !== '1') {
+    attrs.push(`type="${orderType}"`)
+  }
+  if (orderStart !== 1) {
+    attrs.push(`start="${orderStart}"`)
+  }
+
+  if (attrs.length === 0) { return '<ol>' }
+  return `<ol ${attrs.join(' ')}>`
+}
+
 function elemToHtml(
   elem: Element,
   childrenHtml: string,
@@ -149,15 +190,17 @@ function elemToHtml(
   let startContainerStr = ''
   let endContainerStr = ''
 
-  const { ordered = false } = elem as ListItemElement
+  const listItemElem = elem as ListItemElement
+  const { ordered = false } = listItemElem
   const containerTag = ordered ? 'ol' : 'ul'
+  const containerStartTag = genContainerStartTag(listItemElem)
 
   // 前面需要拼接几个 <ol> 或 <ul>
   const startContainerTagNumber = getStartContainerTagNumber(elem)
 
   if (startContainerTagNumber > 0) {
     for (let i = 0; i < startContainerTagNumber; i += 1) {
-      startContainerStr += `<${containerTag}>` // 记录 start container tag ，如 `<ul>`
+      startContainerStr += containerStartTag // 记录 start container tag ，如 `<ul>`
       CONTAINER_TAG_STACK.push(containerTag) // tag 压栈
     }
   }

--- a/packages/list-module/src/module/helpers.ts
+++ b/packages/list-module/src/module/helpers.ts
@@ -6,7 +6,36 @@
 import { DomEditor, IDomEditor } from '@wangeditor-next/core'
 import { Editor, Path } from 'slate'
 
-import { ListItemElement } from './custom-types'
+import { ListItemElement, OrderedListType } from './custom-types'
+
+export function getNormalizedOrderedListStart(elem: ListItemElement): number {
+  const { ordered = false, start } = elem
+
+  if (!ordered) { return 1 }
+  if (typeof start !== 'number' || Number.isNaN(start)) { return 1 }
+  return start
+}
+
+export function getNormalizedOrderedListType(elem: ListItemElement): OrderedListType {
+  const { orderType } = elem
+
+  if (orderType === 'a'
+    || orderType === 'A'
+    || orderType === 'i'
+    || orderType === 'I') {
+    return orderType
+  }
+
+  return '1'
+}
+
+export function hasSameListConfig(a: ListItemElement, b: ListItemElement): boolean {
+  if (a.ordered !== b.ordered) { return false }
+  if (!a.ordered) { return true }
+
+  return getNormalizedOrderedListType(a) === getNormalizedOrderedListType(b)
+    && getNormalizedOrderedListStart(a) === getNormalizedOrderedListStart(b)
+}
 
 /**
  * 获取上一个同一 level 的 list item
@@ -58,5 +87,5 @@ export function hasSameOrderWithBrother(
 ): boolean {
   const brotherElem = getBrotherListNodeByLevel(editor, elem, level)
 
-  return brotherElem ? brotherElem.ordered === elem.ordered : false
+  return brotherElem ? hasSameListConfig(brotherElem, elem) : false
 }

--- a/packages/list-module/src/module/menu/BaseMenu.ts
+++ b/packages/list-module/src/module/menu/BaseMenu.ts
@@ -68,6 +68,8 @@ abstract class BaseMenu implements IButtonMenu {
         // @ts-ignore
         ordered: undefined,
         level: undefined,
+        start: undefined,
+        orderType: undefined,
       })
     } else {
       // 否则，转换为 list-item
@@ -75,6 +77,8 @@ abstract class BaseMenu implements IButtonMenu {
         type: 'list-item',
         ordered: this.ordered, // 有序/无序
         indent: undefined,
+        start: undefined,
+        orderType: undefined,
       })
     }
   }

--- a/packages/list-module/src/module/parse-elem-html.ts
+++ b/packages/list-module/src/module/parse-elem-html.ts
@@ -8,7 +8,7 @@ import { Dom7Array } from 'dom7'
 import { Descendant, Text } from 'slate'
 
 import $, { DOMElement, getTagName } from '../utils/dom'
-import { ListItemElement } from './custom-types'
+import { ListItemElement, OrderedListType } from './custom-types'
 
 /**
  * 获取 ordered
@@ -20,6 +20,36 @@ function getOrdered($elem: Dom7Array): boolean {
 
   if (listTagName === 'ol') { return true }
   return false
+}
+
+function getOrderedStart($elem: Dom7Array): number | undefined {
+  const $list = $elem.parent()
+
+  if (getTagName($list) !== 'ol') { return undefined }
+  const startStr = ($list.attr('start') || '').trim()
+
+  if (startStr === '') { return undefined }
+  const start = Number.parseInt(startStr, 10)
+
+  if (Number.isNaN(start)) { return undefined }
+  return start
+}
+
+function getOrderedType($elem: Dom7Array): OrderedListType | undefined {
+  const $list = $elem.parent()
+
+  if (getTagName($list) !== 'ol') { return undefined }
+  const orderType = ($list.attr('type') || '').trim()
+
+  if (orderType === '1'
+    || orderType === 'a'
+    || orderType === 'A'
+    || orderType === 'i'
+    || orderType === 'I') {
+    return orderType
+  }
+
+  return undefined
 }
 
 /**
@@ -61,11 +91,15 @@ function parseItemHtml(
 
   const ordered = getOrdered($elem)
   const level = getLevel($elem)
+  const start = getOrderedStart($elem)
+  const orderType = getOrderedType($elem)
 
   return {
     type: 'list-item',
     ordered,
     level,
+    ...(start !== undefined ? { start } : {}),
+    ...(orderType !== undefined ? { orderType } : {}),
     // @ts-ignore
     children,
   }

--- a/packages/list-module/src/module/plugin.ts
+++ b/packages/list-module/src/module/plugin.ts
@@ -44,6 +44,8 @@ function withList<T extends IDomEditor>(editor: T): T {
         // @ts-ignore
         ordered: undefined,
         level: undefined,
+        start: undefined,
+        orderType: undefined,
       })
       return
     }
@@ -74,19 +76,28 @@ function withList<T extends IDomEditor>(editor: T): T {
 
     if (selection.focus.offset === 0) {
       // 选中了当前 list-item 文本的开头，此时按删除键，应该降低 level 或转换为 p 元素
-      const { level = 0, ordered = false } = listItemElem as ListItemElement
+      const { level = 0 } = listItemElem as ListItemElement
 
       if (level > 0) {
-        // 如果有兄弟节点，则判断 ordered 是否一致，不一致需要切换 ordered
+        // 如果有兄弟节点，则对齐兄弟节点的列表配置
         const brotherElem = getBrotherListNodeByLevel(
           editor,
           listItemElem as ListItemElement,
           level - 1,
         )
 
-        if (brotherElem && brotherElem.ordered !== ordered) {
-          Transforms.setNodes(newEditor, { level: level - 1, ordered: !ordered })
-        } else { Transforms.setNodes(newEditor, { level: level - 1 }) }
+        if (brotherElem) {
+          const nextOrdered = brotherElem.ordered
+
+          Transforms.setNodes(newEditor, {
+            level: level - 1,
+            ordered: nextOrdered,
+            start: nextOrdered ? brotherElem.start : undefined,
+            orderType: nextOrdered ? brotherElem.orderType : undefined,
+          })
+        } else {
+          Transforms.setNodes(newEditor, { level: level - 1 })
+        }
       } else {
         // 转换为 p 元素
         Transforms.setNodes(newEditor, {
@@ -94,6 +105,8 @@ function withList<T extends IDomEditor>(editor: T): T {
           // @ts-ignore
           ordered: undefined,
           level: undefined,
+          start: undefined,
+          orderType: undefined,
         })
       }
       return

--- a/packages/list-module/src/module/render-elem.tsx
+++ b/packages/list-module/src/module/render-elem.tsx
@@ -13,6 +13,11 @@ import { jsx, VNode } from 'snabbdom'
 import { ELEM_TO_EDITOR } from '../utils/maps'
 import { getListItemColor } from '../utils/util'
 import { ListItemElement } from './custom-types'
+import {
+  getNormalizedOrderedListStart,
+  getNormalizedOrderedListType,
+  hasSameListConfig,
+} from './helpers'
 
 /**
  * 无序列表：根据 level 获取的前置符号
@@ -37,20 +42,85 @@ function genPreSymbol(level = 0): string {
   return s
 }
 
+function genAlphabetIndex(num: number, upper = false): string {
+  if (num <= 0) { return String(num) }
+
+  let n = num
+  let result = ''
+
+  while (n > 0) {
+    const rem = (n - 1) % 26
+    const charCode = (upper ? 65 : 97) + rem
+
+    result = String.fromCharCode(charCode) + result
+    n = Math.floor((n - 1) / 26)
+  }
+
+  return result
+}
+
+function genRomanIndex(num: number, upper = false): string {
+  if (num <= 0 || num >= 4000) { return String(num) }
+
+  const romanMap: Array<[number, string]> = [
+    [1000, 'M'],
+    [900, 'CM'],
+    [500, 'D'],
+    [400, 'CD'],
+    [100, 'C'],
+    [90, 'XC'],
+    [50, 'L'],
+    [40, 'XL'],
+    [10, 'X'],
+    [9, 'IX'],
+    [5, 'V'],
+    [4, 'IV'],
+    [1, 'I'],
+  ]
+
+  let n = num
+  let result = ''
+
+  for (const [value, roman] of romanMap) {
+    while (n >= value) {
+      result += roman
+      n -= value
+    }
+  }
+
+  return upper ? result : result.toLowerCase()
+}
+
+function genOrderedPrefix(num: number, orderType: string): string {
+  switch (orderType) {
+    case 'a':
+      return `${genAlphabetIndex(num)}.`
+    case 'A':
+      return `${genAlphabetIndex(num, true)}.`
+    case 'i':
+      return `${genRomanIndex(num)}.`
+    case 'I':
+      return `${genRomanIndex(num, true)}.`
+    default:
+      return `${num}.`
+  }
+}
+
 /**
  * 有序列表：获取前缀 number
  * @param editor editor
  * @param elem listItem elem
  */
 function getOrderedItemNumber(editor: IDomEditor, elem: SlateElement): number {
-  const { type, level = 0, ordered = false } = elem as ListItemElement
+  const listItemElem = elem as ListItemElement
+  const { type, level = 0, ordered = false } = listItemElem
 
-  let num = 1 // 默认值 1
+  let num = getNormalizedOrderedListStart(listItemElem)
   let curElem = elem
   let curPath = DomEditor.findPath(editor, curElem)
 
-  // 第一个元素，直接返回 1
-  if (curPath[0] === 0) { return 1 }
+  // 第一个元素，直接返回起始值
+  if (curPath[0] === 0) { return num }
 
   while (curPath[0] > 0) {
     const prevPath = Path.previous(curPath)
@@ -66,11 +136,10 @@ function getOrderedItemNumber(editor: IDomEditor, elem: SlateElement): number {
     if (prevLevel < level) { break }
 
     if (prevLevel === level) {
-      // level 一样，如果 ordered 不一样，则退出循环，不再累加 num
-      if (prevOrdered !== ordered) { break } else {
-        // level 一样，order 一样，则累加 num
-        num += 1
-      }
+      // level 一样，如果 list 配置不一致，则退出循环，不再累加 num
+      if (prevOrdered !== ordered || !hasSameListConfig(prevElem, listItemElem)) { break }
+      // level 一样，order 配置一致，则累加 num
+      num += 1
     }
 
     // prevLevel 更大，不累加 num ，继续向前
@@ -103,8 +172,9 @@ function renderListElem(
   if (ordered) {
     // 有序列表：获取前缀 number
     const orderedNumber = getOrderedItemNumber(editor, elemNode)
+    const orderType = getNormalizedOrderedListType(elemNode as ListItemElement)
 
-    prefix = `${orderedNumber}.`
+    prefix = genOrderedPrefix(orderedNumber, orderType)
   } else {
     // 无序列表：根据层级，使用不同的前缀符号
     prefix = genPreSymbol(level)


### PR DESCRIPTION
## Summary
- support parsing ordered list `start` and `type` attributes into list item model
- support rendering ordered list marker with start offset and marker type (1/a/A/i/I)
- support exporting ordered list `start/type` in toHtml and split ordered list boundaries by full list config
- add regression tests for parse, render, toHtml, and parse-toHtml-parse round trip for issue #612

## Testing
- pnpm --filter @wangeditor-next/list-module test
- pnpm build

Closes #612

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ordered list numbering styles: decimal (1, 2, 3), lowercase and uppercase letters (a–c, A–C), and lowercase and uppercase roman numerals (i–iii, I–III). Custom start positions are now available for all ordered lists, providing more flexibility in list numbering, sequencing, and presentation options within documents.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/852?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->