### PR TITLE
feat: format painter support block-level formats

### DIFF
--- a/.changeset/feat-format-painter-block-level-774.md
+++ b/.changeset/feat-format-painter-block-level-774.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/basic-modules': patch
+---
+
+feat(format-painter): support copying and applying block-level formats (heading, blockquote, list, todo) in issue 774.

--- a/packages/basic-modules/__tests__/format-painter/format-painter-menu.test.ts
+++ b/packages/basic-modules/__tests__/format-painter/format-painter-menu.test.ts
@@ -22,6 +22,7 @@ describe('format painter menu', () => {
     menu = null
     FormatPainter.attrs.isSelect = false
     FormatPainter.attrs.formatStyle = null
+    FormatPainter.attrs.formatBlockStyle = null
   })
 
   it('is disabled', () => {
@@ -60,6 +61,7 @@ describe('format painter menu', () => {
     expect(Editor.marks(editor)).toEqual({ bold: true, italic: true })
     expect(FormatPainter.attrs.isSelect).toBeFalsy()
     expect(FormatPainter.attrs.formatStyle).toBeNull()
+    expect(FormatPainter.attrs.formatBlockStyle).toBeNull()
   })
 
   it('exec', () => {
@@ -87,6 +89,7 @@ describe('format painter menu', () => {
 
     menu.exec(editor) // 取消格式刷
     expect(FormatPainter.attrs.isSelect).toBeFalsy()
+    expect(FormatPainter.attrs.formatBlockStyle).toBeNull()
 
     // 选中文本
     editor.select({
@@ -100,5 +103,125 @@ describe('format painter menu', () => {
 
     menu.exec(editor)
     expect(FormatPainter.attrs.formatStyle).toEqual({ bold: true, italic: true })
+  })
+
+  it('copies and applies heading block format', () => {
+    editor = createEditor({
+      content: [
+        { type: 'header2', children: [{ text: 'Heading source' }] },
+        { type: 'paragraph', children: [{ text: 'Paragraph target' }] },
+      ],
+    })
+
+    editor.select({
+      anchor: { path: [0, 0], offset: 0 },
+      focus: { path: [0, 0], offset: 7 },
+    })
+
+    menu.exec(editor)
+    expect(FormatPainter.attrs.formatBlockStyle).toEqual({ type: 'header2' })
+
+    editor.select({
+      anchor: { path: [1, 0], offset: 0 },
+      focus: { path: [1, 0], offset: 9 },
+    })
+    menu.setFormatHtml(editor)
+
+    expect((editor.children[1] as any).type).toBe('header2')
+  })
+
+  it('copies and applies list block format', () => {
+    editor = createEditor({
+      content: [
+        {
+          type: 'list-item',
+          ordered: true,
+          orderType: 'a',
+          children: [{ text: 'List source' }],
+        },
+        { type: 'paragraph', children: [{ text: 'Paragraph target' }] },
+      ],
+    })
+
+    editor.select({
+      anchor: { path: [0, 0], offset: 0 },
+      focus: { path: [0, 0], offset: 4 },
+    })
+
+    menu.exec(editor)
+    expect(FormatPainter.attrs.formatBlockStyle).toEqual({
+      type: 'list-item',
+      ordered: true,
+      orderType: 'a',
+    })
+
+    editor.select({
+      anchor: { path: [1, 0], offset: 0 },
+      focus: { path: [1, 0], offset: 9 },
+    })
+    menu.setFormatHtml(editor)
+
+    expect(editor.children[1]).toMatchObject({
+      type: 'list-item',
+      ordered: true,
+      orderType: 'a',
+    })
+  })
+
+  it('applies captured block format to multi-block selection', () => {
+    editor = createEditor({
+      content: [
+        { type: 'blockquote', children: [{ text: 'Quote source' }] },
+        { type: 'paragraph', children: [{ text: 'Target one' }] },
+        { type: 'paragraph', children: [{ text: 'Target two' }] },
+      ],
+    })
+
+    editor.select({
+      anchor: { path: [0, 0], offset: 0 },
+      focus: { path: [0, 0], offset: 5 },
+    })
+    menu.exec(editor)
+
+    editor.select({
+      anchor: { path: [1, 0], offset: 0 },
+      focus: { path: [2, 0], offset: 6 },
+    })
+    menu.setFormatHtml(editor)
+
+    expect((editor.children[1] as any).type).toBe('blockquote')
+    expect((editor.children[2] as any).type).toBe('blockquote')
+  })
+
+  it('skips unsupported target blocks when applying block format', () => {
+    editor = createEditor({
+      content: [
+        { type: 'header3', children: [{ text: 'Heading source' }] },
+        {
+          type: 'table',
+          width: 'auto',
+          children: [
+            {
+              type: 'table-row',
+              children: [{ type: 'table-cell', children: [{ text: 'cell' }], isHeader: true }],
+            },
+          ],
+        },
+      ],
+    })
+
+    editor.select({
+      anchor: { path: [0, 0], offset: 0 },
+      focus: { path: [0, 0], offset: 7 },
+    })
+    menu.exec(editor)
+
+    editor.select({
+      anchor: { path: [1, 0, 0, 0], offset: 0 },
+      focus: { path: [1, 0, 0, 0], offset: 4 },
+    })
+    menu.setFormatHtml(editor)
+
+    expect((editor.children[1] as any).type).toBe('table')
   })
 })

--- a/packages/basic-modules/__tests__/format-painter/plugin.test.ts
+++ b/packages/basic-modules/__tests__/format-painter/plugin.test.ts
@@ -22,6 +22,9 @@ describe('format painter plugin', () => {
 
   afterEach(() => {
     vi.clearAllMocks()
+    FormatPainter.attrs.isSelect = false
+    FormatPainter.attrs.formatStyle = null
+    FormatPainter.attrs.formatBlockStyle = null
   })
 
   it('format painter change', () => {

--- a/packages/basic-modules/src/modules/format-painter/menu/FormatPainter.ts
+++ b/packages/basic-modules/src/modules/format-painter/menu/FormatPainter.ts
@@ -4,14 +4,36 @@
  */
 
 import { IButtonMenu, IDomEditor, t } from '@wangeditor-next/core'
-import { Editor, Text } from 'slate'
+import {
+  Editor, Element, Path, Text, Transforms,
+} from 'slate'
 
 import { FORMAT_PAINTER } from '../../../constants/icon-svg'
 import { clearAllMarks } from '../helper'
 
+type BlockTypeForFormatPainter = 'header1'
+| 'header2'
+| 'header3'
+| 'header4'
+| 'header5'
+| 'header6'
+| 'blockquote'
+| 'list-item'
+| 'todo'
+
+type OrderedListTypeForFormatPainter = '1' | 'a' | 'A' | 'i' | 'I'
+type TargetBlockTypeForFormatPainter = BlockTypeForFormatPainter | 'paragraph'
+
+interface BlockStyleForFormatPainter {
+  type: BlockTypeForFormatPainter
+  ordered?: boolean
+  orderType?: OrderedListTypeForFormatPainter
+}
+
 interface FormatPaintAttributes {
   isSelect: boolean
   formatStyle: Omit<Text, 'text'> | null
+  formatBlockStyle: BlockStyleForFormatPainter | null
 }
 
 class FormatPainter implements IButtonMenu {
@@ -24,6 +46,7 @@ class FormatPainter implements IButtonMenu {
   static attrs: FormatPaintAttributes = {
     isSelect: false,
     formatStyle: null,
+    formatBlockStyle: null,
   }
 
   getValue(_editor: IDomEditor): string | boolean {
@@ -38,6 +61,128 @@ class FormatPainter implements IButtonMenu {
     return false
   }
 
+  private isSourceBlockType(type: string): type is BlockTypeForFormatPainter {
+    return type === 'blockquote'
+      || type === 'header1'
+      || type === 'header2'
+      || type === 'header3'
+      || type === 'header4'
+      || type === 'header5'
+      || type === 'header6'
+      || type === 'list-item'
+      || type === 'todo'
+  }
+
+  private isTargetBlockType(type: string): type is TargetBlockTypeForFormatPainter {
+    return type === 'paragraph' || this.isSourceBlockType(type)
+  }
+
+  private getTopLevelSelectedBlocks(editor: IDomEditor, checkType: (type: string) => boolean): Path[] {
+    return Array.from(Editor.nodes(editor, {
+      at: editor.selection || undefined,
+      match: node => Element.isElement(node),
+    }))
+      .filter(([node, path]) => path.length === 1 && checkType(node.type))
+      .map(([, path]) => path)
+  }
+
+  private normalizeListOrderType(orderType: unknown): OrderedListTypeForFormatPainter | undefined {
+    if (orderType === 'a'
+      || orderType === 'A'
+      || orderType === 'i'
+      || orderType === 'I') {
+      return orderType
+    }
+
+    if (orderType === '1') { return '1' }
+    return undefined
+  }
+
+  private getSelectedBlockStyle(editor: IDomEditor): BlockStyleForFormatPainter | null {
+    const topLevelPaths = this.getTopLevelSelectedBlocks(editor, type => this.isSourceBlockType(type))
+    const [firstPath] = topLevelPaths
+
+    if (!firstPath) { return null }
+
+    const [selectedBlock] = Editor.node(editor, firstPath)
+
+    if (!Element.isElement(selectedBlock)) { return null }
+
+    if (!this.isSourceBlockType(selectedBlock.type)) { return null }
+
+    if (selectedBlock.type === 'blockquote'
+      || selectedBlock.type === 'header1'
+      || selectedBlock.type === 'header2'
+      || selectedBlock.type === 'header3'
+      || selectedBlock.type === 'header4'
+      || selectedBlock.type === 'header5'
+      || selectedBlock.type === 'header6'
+      || selectedBlock.type === 'todo') {
+      return { type: selectedBlock.type }
+    }
+
+    if (selectedBlock.type === 'list-item') {
+      const ordered = 'ordered' in selectedBlock ? !!selectedBlock.ordered : false
+      const orderType = 'orderType' in selectedBlock
+        ? this.normalizeListOrderType(selectedBlock.orderType)
+        : undefined
+
+      return {
+        type: 'list-item',
+        ordered,
+        orderType,
+      }
+    }
+
+    return null
+  }
+
+  private unsetListAttrs(editor: IDomEditor, path: Path) {
+    Transforms.unsetNodes(editor, 'ordered', { at: path })
+    Transforms.unsetNodes(editor, 'level', { at: path })
+    Transforms.unsetNodes(editor, 'start', { at: path })
+    Transforms.unsetNodes(editor, 'orderType', { at: path })
+  }
+
+  private applyBlockStyle(editor: IDomEditor, blockStyle: BlockStyleForFormatPainter) {
+    const blockPaths = this.getTopLevelSelectedBlocks(editor, type => this.isTargetBlockType(type))
+
+    if (blockPaths.length === 0) { return }
+
+    if (blockStyle.type === 'list-item') {
+      blockPaths.forEach(path => {
+        Transforms.setNodes(editor, {
+          type: 'list-item',
+          ordered: blockStyle.ordered,
+          orderType: blockStyle.orderType,
+          level: 0,
+        }, { at: path })
+        Transforms.unsetNodes(editor, 'checked', { at: path })
+        Transforms.unsetNodes(editor, 'start', { at: path })
+      })
+      return
+    }
+
+    if (blockStyle.type === 'todo') {
+      blockPaths.forEach(path => {
+        Transforms.setNodes(editor, {
+          type: 'todo',
+          checked: false,
+        }, { at: path })
+        this.unsetListAttrs(editor, path)
+      })
+      return
+    }
+
+    blockPaths.forEach(path => {
+      Transforms.setNodes(editor, {
+        type: blockStyle.type,
+      }, { at: path })
+      this.unsetListAttrs(editor, path)
+      Transforms.unsetNodes(editor, 'checked', { at: path })
+    })
+  }
+
   setFormatHtml(editor: IDomEditor) {
     const selectionText = editor.getSelectionText()
 
@@ -48,7 +193,13 @@ class FormatPainter implements IButtonMenu {
         editor.addMark(key, value)
       }
     }
+
+    if (FormatPainter.attrs.formatBlockStyle) {
+      this.applyBlockStyle(editor, FormatPainter.attrs.formatBlockStyle)
+    }
+
     FormatPainter.attrs.formatStyle = null
+    FormatPainter.attrs.formatBlockStyle = null
     FormatPainter.attrs.isSelect = false
   }
 
@@ -57,12 +208,14 @@ class FormatPainter implements IButtonMenu {
     if (FormatPainter.attrs.isSelect) {
       FormatPainter.attrs.isSelect = false
       FormatPainter.attrs.formatStyle = null
+      FormatPainter.attrs.formatBlockStyle = null
     } else {
       const selectionText = editor.getSelectionText()
       // 判断是否选中文本
 
       if (selectionText.length) {
         FormatPainter.attrs.formatStyle = Editor.marks(editor)
+        FormatPainter.attrs.formatBlockStyle = this.getSelectedBlockStyle(editor)
         FormatPainter.attrs.isSelect = true
       }
     }


### PR DESCRIPTION
## Summary
- support copying and applying block-level format in format painter for top-level blocks
- supported block types: `header1-6`, `blockquote`, `list-item`, `todo`
- keep mark-format behavior unchanged, and clear painter state after apply

## Behavior details
- capture source block style from current selection's top-level block
- apply captured block style only to target selection's top-level blocks
- skip unsupported blocks (for example `table`) instead of forcing conversion
- list mode copies `ordered` and normalized `orderType` (`1/a/A/i/I`)
- todo mode applies with `checked: false`

## Tests
- `pnpm --filter @wangeditor-next/basic-modules test -- __tests__/format-painter/format-painter-menu.test.ts __tests__/format-painter/plugin.test.ts __tests__/format-painter/helper.test.ts`
- `pnpm --filter @wangeditor-next/basic-modules test`
- `pnpm --filter @wangeditor-next/basic-modules build`
- `pnpm build`

Closes #774


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Format painter now captures and applies block-level formatting, enabling users to copy and apply heading types, blockquote styles, list properties, and todo states across document sections
  * Block format application intelligently handles multi-block selections, automatically skipping incompatible target blocks to preserve document structure and integrity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/856?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->