### PR TITLE
feat(image): add built-in preview menu

### DIFF
--- a/.changeset/feat-image-preview-menu-626.md
+++ b/.changeset/feat-image-preview-menu-626.md
@@ -1,0 +1,7 @@
+---
+'@wangeditor-next/basic-modules': patch
+'@wangeditor-next/core': patch
+'@wangeditor-next/editor': patch
+---
+
+feat(image): add built-in image preview menu in hoverbar to open image src directly.

--- a/packages/basic-modules/__tests__/image/menu/preview-image.test.ts
+++ b/packages/basic-modules/__tests__/image/menu/preview-image.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @description preview image menu test
+ */
+
+import { Editor } from 'slate'
+
+import createEditor from '../../../../../tests/utils/create-editor'
+import PreviewImage from '../../../src/modules/image/menu/PreviewImage'
+
+describe('preview image menu', () => {
+  const menu = new PreviewImage()
+  let editor: any
+  let startLocation: any
+
+  const src = 'https://www.wangeditor.com/imgs/logo.png'
+  const alt = 'logo'
+
+  beforeEach(() => {
+    editor = createEditor()
+    startLocation = Editor.start(editor, [])
+  })
+
+  afterEach(() => {
+    editor = null
+    startLocation = null
+  })
+
+  it('getValue and isDisabled', () => {
+    editor.select(startLocation)
+    expect(menu.getValue(editor)).toBe('')
+    expect(menu.isActive(editor)).toBeFalsy()
+    expect(menu.isDisabled(editor)).toBeTruthy()
+
+    const elem = {
+      type: 'image',
+      src,
+      alt,
+      href: '',
+      style: { width: '100', height: '80' },
+      children: [{ text: '' }],
+    }
+
+    editor.insertNode(elem)
+    editor.select({
+      path: [0, 1, 0],
+      offset: 0,
+    })
+    expect(menu.getValue(editor)).toBe(src)
+    expect(menu.isDisabled(editor)).toBeFalsy()
+  })
+
+  it('exec', () => {
+    editor.select(startLocation)
+    const value = ''
+    const url = 'https://github.com/wangeditor-next/wangEditor-next'
+
+    expect(menu.exec(editor, value)).toBeUndefined()
+    const elem = {
+      type: 'image',
+      src,
+      alt,
+      href: '',
+      style: { width: '100', height: '80' },
+      children: [{ text: '' }],
+    }
+
+    editor.insertNode(elem)
+    editor.select({
+      path: [0, 1, 0],
+      offset: 0,
+    })
+    expect(() => menu.exec(editor, value)).toThrow(
+      `Preview image failed, image.src is '${value}'`,
+    )
+    menu.exec(editor, url)
+  })
+})

