### PR TITLE
feat(list): support lower-alpha ordered list menu for #702

### DIFF
--- a/.changeset/feat-list-module-issue-702-alpha-menu.md
+++ b/.changeset/feat-list-module-issue-702-alpha-menu.md
@@ -1,0 +1,6 @@
+---
+'@wangeditor-next/list-module': patch
+'@wangeditor-next/core': patch
+---
+
+feat(list): add built-in lower-alpha ordered-list menu key (`numberedListLowerAlpha`) for issue 702.

--- a/packages/core/src/config/interface.ts
+++ b/packages/core/src/config/interface.ts
@@ -198,6 +198,7 @@ export interface IMenuConfig {
   enter: ISingleMenuConfig;
   bulletedList: ISingleMenuConfig;
   numberedList: ISingleMenuConfig;
+  numberedListLowerAlpha: ISingleMenuConfig;
   insertTable: ISingleMenuConfig;
   deleteTable: ISingleMenuConfig;
   insertTableRow: IInsertTableConfig;

--- a/packages/list-module/__tests__/menu/lower-alpha-list-menu.test.ts
+++ b/packages/list-module/__tests__/menu/lower-alpha-list-menu.test.ts
@@ -1,13 +1,13 @@
 /**
- * @description list NumberedListMenu test
+ * @description list LowerAlphaListMenu test
  * @author wangfupeng
  */
 
 import createEditor from '../../../../tests/utils/create-editor'
-import NumberedListMenu from '../../src/module/menu/NumberedListMenu'
+import LowerAlphaListMenu from '../../src/module/menu/LowerAlphaListMenu'
 
-describe('list NumberedListMenu', () => {
-  const menu = new NumberedListMenu()
+describe('list LowerAlphaListMenu', () => {
+  const menu = new LowerAlphaListMenu()
 
   it('isActive', () => {
     const editor = createEditor({
@@ -26,18 +26,20 @@ describe('list NumberedListMenu', () => {
     editor.select({ path: [0, 0], offset: 0 }) // 选中 p
     expect(menu.isActive(editor)).toBeFalsy()
 
-    editor.select({ path: [1, 0], offset: 0 }) // 选中 li
-    expect(menu.isActive(editor)).toBeTruthy()
+    editor.select({ path: [1, 0], offset: 0 }) // 选中 numbered li
+    expect(menu.isActive(editor)).toBeFalsy()
 
     editor.select({ path: [2, 0], offset: 0 }) // 选中 lower-alpha li
-    expect(menu.isActive(editor)).toBeFalsy()
+    expect(menu.isActive(editor)).toBeTruthy()
   })
 
   it('isDisabled', () => {
     const editor = createEditor({
       content: [
         { type: 'paragraph', children: [{ text: 'hello' }] },
-        { type: 'list-item', ordered: true, children: [{ text: 'a' }] },
+        {
+          type: 'list-item', ordered: true, orderType: 'a', children: [{ text: 'a' }],
+        },
         {
           type: 'table',
           width: 'auto',
@@ -80,11 +82,12 @@ describe('list NumberedListMenu', () => {
     expect(menu.getValue(editor)).toBe('')
     editor.select({ path: [0, 0], offset: 0 }) // 选中 p
 
-    menu.exec(editor, '') // p 转 li
+    menu.exec(editor, '') // p 转 lower-alpha li
     expect(editor.children).toEqual([
       {
         type: 'list-item',
         ordered: true,
+        orderType: 'a',
         children: [{ text: 'hello' }],
       },
     ])
@@ -93,11 +96,9 @@ describe('list NumberedListMenu', () => {
     expect(editor.children).toEqual([pElem])
   })
 
-  it('exec should switch lower-alpha to numbered', () => {
+  it('exec should switch numbered to lower-alpha', () => {
     const editor = createEditor({
-      content: [{
-        type: 'list-item', ordered: true, orderType: 'a', children: [{ text: 'hello' }],
-      }],
+      content: [{ type: 'list-item', ordered: true, children: [{ text: 'hello' }] }],
     })
 
     editor.select({ path: [0, 0], offset: 0 })
@@ -107,6 +108,7 @@ describe('list NumberedListMenu', () => {
       {
         type: 'list-item',
         ordered: true,
+        orderType: 'a',
         children: [{ text: 'hello' }],
       },
     ])

--- a/packages/list-module/src/locale/en.ts
+++ b/packages/list-module/src/locale/en.ts
@@ -7,5 +7,6 @@ export default {
   listModule: {
     unOrderedList: 'Unordered list',
     orderedList: 'Ordered list',
+    lowerAlphaList: 'Ordered list (a,b,c)',
   },
 }

--- a/packages/list-module/src/locale/zh-CN.ts
+++ b/packages/list-module/src/locale/zh-CN.ts
@@ -7,5 +7,6 @@ export default {
   listModule: {
     unOrderedList: '无序列表',
     orderedList: '有序列表',
+    lowerAlphaList: '有序列表（a,b,c）',
   },
 }

--- a/packages/list-module/src/module/index.ts
+++ b/packages/list-module/src/module/index.ts
@@ -6,7 +6,11 @@
 import { IModuleConf } from '@wangeditor-next/core'
 
 import listItemToHtmlConf from './elem-to-html'
-import { bulletedListMenuConf, numberedListMenuConf } from './menu/index'
+import {
+  bulletedListMenuConf,
+  numberedListLowerAlphaMenuConf,
+  numberedListMenuConf,
+} from './menu/index'
 import { parseItemHtmlConf, parseListHtmlConf } from './parse-elem-html'
 import withList from './plugin'
 import renderListItemConf from './render-elem'
@@ -14,7 +18,7 @@ import renderListItemConf from './render-elem'
 const list: Partial<IModuleConf> = {
   renderElems: [renderListItemConf],
   editorPlugin: withList,
-  menus: [bulletedListMenuConf, numberedListMenuConf],
+  menus: [bulletedListMenuConf, numberedListMenuConf, numberedListLowerAlphaMenuConf],
   elemsToHtml: [listItemToHtmlConf],
   parseElemsHtml: [parseListHtmlConf, parseItemHtmlConf],
 }

--- a/packages/list-module/src/module/menu/BaseMenu.ts
+++ b/packages/list-module/src/module/menu/BaseMenu.ts
@@ -8,12 +8,15 @@ import {
   Editor, Element, Node, Transforms,
 } from 'slate'
 
-import { ListItemElement } from '../custom-types'
+import { ListItemElement, OrderedListType } from '../custom-types'
+import { getNormalizedOrderedListType } from '../helpers'
 
 abstract class BaseMenu implements IButtonMenu {
   readonly type = 'list-item'
 
   abstract readonly ordered: boolean
+
+  readonly orderType?: OrderedListType
 
   abstract readonly title: string
 
@@ -35,9 +38,16 @@ abstract class BaseMenu implements IButtonMenu {
     const node = this.getListNode(editor)
 
     if (node == null) { return false }
-    const { ordered = false } = node as ListItemElement
+    const listNode = node as ListItemElement
+    const { ordered = false } = listNode
 
-    return ordered === this.ordered
+    if (ordered !== this.ordered) { return false }
+    if (!ordered) { return true }
+
+    const currentOrderType = getNormalizedOrderedListType(listNode)
+    const targetOrderType = this.orderType || '1'
+
+    return currentOrderType === targetOrderType
   }
 
   isDisabled(editor: IDomEditor): boolean {
@@ -78,7 +88,7 @@ abstract class BaseMenu implements IButtonMenu {
         ordered: this.ordered, // 有序/无序
         indent: undefined,
         start: undefined,
-        orderType: undefined,
+        orderType: this.ordered ? this.orderType : undefined,
       })
     }
   }

--- a/packages/list-module/src/module/menu/LowerAlphaListMenu.ts
+++ b/packages/list-module/src/module/menu/LowerAlphaListMenu.ts
@@ -1,0 +1,22 @@
+/**
+ * @description lower-alpha ordered list menu
+ * @author wangfupeng
+ */
+
+import { t } from '@wangeditor-next/core'
+
+import { NUMBERED_LIST_SVG } from '../../constants/svg'
+import { OrderedListType } from '../custom-types'
+import BaseMenu from './BaseMenu'
+
+class LowerAlphaListMenu extends BaseMenu {
+  readonly ordered = true
+
+  readonly orderType: OrderedListType = 'a'
+
+  readonly title = t('listModule.lowerAlphaList')
+
+  readonly iconSvg = NUMBERED_LIST_SVG
+}
+
+export default LowerAlphaListMenu

--- a/packages/list-module/src/module/menu/index.ts
+++ b/packages/list-module/src/module/menu/index.ts
@@ -4,6 +4,7 @@
  */
 
 import BulletedListMenu from './BulletedListMenu'
+import LowerAlphaListMenu from './LowerAlphaListMenu'
 import NumberedListMenu from './NumberedListMenu'
 
 export const bulletedListMenuConf = {
@@ -17,5 +18,12 @@ export const numberedListMenuConf = {
   key: 'numberedList',
   factory() {
     return new NumberedListMenu()
+  },
+}
+
+export const numberedListLowerAlphaMenuConf = {
+  key: 'numberedListLowerAlpha',
+  factory() {
+    return new LowerAlphaListMenu()
   },
 }


### PR DESCRIPTION
## Summary
- add a built-in list menu key `numberedListLowerAlpha` to output ordered list items with `orderType: 'a'`
- refine list `BaseMenu` active/exec logic to distinguish ordered list style (`1` vs `a`) so list menus no longer conflict
- extend i18n and menu config typings for the new menu key
- add regression tests for both `numberedList` and `numberedListLowerAlpha` menu behavior

## Validation
- pnpm --filter @wangeditor-next/list-module test
- pnpm build

Closes #702


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new ordered list style with lower-alpha numbering (a, b, c, etc.) as a menu option, resolving issue 702.
  * Supports switching between standard numbered lists and lower-alpha lists.

* **Tests**
  * Added comprehensive test coverage for the new lower-alpha ordered list functionality.

* **Documentation**
  * Updated localization strings in English and Chinese for the new menu option.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/854?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->