### PR TITLE
fix(core): preserve template-wrapped clipboard html for issue #703

### DIFF
--- a/.changeset/fix-core-template-sanitize-703.md
+++ b/.changeset/fix-core-template-sanitize-703.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/core': patch
+---
+
+fix(core): preserve template-wrapped clipboard html by safely unwrapping template content during sanitize.

--- a/packages/core/__tests__/editor/plugins/with-content.test.ts
+++ b/packages/core/__tests__/editor/plugins/with-content.test.ts
@@ -618,4 +618,21 @@ describe('editor content API', () => {
       },
     ])
   })
+
+  it('insertData parses html wrapped by template tags', () => {
+    const editor = createEditor()
+
+    editor.select(getStartLocation(editor))
+    editor.insertData({
+      getData(type: string) {
+        if (type === 'text/html') {
+          return '<template><p>hello <strong>world</strong></p></template>'
+        }
+        return ''
+      },
+    } as DataTransfer)
+
+    expect(editor.getText()).toBe('hello world')
+    expect(editor.getHtml()).toContain('hello world')
+  })
 })

--- a/packages/core/__tests__/utils/sanitize-html.test.ts
+++ b/packages/core/__tests__/utils/sanitize-html.test.ts
@@ -48,4 +48,28 @@ describe('sanitize html', () => {
     expect(sanitized).toContain('disabled=""')
     expect(sanitized).toContain('checked=""')
   })
+
+  it('unwraps template content and still removes unsafe payloads', () => {
+    const unsafeHref = ['java', 'script:alert(1)'].join('')
+    const html = `
+      <template>
+        <p>
+          <strong>bold</strong>
+          <em>italic</em>
+          <a href="${unsafeHref}" onclick="alert(1)">bad</a>
+          <script>alert(1)</script>
+        </p>
+      </template>
+    `
+
+    const sanitized = defaultSanitizeHtml(html)
+
+    expect(sanitized).not.toContain('<template')
+    expect(sanitized).toContain('<strong>bold</strong>')
+    expect(sanitized).toContain('<em>italic</em>')
+    expect(sanitized).toContain('<a>bad</a>')
+    expect(sanitized).not.toContain(unsafeHref)
+    expect(sanitized).not.toContain('onclick')
+    expect(sanitized).not.toContain('<script')
+  })
 })

--- a/packages/core/src/utils/sanitize-html.ts
+++ b/packages/core/src/utils/sanitize-html.ts
@@ -11,7 +11,6 @@ const BLOCKED_TAGS = new Set([
   'object',
   'script',
   'svg',
-  'template',
 ])
 
 const URL_ATTRS = new Set([
@@ -47,32 +46,56 @@ function isSafeUrl(tagName: string, attrName: string, value: string) {
 export function defaultSanitizeHtml(html: string = '') {
   if (!html) { return '' }
 
-  const parser = new DOMParser()
-  const doc = parser.parseFromString(html, 'text/html')
-  const elements = Array.from(doc.body.querySelectorAll('*'))
+  const container = document.createElement('div')
 
-  elements.forEach(elem => {
-    const tagName = elem.tagName.toLowerCase()
+  container.innerHTML = html
+  const sanitizeChildren = parent => {
+    const children = Array.from(parent.childNodes)
 
-    if (BLOCKED_TAGS.has(tagName)) {
-      elem.remove()
-      return
-    }
+    children.forEach(node => {
+      if (!(node instanceof Element)) { return }
 
-    Array.from(elem.attributes).forEach(attr => {
-      const attrName = attr.name.toLowerCase()
-      const attrValue = attr.value || ''
+      const elem = node
+      const tagName = elem.tagName.toLowerCase()
 
-      if (attrName === 'srcdoc' || attrName.startsWith('on')) {
-        elem.removeAttribute(attr.name)
+      if (tagName === 'template') {
+        const template = elem as HTMLTemplateElement
+        const sanitizedTemplateHtml = defaultSanitizeHtml(template.innerHTML)
+
+        if (!sanitizedTemplateHtml) {
+          template.remove()
+          return
+        }
+
+        template.insertAdjacentHTML('beforebegin', sanitizedTemplateHtml)
+        template.remove()
         return
       }
 
-      if (URL_ATTRS.has(attrName) && !isSafeUrl(tagName, attrName, attrValue)) {
-        elem.removeAttribute(attr.name)
+      if (BLOCKED_TAGS.has(tagName)) {
+        elem.remove()
+        return
       }
-    })
-  })
 
-  return doc.body.innerHTML
+      Array.from(elem.attributes).forEach(attr => {
+        const attrName = attr.name.toLowerCase()
+        const attrValue = attr.value || ''
+
+        if (attrName === 'srcdoc' || attrName.startsWith('on')) {
+          elem.removeAttribute(attr.name)
+          return
+        }
+
+        if (URL_ATTRS.has(attrName) && !isSafeUrl(tagName, attrName, attrValue)) {
+          elem.removeAttribute(attr.name)
+        }
+      })
+
+      sanitizeChildren(elem)
+    })
+  }
+
+  sanitizeChildren(container)
+
+  return container.innerHTML
 }


### PR DESCRIPTION
## Summary
- fix `defaultSanitizeHtml` to sanitize clipboard HTML as a fragment (`div.innerHTML`) instead of `DOMParser` body-only extraction, so top-level `template` payloads are not dropped
- safely unwrap `<template>` content during sanitize and recursively sanitize nested content before insertion
- keep existing security guarantees for blocked tags and unsafe event/url attributes
- add regression tests for both sanitize behavior and `insertData` behavior with template-wrapped HTML

## Validation
- pnpm --filter @wangeditor-next/core test
- pnpm build

Closes #703


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of clipboard HTML content that includes template elements. The editor now correctly unwraps and processes such content while maintaining full security protections to prevent execution of scripts, malicious event handlers, and unsafe URLs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/855?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->