### PR TITLE
fix(blockquote): support Feishu div line breaks in imported html

### DIFF
--- a/.changeset/fix-blockquote-feishu-div-linebreak-44.md
+++ b/.changeset/fix-blockquote-feishu-div-linebreak-44.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/basic-modules': patch
+---
+
+Fix blockquote HTML parsing for imported content where line breaks are represented by block children (for example `blockquote > div` from Feishu docs). The parser now flattens block children into newline-separated content while preserving inline text marks.

--- a/packages/basic-modules/__tests__/blockquote/parse-html.test.ts
+++ b/packages/basic-modules/__tests__/blockquote/parse-html.test.ts
@@ -66,4 +66,41 @@ describe('blockquote - parse html', () => {
       children: [{ text: 'hello ' }, { type: 'link', url: 'http://wangeditor.com' }],
     })
   })
+
+  it('with block children from other editors', () => {
+    const $elem = $('<blockquote></blockquote>')
+    const children: any[] = [
+      { type: 'paragraph', children: [{ text: 'line 1' }] },
+      { type: 'paragraph', children: [{ text: 'line 2' }] },
+    ]
+
+    // parse
+    const res = parseHtmlConf.parseElemHtml($elem[0], children, editor)
+
+    expect(res).toEqual({
+      type: 'blockquote',
+      children: [{ text: 'line 1' }, { text: '\n' }, { text: 'line 2' }],
+    })
+  })
+
+  it('with block children should keep text marks', () => {
+    const $elem = $('<blockquote></blockquote>')
+    const children: any[] = [
+      { type: 'paragraph', children: [{ text: 'hello ', bold: true }, { text: 'world' }] },
+      { type: 'paragraph', children: [{ text: 'tail', italic: true }] },
+    ]
+
+    // parse
+    const res = parseHtmlConf.parseElemHtml($elem[0], children, editor)
+
+    expect(res).toEqual({
+      type: 'blockquote',
+      children: [
+        { text: 'hello ', bold: true },
+        { text: 'world' },
+        { text: '\n' },
+        { text: 'tail', italic: true },
+      ],
+    })
+  })
 })

--- a/packages/basic-modules/src/modules/blockquote/parse-elem-html.ts
+++ b/packages/basic-modules/src/modules/blockquote/parse-elem-html.ts
@@ -4,10 +4,49 @@
  */
 
 import { IDomEditor } from '@wangeditor-next/core'
-import { Descendant, Text } from 'slate'
+import {
+  Descendant, Element as SlateElement, Node, Text,
+} from 'slate'
 
 import $, { DOMElement } from '../../utils/dom'
 import { BlockQuoteElement } from './custom-types'
+
+function isTextOrInline(child: Descendant, editor: IDomEditor): boolean {
+  if (Text.isText(child)) { return true }
+  if (editor.isInline(child)) { return true }
+  return false
+}
+
+function appendLineBreak(children: Descendant[]) {
+  const lastChild = children[children.length - 1]
+
+  // avoid duplicate '\n' during flattening
+  if (Text.isText(lastChild) && lastChild.text.endsWith('\n')) { return }
+  children.push({ text: '\n' })
+}
+
+function hasNextBlockChild(children: Descendant[], startIndex: number, editor: IDomEditor): boolean {
+  for (let i = startIndex + 1; i < children.length; i += 1) {
+    const child = children[i]
+
+    if (SlateElement.isElement(child) && !editor.isInline(child)) {
+      return true
+    }
+  }
+  return false
+}
+
+function flattenBlockChild(child: SlateElement, editor: IDomEditor): Descendant[] {
+  const normalizedChildren = child.children.filter(node => isTextOrInline(node, editor))
+
+  if (normalizedChildren.length > 0) { return normalizedChildren }
+
+  // fallback for nested block content
+  const text = Node.string(child)
+
+  if (!text) { return [] }
+  return [{ text }]
+}
 
 function parseHtml(
   elem: DOMElement,
@@ -15,12 +54,25 @@ function parseHtml(
   editor: IDomEditor,
 ): BlockQuoteElement {
   const $elem = $(elem)
+  const normalizedChildren: Descendant[] = []
 
-  children = children.filter(child => {
-    if (Text.isText(child)) { return true }
-    if (editor.isInline(child)) { return true }
-    return false
+  children.forEach((child, index) => {
+    if (isTextOrInline(child, editor)) {
+      normalizedChildren.push(child)
+      return
+    }
+
+    if (!SlateElement.isElement(child)) { return }
+
+    normalizedChildren.push(...flattenBlockChild(child, editor))
+
+    // Compatibility for HTML like <blockquote><div>line1</div><div>line2</div></blockquote>
+    if (hasNextBlockChild(children, index, editor)) {
+      appendLineBreak(normalizedChildren)
+    }
   })
+
+  children = normalizedChildren
 
   // 无 children ，则用纯文本
   if (children.length === 0) {

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -281,6 +281,40 @@ test.describe('Basic Editor', () => {
     expect(consoleErrors).toEqual([])
   })
 
+  test('regression #44: blockquote div line breaks should survive setHtml(getHtml())', async ({ page }) => {
+    const issueHtml = '<blockquote><div>line 1</div><div><span style="font-weight: 700;">line 2</span></div></blockquote>'
+
+    const snapshot = await page.evaluate(value => {
+      const editor = (window as any).wangEditorExampleBridge?.editor
+
+      if (!editor) {
+        throw new Error('editor missing')
+      }
+
+      editor.setHtml(value)
+      const firstPassHtml = editor.getHtml()
+
+      editor.setHtml(firstPassHtml)
+
+      return {
+        firstPassHtml,
+        secondPassHtml: editor.getHtml(),
+        plainText: editor.getText?.() || '',
+      }
+    }, issueHtml)
+
+    expect(snapshot.firstPassHtml).toContain('<blockquote>')
+    expect(snapshot.firstPassHtml).toContain('line 1')
+    expect(snapshot.firstPassHtml).toContain('line 2')
+    expect(snapshot.secondPassHtml).toContain('<blockquote>')
+    expect(snapshot.secondPassHtml).toContain('line 1')
+    expect(snapshot.secondPassHtml).toContain('line 2')
+    expect(snapshot.secondPassHtml).toContain('<br>')
+    expect(snapshot.plainText).toContain('line 1')
+    expect(snapshot.plainText).toContain('line 2')
+    expect(snapshot.plainText).toContain('\n')
+  })
+
   test('regression #609: insertData with complex html should not break editing', async ({ page }) => {
     const pageErrors: string[] = []
     const consoleErrors: string[] = []


### PR DESCRIPTION
## Summary
- compat parse for `blockquote` imported from editors that use block children as line breaks (e.g. `blockquote > div` from Feishu)
- flatten block children into existing `\n`-based blockquote model while preserving inline text marks
- add regression coverage for parse + round-trip

## Tests
- `pnpm test packages/basic-modules/__tests__/blockquote/parse-html.test.ts`
- `pnpm e2e --grep "regression #44:"`

Closes #44


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed blockquote HTML parsing for content imported from other editors. When blockquotes contain internal block-level elements (such as div-based line breaks), the content is now correctly flattened while preserving inline text formatting and structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/858?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->