--- a/packages/basic-modules/src/locale/en.ts
+++ b/packages/basic-modules/src/locale/en.ts
@@ -50,6 +50,7 @@ export default {
     delete: 'Delete image',
     edit: 'Edit image',
     editSize: 'Edit size',
+    preview: 'Preview image',
     viewLink: 'View link',
     src: 'Image src',
     desc: 'Description',

--- a/packages/basic-modules/src/locale/zh-CN.ts
+++ b/packages/basic-modules/src/locale/zh-CN.ts
@@ -50,6 +50,7 @@ export default {
     delete: '删除图片',
     edit: '编辑图片',
     editSize: '修改尺寸',
+    preview: '预览图片',
     viewLink: '查看链接',
     src: '图片地址',
     desc: '图片描述',

--- a/packages/basic-modules/src/modules/image/index.ts
+++ b/packages/basic-modules/src/modules/image/index.ts
@@ -14,6 +14,7 @@ import {
   imageWidth50MenuConf,
   imageWidth100MenuConf,
   insertImageMenuConf,
+  previewImageMenuConf,
   viewImageLinkMenuConf,
 } from './menu/index'
 import { parseHtmlConf } from './parse-elem-html'
@@ -28,6 +29,7 @@ const image: Partial<IModuleConf> = {
     insertImageMenuConf,
     deleteImageMenuConf,
     editImageMenuConf,
+    previewImageMenuConf,
     viewImageLinkMenuConf,
     imageWidth30MenuConf,
     imageWidth50MenuConf,

--- a/packages/basic-modules/src/modules/image/menu/PreviewImage.ts
+++ b/packages/basic-modules/src/modules/image/menu/PreviewImage.ts
@@ -1,0 +1,52 @@
+/**
+ * @description preview image menu
+ */
+
+import {
+  DomEditor, IButtonMenu, IDomEditor, t,
+} from '@wangeditor-next/core'
+
+import { EXTERNAL_SVG } from '../../../constants/icon-svg'
+import { ImageElement } from '../custom-types'
+
+class PreviewImage implements IButtonMenu {
+  readonly title = t('image.preview')
+
+  readonly iconSvg = EXTERNAL_SVG
+
+  readonly tag = 'button'
+
+  getValue(editor: IDomEditor): string | boolean {
+    const imageNode = DomEditor.getSelectedNodeByType(editor, 'image')
+
+    if (imageNode) {
+      return (imageNode as ImageElement).src || ''
+    }
+    return ''
+  }
+
+  isActive(_editor: IDomEditor): boolean {
+    return false
+  }
+
+  isDisabled(editor: IDomEditor): boolean {
+    if (editor.selection == null) { return true }
+
+    const src = this.getValue(editor)
+
+    if (src) { return false }
+    return true
+  }
+
+  exec(editor: IDomEditor, value: string | boolean) {
+    if (this.isDisabled(editor)) { return }
+
+    if (!value || typeof value !== 'string') {
+      throw new Error(`Preview image failed, image.src is '${value}'`)
+    }
+
+    window.open(value, '_blank')
+  }
+}
+
+export default PreviewImage

--- a/packages/basic-modules/src/modules/image/menu/index.ts
+++ b/packages/basic-modules/src/modules/image/menu/index.ts
@@ -8,6 +8,7 @@ import DeleteImage from './DeleteImage'
 import EditImage from './EditImage'
 import EditorImageSizeMenu from './EditImageSizeMenu'
 import InsertImage from './InsertImage'
+import PreviewImage from './PreviewImage'
 import ViewImageLink from './ViewImageLink'
 import ImageWidth30 from './Width30'
 import ImageWidth50 from './Width50'
@@ -45,6 +46,13 @@ export const viewImageLinkMenuConf = {
   key: 'viewImageLink',
   factory() {
     return new ViewImageLink()
+  },
+}
+
+export const previewImageMenuConf = {
+  key: 'previewImage',
+  factory() {
+    return new PreviewImage()
   },
 }
 

--- a/packages/core/src/config/interface.ts
+++ b/packages/core/src/config/interface.ts
@@ -169,6 +169,7 @@ export interface IMenuConfig {
   insertImage: IInsertImageConfig;
   deleteImage: ISingleMenuConfig;
   editImage: IEditImageConfig;
+  previewImage: ISingleMenuConfig;
   viewImageLink: ISingleMenuConfig;
   imageWidth30: ISingleMenuConfig;
   imageWidth50: ISingleMenuConfig;

--- a/packages/editor/src/init-default-config/config/hoverbar.ts
+++ b/packages/editor/src/init-default-config/config/hoverbar.ts
@@ -15,6 +15,7 @@ const COMMON_HOVERBAR_KEYS = {
       'imageWidth100',
       'editorImageSizeMenu',
       'editImage',
+      'previewImage',
       'viewImageLink',
       'deleteImage',
     ],


### PR DESCRIPTION
## Summary
- add built-in image hoverbar menu `previewImage` to open selected image `src` in a new tab
- add i18n copy for image preview menu in zh-CN/en
- register `previewImage` in image module and default hoverbar keys
- extend menu config typing with `previewImage`
- add regression tests for preview menu behavior

## Testing
- pnpm --filter @wangeditor-next/basic-modules test
- pnpm build

Closes #626

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added image preview menu to the hoverbar, enabling users to open image sources directly in a new browser tab for quick preview.

* **Localization**
  * Added multilingual support for the preview image menu in English and Chinese.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/853?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->