### PR TITLE
fix(list-module): export nested lists as standard html

### DIFF
--- a/.changeset/fix-list-nested-html-543.md
+++ b/.changeset/fix-list-nested-html-543.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/list-module': patch
+---
+
+Fix nested list import/export so standard HTML nesting is preserved. `li > ul/ol` structures are now parsed into list levels correctly, and list serialization outputs nested lists inside their parent `<li>` instead of sibling containers.

--- a/packages/list-module/__tests__/elem-to-html.test.ts
+++ b/packages/list-module/__tests__/elem-to-html.test.ts
@@ -8,128 +8,95 @@ import listItemToHtmlConf from '../src/module/elem-to-html'
 import $, { getTagName } from '../src/utils/dom'
 import { ELEM_TO_EDITOR } from '../src/utils/maps'
 
-describe('module elem-to-html', () => {
-  const childrenHtml = '<span>hello</span>'
+type TestListItem = {
+  type: 'list-item'
+  ordered?: boolean
+  level?: number
+  start?: number
+  orderType?: '1' | 'a' | 'A' | 'i' | 'I'
+  children: Array<{ text: string; color?: string }>
+}
 
-  const orderedElem1 = { type: 'list-item', ordered: true, children: [{ text: '' }] }
-  const orderedElem2 = { type: 'list-item', ordered: true, children: [{ text: '' }] }
-  const unOrderedItem1 = { type: 'list-item', children: [{ text: '' }] }
-  const unOrderedItem2 = { type: 'list-item', children: [{ text: '' }] }
-  const unOrderedItem21 = { type: 'list-item', level: 1, children: [{ text: '' }] }
+function serializeListItems(items: TestListItem[], styleEditor?: any) {
+  const editor = createEditor({ content: items as any })
+  const { elemToHtml } = listItemToHtmlConf
+  const chunks: Array<{ html: string; prefix?: string; suffix?: string }> = []
+  let html = ''
 
-  let editor: ReturnType<typeof createEditor>
+  items.forEach(item => ELEM_TO_EDITOR.set(item as any, editor))
 
-  beforeEach(() => {
-    editor = createEditor({
-      content: [orderedElem1, orderedElem2, unOrderedItem1, unOrderedItem2, unOrderedItem21],
-    })
+  items.forEach(item => {
+    const text = item.children[0]?.text || ''
+    const res = elemToHtml(item as any, `<span>${text}</span>`, styleEditor)
 
-    // elem 绑定 editor
-    ELEM_TO_EDITOR.set(orderedElem1, editor)
-    ELEM_TO_EDITOR.set(orderedElem2, editor)
-    ELEM_TO_EDITOR.set(unOrderedItem1, editor)
-    ELEM_TO_EDITOR.set(unOrderedItem2, editor)
-    ELEM_TO_EDITOR.set(unOrderedItem21, editor)
+    chunks.push(res)
+    html += `${res.prefix || ''}${res.html}${res.suffix || ''}`
   })
 
+  return { html, chunks }
+}
+
+describe('module elem-to-html', () => {
   test('toHtml conf type', () => {
     expect(listItemToHtmlConf.type).toBe('list-item')
   })
 
-  test('ordered item toHtml', () => {
-    const { elemToHtml } = listItemToHtmlConf
+  test('ordered list serialization', () => {
+    const orderedElem1: TestListItem = { type: 'list-item', ordered: true, children: [{ text: 'hello' }] }
+    const orderedElem2: TestListItem = { type: 'list-item', ordered: true, children: [{ text: 'world' }] }
+    const { html, chunks } = serializeListItems([orderedElem1, orderedElem2])
 
-    // first item
-    const firstHtml = elemToHtml(orderedElem1, childrenHtml)
-
-    expect(firstHtml).toEqual({
+    expect(chunks[0]).toEqual({
       html: '<li><span>hello</span></li>',
-      prefix: '<ol>', // 第一个 item ，前面会有 <ol>
+      prefix: '<ol>',
       suffix: '',
     })
-
-    // last item
-    const lastHtml = elemToHtml(orderedElem2, childrenHtml)
-
-    expect(lastHtml).toEqual({
-      html: '<li><span>hello</span></li>',
-      prefix: '',
-      suffix: '</ol>', // 最后一个 item ，后面会有 </ol>
-    })
-  })
-
-  test('ordered item toHtml with start/type', () => {
-    const orderedWithType1 = {
-      type: 'list-item',
-      ordered: true,
-      orderType: 'A',
-      start: 3,
-      children: [{ text: '' }],
-    }
-    const orderedWithType2 = {
-      type: 'list-item',
-      ordered: true,
-      orderType: 'A',
-      start: 3,
-      children: [{ text: '' }],
-    }
-    const localEditor = createEditor({
-      content: [orderedWithType1, orderedWithType2],
-    })
-
-    ELEM_TO_EDITOR.set(orderedWithType1, localEditor)
-    ELEM_TO_EDITOR.set(orderedWithType2, localEditor)
-
-    const { elemToHtml } = listItemToHtmlConf
-    const firstHtml = elemToHtml(orderedWithType1, childrenHtml)
-    const secondHtml = elemToHtml(orderedWithType2, childrenHtml)
-
-    expect(firstHtml).toEqual({
-      html: '<li><span>hello</span></li>',
-      prefix: '<ol type="A" start="3">',
-      suffix: '',
-    })
-    expect(secondHtml).toEqual({
-      html: '<li><span>hello</span></li>',
+    expect(chunks[1]).toEqual({
+      html: '<li><span>world</span></li>',
       prefix: '',
       suffix: '</ol>',
     })
+    expect(html).toBe('<ol><li><span>hello</span></li><li><span>world</span></li></ol>')
   })
 
-  test('unOrdered item toHtml', () => {
-    const { elemToHtml } = listItemToHtmlConf
+  test('ordered list preserves start/type', () => {
+    const orderedWithType1: TestListItem = {
+      type: 'list-item',
+      ordered: true,
+      orderType: 'A',
+      start: 3,
+      children: [{ text: 'hello' }],
+    }
+    const orderedWithType2: TestListItem = {
+      type: 'list-item',
+      ordered: true,
+      orderType: 'A',
+      start: 3,
+      children: [{ text: 'world' }],
+    }
+    const { html } = serializeListItems([orderedWithType1, orderedWithType2])
 
-    // first item
-    const firstHtml = elemToHtml(unOrderedItem1, childrenHtml)
-
-    expect(firstHtml).toEqual({
-      html: '<li><span>hello</span></li>',
-      prefix: '<ul>', // 第一个 item ，前面会有 <ul>
-      suffix: '',
-    })
-
-    // second item
-    const secondHtml = elemToHtml(unOrderedItem2, childrenHtml)
-
-    expect(secondHtml).toEqual({
-      html: '<li><span>hello</span></li>', // 第二个 item ，不应该有 <ul>
-      prefix: '',
-      suffix: '',
-    })
-
-    // last item - leveled
-    const lastHtml = elemToHtml(unOrderedItem21, childrenHtml)
-
-    expect(lastHtml).toEqual({
-      html: '<li><span>hello</span></li>', // 最后一个 item ( leveled ) ，包裹 <ul>
-      prefix: '<ul>',
-      suffix: '</ul></ul>',
-    })
+    expect(html).toBe('<ol type="A" start="3"><li><span>hello</span></li><li><span>world</span></li></ol>')
   })
 
-  // empty item
+  test('mixed list boundaries stay valid', () => {
+    const ordered1: TestListItem = { type: 'list-item', ordered: true, children: [{ text: 'o1' }] }
+    const ordered2: TestListItem = { type: 'list-item', ordered: true, children: [{ text: 'o2' }] }
+    const unOrdered1: TestListItem = { type: 'list-item', ordered: false, children: [{ text: 'u1' }] }
+    const unOrdered2: TestListItem = {
+      type: 'list-item',
+      ordered: false,
+      level: 1,
+      children: [{ text: 'u2' }],
+    }
+    const { html } = serializeListItems([ordered1, ordered2, unOrdered1, unOrdered2])
+
+    expect(html).toBe(
+      '<ol><li><span>o1</span></li><li><span>o2</span></li></ol><ul><li><span>u1</span><ul><li><span>u2</span></li></ul></li></ul>',
+    )
+  })
+
   test('should return empty string for empty Dom7Array', () => {
-    // 创建一个空的 Dom7Array
     const $elem = $()
     const tagName = getTagName($elem)
 
@@ -137,27 +104,18 @@ describe('module elem-to-html', () => {
   })
 
   test('prefix color in class mode', () => {
-    const color = 'rgb(235, 144, 58)'
-    const colorElem = {
+    const colorElem: TestListItem = {
       type: 'list-item',
-      children: [{ text: 'hello', color }],
+      children: [{ text: 'hello', color: 'rgb(235, 144, 58)' }],
     }
-    const colorEditor = createEditor({
-      content: [colorElem],
-    })
-
-    ELEM_TO_EDITOR.set(colorElem, colorEditor)
-
-    const { elemToHtml } = listItemToHtmlConf
     const mockEditor = {
       getConfig() {
         return { textStyleMode: 'class' }
       },
     } as any
+    const { chunks } = serializeListItems([colorElem], mockEditor)
 
-    const res = elemToHtml(colorElem, childrenHtml, mockEditor)
-
-    expect(res).toEqual({
+    expect(chunks[0]).toEqual({
       html: '<li class="w-e-list-color-xx8cx7" data-w-e-color="rgb(235, 144, 58)"><span>hello</span></li>',
       prefix: '<ul>',
       suffix: '</ul>',
@@ -165,27 +123,18 @@ describe('module elem-to-html', () => {
   })
 
   test('unknown color in class mode keeps data by default', () => {
-    const color = 'rgb(1, 2, 3)'
-    const colorElem = {
+    const colorElem: TestListItem = {
       type: 'list-item',
-      children: [{ text: 'hello', color }],
+      children: [{ text: 'hello', color: 'rgb(1, 2, 3)' }],
     }
-    const colorEditor = createEditor({
-      content: [colorElem],
-    })
-
-    ELEM_TO_EDITOR.set(colorElem, colorEditor)
-
-    const { elemToHtml } = listItemToHtmlConf
     const mockEditor = {
       getConfig() {
         return { textStyleMode: 'class' }
       },
     } as any
+    const { chunks } = serializeListItems([colorElem], mockEditor)
 
-    const res = elemToHtml(colorElem, childrenHtml, mockEditor)
-
-    expect(res).toEqual({
+    expect(chunks[0]).toEqual({
       html: '<li data-w-e-color="rgb(1, 2, 3)"><span>hello</span></li>',
       prefix: '<ul>',
       suffix: '</ul>',
@@ -193,18 +142,10 @@ describe('module elem-to-html', () => {
   })
 
   test('unknown color in class mode falls back to inline when policy is fallback-inline', () => {
-    const color = 'rgb(1, 2, 3)'
-    const colorElem = {
+    const colorElem: TestListItem = {
       type: 'list-item',
-      children: [{ text: 'hello', color }],
+      children: [{ text: 'hello', color: 'rgb(1, 2, 3)' }],
     }
-    const colorEditor = createEditor({
-      content: [colorElem],
-    })
-
-    ELEM_TO_EDITOR.set(colorElem, colorEditor)
-
-    const { elemToHtml } = listItemToHtmlConf
     const mockEditor = {
       getConfig() {
         return {
@@ -213,10 +154,9 @@ describe('module elem-to-html', () => {
         }
       },
     } as any
+    const { chunks } = serializeListItems([colorElem], mockEditor)
 
-    const res = elemToHtml(colorElem, childrenHtml, mockEditor)
-
-    expect(res).toEqual({
+    expect(chunks[0]).toEqual({
       html: '<li data-w-e-color="rgb(1, 2, 3)" style="color:rgb(1, 2, 3)"><span>hello</span></li>',
       prefix: '<ul>',
       suffix: '</ul>',
@@ -224,18 +164,10 @@ describe('module elem-to-html', () => {
   })
 
   test('unknown color in class mode throws when policy is strict', () => {
-    const color = 'rgb(1, 2, 3)'
-    const colorElem = {
+    const colorElem: TestListItem = {
       type: 'list-item',
-      children: [{ text: 'hello', color }],
+      children: [{ text: 'hello', color: 'rgb(1, 2, 3)' }],
     }
-    const colorEditor = createEditor({
-      content: [colorElem],
-    })
-
-    ELEM_TO_EDITOR.set(colorElem, colorEditor)
-
-    const { elemToHtml } = listItemToHtmlConf
     const mockEditor = {
       getConfig() {
         return {
@@ -245,135 +177,89 @@ describe('module elem-to-html', () => {
       },
     } as any
 
-    expect(() => elemToHtml(colorElem, childrenHtml, mockEditor)).toThrow(
+    expect(() => serializeListItems([colorElem], mockEditor)).toThrow(
       '[wangeditor] Unsupported list color class token color=rgb(1, 2, 3). policy=strict',
     )
   })
 })
 
 describe('module elem-to-html complex list', () => {
-  const unOrderedElem1 = { type: 'list-item', ordered: false, children: [{ text: '' }] }
-  const unOrderedElem2 = {
-    type: 'list-item', ordered: false, level: 1, children: [{ text: '' }],
-  }
-  const unOrderedElem3 = { type: 'list-item', ordered: false, children: [{ text: '' }] }
-  const orderedElem1 = {
-    type: 'list-item', ordered: true, level: 1, children: [{ text: '' }],
-  }
-  const orderedElem2 = { type: 'list-item', ordered: true, children: [{ text: '' }] }
-  const firstTextHtml = { type: 'paragraph', children: [{ text: 'hello' }] }
-  const lastTextHtml = { type: 'paragraph', children: [{ text: 'world' }] }
+  test('outputs standard nested html for mixed nested list items', () => {
+    const content: TestListItem[] = [
+      { type: 'list-item', ordered: false, children: [{ text: 'a' }] },
+      {
+        type: 'list-item',
+        ordered: false,
+        level: 1,
+        children: [{ text: 'b' }],
+      },
+      { type: 'list-item', ordered: false, children: [{ text: 'c' }] },
+      {
+        type: 'list-item',
+        ordered: true,
+        level: 1,
+        children: [{ text: 'd' }],
+      },
+      { type: 'list-item', ordered: true, children: [{ text: 'e' }] },
+    ]
+    const { html } = serializeListItems(content)
 
-  let editor: ReturnType<typeof createEditor>
-
-  beforeEach(() => {
-    editor = createEditor({
-      content: [
-        firstTextHtml,
-        unOrderedElem1,
-        unOrderedElem2,
-        unOrderedElem3,
-        orderedElem1,
-        orderedElem2,
-        lastTextHtml,
-      ],
-    })
-
-    // elem 绑定 editor
-    ELEM_TO_EDITOR.set(firstTextHtml, editor)
-    ELEM_TO_EDITOR.set(unOrderedElem1, editor)
-    ELEM_TO_EDITOR.set(unOrderedElem2, editor)
-    ELEM_TO_EDITOR.set(orderedElem1, editor)
-    ELEM_TO_EDITOR.set(orderedElem2, editor)
-    ELEM_TO_EDITOR.set(lastTextHtml, editor)
-  })
-
-  test('get container tag mumber', () => {
-    const childrenHtml = '<span>hello</span>'
-    const { elemToHtml } = listItemToHtmlConf
-    const unOrderedHtml1 = elemToHtml(unOrderedElem1, childrenHtml)
-
-    expect(unOrderedHtml1).toEqual({
-      html: '<li><span>hello</span></li>',
-      prefix: '<ul>',
-      suffix: '',
-    })
-    const unOrderedHtml2 = elemToHtml(unOrderedElem2, childrenHtml)
-
-    expect(unOrderedHtml2).toEqual({
-      html: '<li><span>hello</span></li>',
-      prefix: '<ul>',
-      suffix: '</ul>',
-    })
-    const orderedHtml1 = elemToHtml(orderedElem1, childrenHtml)
-
-    expect(orderedHtml1).toEqual({
-      html: '<li><span>hello</span></li>',
-      prefix: '<ol>',
-      suffix: '</ol></ul>',
-    })
-    const orderedHtml2 = elemToHtml(orderedElem2, childrenHtml)
-
-    expect(orderedHtml2).toEqual({
-      html: '<li><span>hello</span></li>',
-      prefix: '<ol>',
-      suffix: '</ol>',
-    })
+    expect(html).toBe(
+      '<ul><li><span>a</span><ul><li><span>b</span></li></ul></li><li><span>c</span><ol><li><span>d</span></li></ol></li></ul><ol><li><span>e</span></li></ol>',
+    )
   })
 })
 
 describe('module elem-to-html ordered list boundaries', () => {
-  const orderedDecimal = {
-    type: 'list-item',
-    ordered: true,
-    children: [{ text: '' }],
-  }
-  const orderedUpperAlpha = {
-    type: 'list-item',
-    ordered: true,
-    orderType: 'A',
-    children: [{ text: '' }],
-  }
-  const orderedUpperRomanFrom2 = {
-    type: 'list-item',
-    ordered: true,
-    orderType: 'I',
-    start: 2,
-    children: [{ text: '' }],
-  }
-
-  let editor: ReturnType<typeof createEditor>
-
-  beforeEach(() => {
-    editor = createEditor({
-      content: [orderedDecimal, orderedUpperAlpha, orderedUpperRomanFrom2],
-    })
-
-    ELEM_TO_EDITOR.set(orderedDecimal, editor)
-    ELEM_TO_EDITOR.set(orderedUpperAlpha, editor)
-    ELEM_TO_EDITOR.set(orderedUpperRomanFrom2, editor)
-  })
-
   test('split consecutive ordered lists by type/start config', () => {
-    const childrenHtml = '<span>hello</span>'
-    const { elemToHtml } = listItemToHtmlConf
+    const orderedDecimal: TestListItem = {
+      type: 'list-item',
+      ordered: true,
+      children: [{ text: 'hello' }],
+    }
+    const orderedUpperAlpha: TestListItem = {
+      type: 'list-item',
+      ordered: true,
+      orderType: 'A',
+      children: [{ text: 'world' }],
+    }
+    const orderedUpperRomanFrom2: TestListItem = {
+      type: 'list-item',
+      ordered: true,
+      orderType: 'I',
+      start: 2,
+      children: [{ text: 'tail' }],
+    }
+    const { html } = serializeListItems([orderedDecimal, orderedUpperAlpha, orderedUpperRomanFrom2])
 
-    expect(elemToHtml(orderedDecimal, childrenHtml)).toEqual({
-      html: '<li><span>hello</span></li>',
-      prefix: '<ol>',
-      suffix: '</ol>',
-    })
+    expect(html).toBe(
+      '<ol><li><span>hello</span></li></ol><ol type="A"><li><span>world</span></li></ol><ol type="I" start="2"><li><span>tail</span></li></ol>',
+    )
+  })
+})
 
-    expect(elemToHtml(orderedUpperAlpha, childrenHtml)).toEqual({
-      html: '<li><span>hello</span></li>',
-      prefix: '<ol type="A">',
-      suffix: '</ol>',
-    })
+describe('module elem-to-html regression #543', () => {
+  test('should export nested list inside parent li', () => {
+    const content: TestListItem[] = [
+      { type: 'list-item', ordered: true, children: [{ text: '第一项' }] },
+      {
+        type: 'list-item',
+        ordered: false,
+        level: 1,
+        children: [{ text: '子项1' }],
+      },
+      {
+        type: 'list-item',
+        ordered: false,
+        level: 1,
+        children: [{ text: '子项2' }],
+      },
+      { type: 'list-item', ordered: true, children: [{ text: '第二项' }] },
+    ]
+    const { html } = serializeListItems(content)
 
-    expect(elemToHtml(orderedUpperRomanFrom2, childrenHtml)).toEqual({
-      html: '<li><span>hello</span></li>',
-      prefix: '<ol type="I" start="2">',
-      suffix: '</ol>',
-    })
+    expect(html).toBe(
+      '<ol><li><span>第一项</span><ul><li><span>子项1</span></li><li><span>子项2</span></li></ul></li><li><span>第二项</span></li></ol>',
+    )
   })
 })

--- a/packages/list-module/__tests__/issue-543-roundtrip.test.ts
+++ b/packages/list-module/__tests__/issue-543-roundtrip.test.ts
@@ -1,0 +1,28 @@
+/**
+ * @description issue #543 nested list round-trip
+ */
+
+import createEditor from '../../../tests/utils/create-editor'
+
+describe('list issue #543 round-trip', () => {
+  it('setHtml/getHtml should keep nested list structure', () => {
+    const editor = createEditor()
+    const html = '<ol><li>第一项<ul><li>子项1</li><li>子项2</li></ul></li><li>第二项</li></ol>'
+
+    editor.setHtml(html)
+
+    const output = editor.getHtml()
+    const wrapper = document.createElement('div')
+
+    wrapper.innerHTML = output
+    const topOl = wrapper.querySelector('ol')
+    const topLevelLi = topOl ? Array.from(topOl.children).filter(el => el.tagName === 'LI') : []
+    const firstLi = topLevelLi[0] as HTMLLIElement | undefined
+    const nestedUl = firstLi?.querySelector(':scope > ul')
+
+    expect(topLevelLi.length).toBe(2)
+    expect(!!nestedUl).toBe(true)
+    expect(topOl?.querySelectorAll(':scope > ul').length || 0).toBe(0)
+    expect(nestedUl?.querySelectorAll(':scope > li').length || 0).toBe(2)
+  })
+})

--- a/packages/list-module/__tests__/parse-html.test.ts
+++ b/packages/list-module/__tests__/parse-html.test.ts
@@ -87,6 +87,27 @@ describe('list - parse html', () => {
     })
   })
 
+  it('parse leveled list item from standard nested html', () => {
+    const $ol = $('<ol></ol>')
+    const $liParent = $('<li></li>')
+    const $ul = $('<ul></ul>')
+    const $liChild = $('<li></li>')
+
+    $ol.append($liParent)
+    $liParent.append($ul)
+    $ul.append($liChild)
+
+    const children = [{ text: 'child' }]
+    const elem = parseItemHtmlConf.parseElemHtml($liChild[0], children, editor)
+
+    expect(elem).toEqual({
+      type: 'list-item',
+      ordered: false,
+      level: 1,
+      children,
+    })
+  })
+
   it('parse list', () => {
     const $ol = $('<ol></ol>')
     const children = [
@@ -118,6 +139,48 @@ describe('list - parse html', () => {
     const listElems = parseListHtmlConf.parseElemHtml($ol[0], children, editor)
 
     expect(listElems.length).toBe(4) // parse list 时，会把输出的结果（数组）flatten ，把嵌套的平铺开
+  })
+
+  it('parse parent li with nested list children should keep parent and flatten nested list items', () => {
+    const $ol = $('<ol><li></li></ol>')
+    const children: any[] = [
+      { text: 'parent' },
+      {
+        type: 'list-item',
+        ordered: false,
+        level: 1,
+        children: [{ text: 'child1' }],
+      },
+      {
+        type: 'list-item',
+        ordered: false,
+        level: 1,
+        children: [{ text: 'child2' }],
+      },
+    ]
+
+    const elems = parseItemHtmlConf.parseElemHtml($ol.find('li')[0], children, editor) as any[]
+
+    expect(elems).toEqual([
+      {
+        type: 'list-item',
+        ordered: true,
+        level: 0,
+        children: [{ text: 'parent' }],
+      },
+      {
+        type: 'list-item',
+        ordered: false,
+        level: 1,
+        children: [{ text: 'child1' }],
+      },
+      {
+        type: 'list-item',
+        ordered: false,
+        level: 1,
+        children: [{ text: 'child2' }],
+      },
+    ])
   })
 
   it('parse isBlock chidren', () => {

--- a/packages/list-module/src/module/elem-to-html.ts
+++ b/packages/list-module/src/module/elem-to-html.ts
@@ -4,7 +4,7 @@
  */
 
 import { DomEditor, getTextStyleMode, IDomEditor } from '@wangeditor-next/core'
-import { Editor, Element, Path } from 'slate'
+import { Element } from 'slate'
 
 import { ELEM_TO_EDITOR } from '../utils/maps'
 import { getListItemColor } from '../utils/util'
@@ -13,150 +13,20 @@ import {
   getNormalizedOrderedListStart,
   getNormalizedOrderedListType,
   hasSameListConfig,
-  hasSameOrderWithBrother,
 } from './helpers'
 import { genListColorClassName, resolveListColorAction } from './style-class'
 
-/**
- * 当前 list-item 前面需要拼接几个 <ol> 或 <ul>
- * @param elem elem
- */
-function getStartContainerTagNumber(elem: Element): number {
-  const editor = ELEM_TO_EDITOR.get(elem)
-
-  if (editor == null) { return 0 }
-
-  const listItemElem = elem as ListItemElement
-  const {
-    type,
-    ordered = false,
-    level = 0,
-  } = listItemElem
-
-  const path = DomEditor.findPath(editor, elem)
-
-  if (path[0] === 0) {
-    // list-item 是第一个元素，再往前没有了。需要拼接 <ol> 或 <ul>
-    return level + 1
-  }
-
-  // 获取上一个 elem
-  const prevPath = Path.previous(path)
-  const prevEntry = Editor.node(editor, prevPath)
-
-  if (!prevEntry) { return 0 }
-  const [prevElem] = prevEntry
-
-  const prevType = DomEditor.getNodeType(prevElem)
-
-  if (prevType !== type) {
-    // 上一个 elem 不是 list-item ，需要拼接 <ol> 或 <ul>
-    return level + 1
-  }
-
-  // 上一个 elem 是 list-item
-  const {
-    ordered: prevOrdered = false,
-    level: prevLevel = 0,
-  } = prevElem as ListItemElement
-
-  if (prevLevel < level) {
-    // 上一个 level 小于当前 level ，需要拼接 <ol> 或 <ul>
-    return level - prevLevel
-  }
-  if (prevLevel > level) {
-    // 此处需要看上一个同级兄弟节点 ordered 是否一致，如果一致则不需要拼接，否则需要拼接
-    return hasSameOrderWithBrother(editor, elem as ListItemElement) ? 0 : 1
-  }
-  if (prevLevel === level) {
-    // 上一个 level 等于当前 level
-    if (prevOrdered === ordered && hasSameListConfig(prevElem as ListItemElement, listItemElem)) {
-      // ordered 一致，则不需要拼接 <ol> 或 <ul>
-      return 0
-    }
-    /// ordered 不一致，则需要拼接 <ol> 或 <ul>
-    return 1
-
-  }
-
-  // 其他情况
-  return 0
-}
-
-/**
- * 当前 list-item 后面面需要拼接几个 </ol> 或 </ul>
- * @param elem elem
- */
-function getEndContainerTagNumber(elem: Element): number {
-  const editor = ELEM_TO_EDITOR.get(elem)
-
-  if (editor == null) { return 0 }
-
-  const listItemElem = elem as ListItemElement
-  const {
-    type,
-    ordered = false,
-    level = 0,
-  } = listItemElem
-
-  const path = DomEditor.findPath(editor, elem)
-
-  if (path[0] === editor.children.length - 1) {
-    // list-item 是最后一个元素，再往后没有了。需要拼接 </ol> 或 </ul>
-    return level + 1
-  }
-
-  // 获取下一个 elem
-  const nextPath = Path.next(path)
-  const nextEntry = Editor.node(editor, nextPath)
-
-  if (!nextEntry) { return 0 }
-  const [nextElem] = nextEntry
-
-  const nextType = DomEditor.getNodeType(nextElem)
-
-  if (nextType !== type) {
-    // 下一个 elem 不是 list-item ，需要拼接 <ol> 或 <ul>
-    return level + 1
-  }
-
-  // 下一个 elem 是 list-item
-  const {
-    ordered: nextOrdered = false,
-    level: nextLevel = 0,
-  } = nextElem as ListItemElement
-
-  if (nextLevel < level) {
-    // 下一个 level 小于当前 level，此处需要看上一个同级兄弟节点 ordered 是否一致，如果一致则不需要拼接，否则需要拼接
-    if (hasSameOrderWithBrother(editor, nextElem as ListItemElement)) {
-      // ordered 一致，则不需要额外拼接 </ol> 或 </ul>
-      return level - nextLevel
-    }
-    // ordered 不一致，则需要额外拼接 </ol> 或 </ul>
-    return level - nextLevel + 1
-
-  }
-  if (nextLevel > level) {
-    // 下一个 level 大于当前 level ，不需要拼接 </ol> 或 </ul>
-    return 0
-  }
-  if (nextLevel === level) {
-    // 下一个 level 等于当前 level
-    if (nextOrdered === ordered && hasSameListConfig(nextElem as ListItemElement, listItemElem)) {
-      // ordered 一致，则不需要拼接 </ol> 或 </ul>
-      return 0
-    }
-    /// ordered 不一致，则需要拼接 </ol> 或 </ul>
-    return 1
-
-  }
-
-  // 其他情况
-  return 0
-}
-
-// ol ul 栈
+// ol ul stack for streaming list-item serialization
 const CONTAINER_TAG_STACK: Array<string> = []
+let STACK_EDITOR: IDomEditor | null = null
+
+function getContainerTag(elem: ListItemElement): 'ol' | 'ul' {
+  return elem.ordered ? 'ol' : 'ul'
+}
+
+function getFallbackContainerTag(elem: ListItemElement): string {
+  return elem.ordered ? 'ol' : 'ul'
+}
 
 function genContainerStartTag(elem: ListItemElement): string {
   const { ordered = false } = elem
@@ -178,6 +48,37 @@ function genContainerStartTag(elem: ListItemElement): string {
   return `<ol ${attrs.join(' ')}>`
 }
 
+function getAdjacentListItem(
+  editor: IDomEditor,
+  index: number,
+  direction: 'prev' | 'next',
+): ListItemElement | null {
+  if (direction === 'prev' && index === 0) { return null }
+  if (direction === 'next' && index === editor.children.length - 1) { return null }
+
+  const targetIndex = direction === 'prev' ? index - 1 : index + 1
+  const targetNode = editor.children[targetIndex] as any
+
+  if (!DomEditor.checkNodeType(targetNode, 'list-item')) { return null }
+  return targetNode as ListItemElement
+}
+
+function getPrevSameLevelListItem(
+  editor: IDomEditor,
+  index: number,
+  level: number,
+): ListItemElement | null {
+  for (let i = index - 1; i >= 0; i -= 1) {
+    const node = editor.children[i] as any
+
+    if (!DomEditor.checkNodeType(node, 'list-item')) { continue }
+    if ((node.level || 0) === level) {
+      return node as ListItemElement
+    }
+  }
+  return null
+}
+
 function elemToHtml(
   elem: Element,
   childrenHtml: string,
@@ -191,34 +92,105 @@ function elemToHtml(
   let endContainerStr = ''
 
   const listItemElem = elem as ListItemElement
-  const { ordered = false } = listItemElem
-  const containerTag = ordered ? 'ol' : 'ul'
+  const { level = 0 } = listItemElem
+  const containerTag = getContainerTag(listItemElem)
   const containerStartTag = genContainerStartTag(listItemElem)
+  const bindEditor = ELEM_TO_EDITOR.get(elem)
+  const bindEditorWithChildren = bindEditor && Array.isArray((bindEditor as any).children)
+    ? bindEditor
+    : null
+  const passedEditorWithChildren = editor && Array.isArray((editor as any).children)
+    ? editor
+    : null
+  const editorContainsElem = (candidate: IDomEditor | null | undefined) => (
+    !!candidate && candidate.children.indexOf(elem as any) >= 0
+  )
+  let finalEditor = passedEditorWithChildren || bindEditorWithChildren
 
-  // 前面需要拼接几个 <ol> 或 <ul>
-  const startContainerTagNumber = getStartContainerTagNumber(elem)
+  if (editorContainsElem(passedEditorWithChildren)) {
+    finalEditor = passedEditorWithChildren
+  } else if (editorContainsElem(bindEditorWithChildren)) {
+    finalEditor = bindEditorWithChildren
+  }
+  const styleEditor = editor || bindEditor
 
-  if (startContainerTagNumber > 0) {
-    for (let i = 0; i < startContainerTagNumber; i += 1) {
-      startContainerStr += containerStartTag // 记录 start container tag ，如 `<ul>`
-      CONTAINER_TAG_STACK.push(containerTag) // tag 压栈
+  if (finalEditor == null) {
+    return {
+      html: `<li>${childrenHtml}</li>`,
+      prefix: '',
+      suffix: '',
     }
   }
 
-  // 后面需要拼接几个 </ol> 或 </ul>
-  const endContainerTagNumber = getEndContainerTagNumber(elem)
+  if (STACK_EDITOR !== finalEditor) {
+    CONTAINER_TAG_STACK.length = 0
+    STACK_EDITOR = finalEditor
+  }
 
-  if (endContainerTagNumber > 0) {
-    for (let i = 0; i < endContainerTagNumber; i += 1) {
-      const tag = CONTAINER_TAG_STACK.pop() // tag 从栈中获取
+  const index = finalEditor.children.indexOf(elem as any)
 
-      endContainerStr += `</${tag}>` // 记录 end container tag ，如 `</ul>`
+  if (index < 0) {
+    return {
+      html: `<li>${childrenHtml}</li>`,
+      prefix: '',
+      suffix: '',
+    }
+  }
+
+  const prevItem = getAdjacentListItem(finalEditor, index, 'prev')
+  const nextItem = getAdjacentListItem(finalEditor, index, 'next')
+  const hasNestedNext = !!nextItem && (nextItem.level || 0) > level
+
+  if (!prevItem) {
+    // list block start
+    CONTAINER_TAG_STACK.length = 0
+    for (let i = 0; i < level + 1; i += 1) {
+      startContainerStr += containerStartTag
+      CONTAINER_TAG_STACK.push(containerTag)
+    }
+  } else {
+    const prevLevel = prevItem.level || 0
+
+    if (level > prevLevel) {
+      // Enter nested lists inside previous <li>.
+      for (let i = 0; i < level - prevLevel; i += 1) {
+        startContainerStr += containerStartTag
+        CONTAINER_TAG_STACK.push(containerTag)
+      }
+    } else if (level === prevLevel) {
+      // Split same-level lists when ordered/type/start differ.
+      if (!hasSameListConfig(prevItem, listItemElem)) {
+        const closeTag = CONTAINER_TAG_STACK.pop() || getFallbackContainerTag(prevItem)
+
+        startContainerStr += `</${closeTag}>${containerStartTag}`
+        CONTAINER_TAG_STACK.push(containerTag)
+      }
+    } else {
+      // Climb up: close nested list containers and parent <li>.
+      let diff = prevLevel - level
+
+      while (diff > 0) {
+        const closeTag = CONTAINER_TAG_STACK.pop() || getFallbackContainerTag(prevItem)
+
+        startContainerStr += `</${closeTag}></li>`
+        diff -= 1
+      }
+
+      // Split target-level list container when config changed.
+      const brother = getPrevSameLevelListItem(finalEditor, index, level)
+
+      if (brother && !hasSameListConfig(brother, listItemElem)) {
+        const closeTag = CONTAINER_TAG_STACK.pop() || getFallbackContainerTag(brother)
+
+        startContainerStr += `</${closeTag}>${containerStartTag}`
+        CONTAINER_TAG_STACK.push(containerTag)
+      }
     }
   }
 
   // 获取前缀颜色
   const prefixColor = getListItemColor(elem)
-  const textStyleMode = getTextStyleMode(editor)
+  const textStyleMode = getTextStyleMode(styleEditor)
   let colorStyle = ''
   let colorClass = ''
   let colorData = ''
@@ -226,7 +198,7 @@ function elemToHtml(
   if (prefixColor) {
     if (textStyleMode === 'class') {
       colorData = ` data-w-e-color="${prefixColor}"`
-      const action = resolveListColorAction(editor, prefixColor)
+      const action = resolveListColorAction(styleEditor, prefixColor)
 
       if (action === 'class') {
         colorClass = ` class="${genListColorClassName(prefixColor)}"`
@@ -238,8 +210,24 @@ function elemToHtml(
     }
   }
 
+  const html = `<li${colorClass}${colorData}${colorStyle}>${childrenHtml}${hasNestedNext ? '' : '</li>'}`
+
+  if (!nextItem) {
+    // list block end
+    while (CONTAINER_TAG_STACK.length > 0) {
+      const tag = CONTAINER_TAG_STACK.pop()
+
+      if (!tag) { break }
+      endContainerStr += `</${tag}>`
+      if (CONTAINER_TAG_STACK.length > 0) {
+        endContainerStr += '</li>'
+      }
+    }
+    STACK_EDITOR = null
+  }
+
   return {
-    html: `<li${colorClass}${colorData}${colorStyle}>${childrenHtml}</li>`,
+    html,
     prefix: startContainerStr,
     suffix: endContainerStr,
   }

--- a/packages/list-module/src/module/parse-elem-html.ts
+++ b/packages/list-module/src/module/parse-elem-html.ts
@@ -3,7 +3,7 @@
  * @author wangfupeng
  */
 
-import { IDomEditor } from '@wangeditor-next/core'
+import { DomEditor, IDomEditor } from '@wangeditor-next/core'
 import { Dom7Array } from 'dom7'
 import { Descendant, Text } from 'slate'
 
@@ -57,36 +57,53 @@ function getOrderedType($elem: Dom7Array): OrderedListType | undefined {
  * @param $elem list $elem
  */
 function getLevel($elem: Dom7Array): number {
-  let level = 0
-
+  let listAncestorCount = 0
   let $cur: Dom7Array = $elem.parent()
-  let tagName: string = getTagName($cur)
 
-  while (tagName === 'ul' || tagName === 'ol') {
+  while ($cur.length > 0) {
+    const tagName = getTagName($cur)
+
+    if (tagName === 'ul' || tagName === 'ol') {
+      listAncestorCount += 1
+    }
     $cur = $cur.parent()
-    tagName = getTagName($cur)
-    level += 1
   }
 
-  return level - 1
+  return Math.max(0, listAncestorCount - 1)
 }
 
 function parseItemHtml(
   elem: DOMElement,
   children: Descendant[],
   editor: IDomEditor,
-): ListItemElement {
+): ListItemElement | ListItemElement[] {
   const $elem = $(elem)
+  const normalizedChildren: Descendant[] = []
+  const nestedListChildren: ListItemElement[] = []
 
-  children = children.filter(child => {
-    if (Text.isText(child)) { return true }
-    if (editor.isInline(child)) { return true }
-    return false
+  children.forEach(child => {
+    if (Text.isText(child)) {
+      normalizedChildren.push(child)
+      return
+    }
+
+    if (editor.isInline(child)) {
+      normalizedChildren.push(child)
+      return
+    }
+
+    if (DomEditor.checkNodeType(child, 'list-item')) {
+      nestedListChildren.push(child as ListItemElement)
+    }
   })
 
   // 无 children ，则用纯文本
-  if (children.length === 0) {
-    children = [{ text: $elem.text().replace(/\s+/gm, ' ') }]
+  if (normalizedChildren.length === 0) {
+    if (nestedListChildren.length > 0) {
+      normalizedChildren.push({ text: '' })
+    } else {
+      normalizedChildren.push({ text: $elem.text().replace(/\s+/gm, ' ') })
+    }
   }
 
   const ordered = getOrdered($elem)
@@ -94,15 +111,18 @@ function parseItemHtml(
   const start = getOrderedStart($elem)
   const orderType = getOrderedType($elem)
 
-  return {
+  const currentItem: ListItemElement = {
     type: 'list-item',
     ordered,
     level,
     ...(start !== undefined ? { start } : {}),
     ...(orderType !== undefined ? { orderType } : {}),
     // @ts-ignore
-    children,
+    children: normalizedChildren,
   }
+
+  if (nestedListChildren.length === 0) { return currentItem }
+  return [currentItem, ...nestedListChildren]
 }
 
 export const parseItemHtmlConf = {

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -590,6 +590,53 @@ test.describe('Basic Editor', () => {
     await expect(page.getByTestId('editor-html')).toContainText('<li>numbered item</li>')
   })
 
+  test('regression #543: nested list should stay inside parent li after round-trip', async ({ page }) => {
+    const issueHtml = '<ol><li>第一项<ul><li>子项1</li><li>子项2</li></ul></li><li>第二项</li></ol>'
+
+    const snapshot = await page.evaluate(value => {
+      const editor = (window as any).wangEditorExampleBridge?.editor
+
+      if (!editor) {
+        throw new Error('editor missing')
+      }
+
+      editor.setHtml(value)
+      const firstPassHtml = editor.getHtml()
+
+      editor.setHtml(firstPassHtml)
+      const secondPassHtml = editor.getHtml()
+
+      const wrapper = document.createElement('div')
+
+      wrapper.innerHTML = secondPassHtml
+      const topOl = wrapper.querySelector('ol')
+      const topLevelLi = topOl
+        ? Array.from(topOl.children).filter(el => el.tagName === 'LI')
+        : []
+      const firstLi = topLevelLi[0] as HTMLLIElement | undefined
+      const nestedUl = firstLi?.querySelector(':scope > ul')
+      const directUlUnderOl = topOl?.querySelectorAll(':scope > ul').length || 0
+
+      return {
+        firstPassHtml,
+        secondPassHtml,
+        topLevelLiCount: topLevelLi.length,
+        hasNestedUlInFirstLi: !!nestedUl,
+        nestedLiCount: nestedUl?.querySelectorAll(':scope > li').length || 0,
+        directUlUnderOl,
+      }
+    }, issueHtml)
+
+    expect(snapshot.firstPassHtml).toContain('<ol>')
+    expect(snapshot.firstPassHtml).toContain('<ul>')
+    expect(snapshot.secondPassHtml).toContain('<ol>')
+    expect(snapshot.secondPassHtml).toContain('<ul>')
+    expect(snapshot.topLevelLiCount).toBe(2)
+    expect(snapshot.hasNestedUlInFirstLi).toBe(true)
+    expect(snapshot.nestedLiCount).toBe(2)
+    expect(snapshot.directUlUnderOl).toBe(0)
+  })
+
   test('creates a todo item', async ({ page }) => {
     await typeInEditor(page, 'todo item')
     await selectAll(page)


### PR DESCRIPTION
## Summary
- fix list HTML import/export so nested lists follow standard structure (`li > ul/ol`) instead of sibling nested containers
- support parsing standard nested list HTML by flattening nested `list-item` nodes into the existing leveled list-item model
- update list serialization to emit standard nested HTML while keeping ordered list boundary behavior (`type`/`start` split)
- add regression coverage for issue #543 in unit tests and Playwright

## Tests
- `pnpm test packages/list-module/__tests__`
- `pnpm e2e --grep "regression #543"`

Closes #543


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed nested list handling to preserve standard HTML nesting structure. Nested lists now remain correctly contained within their parent list items during parsing and serialization, rather than appearing as separate elements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/860?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->