### PR TITLE
fix(core): support soft line breaks on shift+enter

### DIFF
--- a/.changeset/fix-core-soft-line-break-542.md
+++ b/.changeset/fix-core-soft-line-break-542.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/core': patch
+---
+
+fix(core): map Shift+Enter to soft line breaks (`\n` -> `<br>`) instead of paragraph breaks.

--- a/packages/core/__tests__/text-area/event-handlers/before-input.test.ts
+++ b/packages/core/__tests__/text-area/event-handlers/before-input.test.ts
@@ -372,10 +372,18 @@ describe('handleBeforeInput', () => {
     expect(Editor.deleteForward).toHaveBeenCalledWith(editor, { unit: 'word' })
   })
 
-  it('inserts breaks for paragraph input and ignores composition-text mutations', () => {
+  it('inserts soft line break for shift+enter and block break for enter', () => {
     const editor = {
       selection: createSelection(false),
       getConfig: () => ({ readOnly: false }),
+    } as any
+    const lineBreakEvent = {
+      inputType: 'insertLineBreak',
+      data: null,
+      dataTransfer: null,
+      target: {},
+      preventDefault: vi.fn(),
+      getTargetRanges: () => [],
     } as any
     const paragraphEvent = {
       inputType: 'insertParagraph',
@@ -395,11 +403,14 @@ describe('handleBeforeInput', () => {
     } as any
 
     vi.spyOn(helpers, 'hasEditableTarget').mockReturnValue(true)
+    vi.spyOn(Editor, 'insertText').mockImplementation(() => {})
     vi.spyOn(Editor, 'insertBreak').mockImplementation(() => {})
 
+    handleBeforeInput(lineBreakEvent, {} as any, editor)
     handleBeforeInput(paragraphEvent, {} as any, editor)
     handleBeforeInput(compositionEvent, {} as any, editor)
 
+    expect(Editor.insertText).toHaveBeenCalledWith(editor, '\n')
     expect(Editor.insertBreak).toHaveBeenCalledWith(editor)
     expect(compositionEvent.preventDefault).not.toHaveBeenCalled()
   })

--- a/packages/core/__tests__/text-area/event-handlers/keydown.test.ts
+++ b/packages/core/__tests__/text-area/event-handlers/keydown.test.ts
@@ -262,13 +262,17 @@ describe('handleOnKeydown', () => {
     expect(event.preventDefault).toHaveBeenCalled()
   })
 
-  it('splits block on splitBlock hotkey', () => {
+  it('splits block on enter without shift when beforeinput is unsupported', () => {
     const editor = {
       selection: createSelection(false),
       getConfig: () => ({ readOnly: false }),
     } as any
     const textarea = { isComposing: false } as any
-    const event = { preventDefault: vi.fn(), target: {} } as any
+    const event = {
+      preventDefault: vi.fn(),
+      target: {},
+      shiftKey: false,
+    } as any
 
     vi.spyOn(helpers, 'hasEditableTarget').mockReturnValue(true)
     vi.spyOn(Hotkeys, 'isSplitBlock').mockReturnValue(true)
@@ -277,6 +281,30 @@ describe('handleOnKeydown', () => {
     handleOnKeydown(event, textarea, editor)
 
     expect(Editor.insertBreak).toHaveBeenCalledWith(editor)
+    expect(event.preventDefault).toHaveBeenCalled()
+  })
+
+  it('inserts soft line break on shift+enter when beforeinput is unsupported', () => {
+    const editor = {
+      selection: createSelection(false),
+      getConfig: () => ({ readOnly: false }),
+    } as any
+    const textarea = { isComposing: false } as any
+    const event = {
+      preventDefault: vi.fn(),
+      target: {},
+      shiftKey: true,
+    } as any
+
+    vi.spyOn(helpers, 'hasEditableTarget').mockReturnValue(true)
+    vi.spyOn(Hotkeys, 'isSplitBlock').mockReturnValue(true)
+    vi.spyOn(Editor, 'insertBreak').mockImplementation(() => {})
+    vi.spyOn(Editor, 'insertText').mockImplementation(() => {})
+
+    handleOnKeydown(event, textarea, editor)
+
+    expect(Editor.insertText).toHaveBeenCalledWith(editor, '\n')
+    expect(Editor.insertBreak).not.toHaveBeenCalled()
     expect(event.preventDefault).toHaveBeenCalled()
   })
 

--- a/packages/core/src/text-area/event-handlers/beforeInput.ts
+++ b/packages/core/src/text-area/event-handlers/beforeInput.ts
@@ -143,7 +143,11 @@ function handleBeforeInput(e: Event, textarea: TextArea, editor: IDomEditor) {
       break
     }
 
-    case 'insertLineBreak':
+    case 'insertLineBreak': {
+      Editor.insertText(editor, '\n')
+      break
+    }
+
     case 'insertParagraph': {
       Editor.insertBreak(editor)
       break

--- a/packages/core/src/text-area/event-handlers/keydown.ts
+++ b/packages/core/src/text-area/event-handlers/keydown.ts
@@ -4,13 +4,16 @@
  */
 
 import { isHotkey } from 'is-hotkey'
-import { Editor, Transforms, Range, Node, Element } from 'slate'
+import {
+  Editor, Element, Node, Range, Transforms,
+} from 'slate'
+
 import { IDomEditor } from '../../editor/interface'
-import TextArea from '../TextArea'
 import Hotkeys from '../../utils/hotkeys'
-import { hasEditableTarget } from '../helpers'
 import { HAS_BEFORE_INPUT_SUPPORT, IS_CHROME, IS_SAFARI } from '../../utils/ua'
-import { EDITOR_TO_TOOLBAR, EDITOR_TO_HOVER_BAR } from '../../utils/weak-maps'
+import { EDITOR_TO_HOVER_BAR, EDITOR_TO_TOOLBAR } from '../../utils/weak-maps'
+import { hasEditableTarget } from '../helpers'
+import TextArea from '../TextArea'
 
 function preventDefault(event: Event) {
   event.preventDefault()
@@ -25,13 +28,17 @@ function triggerMenuHotKey(editor: IDomEditor, event: KeyboardEvent) {
 
   // 合并所有 menus
   const allMenus = { ...toolbarMenus, ...hoverbarMenus }
-  for (let key in allMenus) {
+
+  for (const key of Object.keys(allMenus)) {
     const menu = allMenus[key]
     const { hotkey } = menu
+
     if (hotkey && isHotkey(hotkey, event)) {
       const disabled = menu.isDisabled(editor)
+
       if (!disabled) {
         const val = menu.getValue(editor)
+
         menu.exec(editor, val) // 执行 menu 命令
       }
     }
@@ -43,9 +50,9 @@ function handleOnKeydown(e: Event, textarea: TextArea, editor: IDomEditor) {
   const { selection } = editor
   const { readOnly } = editor.getConfig()
 
-  if (readOnly) return
-  if (textarea.isComposing) return
-  if (!hasEditableTarget(editor, event.target)) return
+  if (readOnly) { return }
+  if (textarea.isComposing) { return }
+  if (!hasEditableTarget(editor, event.target)) { return }
 
   // 触发 menu 快捷键
   triggerMenuHotKey(editor, event)
@@ -172,7 +179,11 @@ function handleOnKeydown(e: Event, textarea: TextArea, editor: IDomEditor) {
 
     if (Hotkeys.isSplitBlock(event)) {
       preventDefault(event)
-      Editor.insertBreak(editor)
+      if (event.shiftKey) {
+        Editor.insertText(editor, '\n')
+      } else {
+        Editor.insertBreak(editor)
+      }
       return
     }
 
@@ -230,30 +241,27 @@ function handleOnKeydown(e: Event, textarea: TextArea, editor: IDomEditor) {
       } else {
         Editor.deleteForward(editor, { unit: 'word' })
       }
-      return
+
     }
-  } else {
-    if (IS_CHROME || IS_SAFARI) {
-      // COMPAT: Chrome and Safari support `beforeinput` event but do not fire
-      // an event when deleting backwards in a selected void inline node
-      // 修复在 Chrome 和 Safari 中删除内容时，内联空节点被选中
+  } else if (IS_CHROME || IS_SAFARI) {
+    // COMPAT: Chrome and Safari support `beforeinput` event but do not fire
+    // an event when deleting backwards in a selected void inline node
+    // 修复在 Chrome 和 Safari 中删除内容时，内联空节点被选中
+    if (
+      selection
+        && (Hotkeys.isDeleteBackward(event) || Hotkeys.isDeleteForward(event))
+        && Range.isCollapsed(selection)
+    ) {
+      const currentNode = Node.parent(editor, selection.anchor.path)
+
       if (
-        selection &&
-        (Hotkeys.isDeleteBackward(event) || Hotkeys.isDeleteForward(event)) &&
-        Range.isCollapsed(selection)
+        Element.isElement(currentNode)
+          && Editor.isVoid(editor, currentNode)
+          && Editor.isInline(editor, currentNode)
       ) {
-        const currentNode = Node.parent(editor, selection.anchor.path)
+        event.preventDefault()
+        Transforms.delete(editor, { unit: 'block' })
 
-        if (
-          Element.isElement(currentNode) &&
-          Editor.isVoid(editor, currentNode) &&
-          Editor.isInline(editor, currentNode)
-        ) {
-          event.preventDefault()
-          Transforms.delete(editor, { unit: 'block' })
-
-          return
-        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- map `Shift+Enter` (`beforeinput.inputType = insertLineBreak`) to soft line break insertion (`\n`) in core handler
- keep `Enter` (`insertParagraph`) behavior unchanged as block split (`insertBreak`)
- align no-`beforeinput` fallback path in `keydown` handler: `Shift+Enter` inserts soft line break, plain `Enter` splits block
- add regression tests for both handler paths

## Why
Issue #542 reports that `Enter` and `Shift+Enter` behave the same (both create new paragraphs). This change restores expected editor behavior:
- `Enter` => new paragraph
- `Shift+Enter` => soft line break (`<br>` in HTML serialization)

## Validation
- `pnpm --filter @wangeditor-next/core test -- __tests__/text-area/event-handlers/before-input.test.ts __tests__/text-area/event-handlers/keydown.test.ts`
- `pnpm --filter @wangeditor-next/core test`
- `pnpm --filter @wangeditor-next/core build`
- `pnpm build`

Closes #542


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Shift+Enter keyboard behavior to insert soft line breaks within paragraphs instead of creating new paragraph blocks, providing the expected text editing experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/857?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->