### PR TITLE
fix(core): fix IME no-echo after backspace clear (#861)

### DIFF
--- a/packages/core/__tests__/text-area/event-handlers/composition.test.ts
+++ b/packages/core/__tests__/text-area/event-handlers/composition.test.ts
@@ -276,8 +276,8 @@ describe('composition handlers', () => {
       focus: { path: [0, 0], offset: 0 },
     }
     const paragraph = { type: 'paragraph', children: [{ text: 'x' }] }
-    const oldStartContainer = { textContent: 'before' }
-    const currentStartContainer = { textContent: 'after' }
+    const oldStartContainer = document.createTextNode('before')
+    const currentStartContainer = document.createTextNode('after')
     const editor = {
       selection,
       getConfig: () => ({ maxLength: 0 }),
@@ -316,5 +316,60 @@ describe('composition handlers', () => {
     expect(oldStartContainer.textContent).toBe('before')
     expect(getSelection).toHaveBeenCalledTimes(3)
     expect(Editor.insertText).toHaveBeenCalledWith(editor, '拼')
+  })
+
+  it('does not rewrite non-text start containers in post-composition cleanup', () => {
+    vi.useFakeTimers()
+
+    const paragraph = { type: 'paragraph', children: [{ text: 'x' }] }
+    const oldStartContainer = document.createElement('span')
+    const newStartContainer = document.createTextNode('new')
+    const editor = {
+      selection: {
+        anchor: { path: [0], offset: 0 },
+        focus: { path: [0], offset: 0 },
+      },
+      getConfig: () => ({ maxLength: 0 }),
+    } as any
+    const textarea = { changeViewState: vi.fn(), isComposing: false } as any
+    const startEvent = { target: {} } as any
+    const endEvent = { target: {}, data: '拼' } as any
+
+    oldStartContainer.textContent = 'start-text'
+
+    const findRootSpy = vi.spyOn(DomEditor, 'findDocumentOrShadowRoot')
+
+    findRootSpy
+      .mockImplementationOnce(() => ({
+        getSelection: () => ({
+          rangeCount: 1,
+          getRangeAt: () => ({ startContainer: oldStartContainer }),
+        }),
+      }) as any)
+      .mockImplementation(() => ({
+        getSelection: () => ({
+          rangeCount: 1,
+          getRangeAt: () => ({ startContainer: newStartContainer }),
+        }),
+      }) as any)
+
+    vi.spyOn(helpers, 'hasEditableTarget').mockReturnValue(true)
+    vi.spyOn(DomEditor, 'cleanExposedTexNodeInSelectionBlock').mockImplementation(() => {})
+    vi.spyOn(Editor, 'node').mockImplementation((_ed, path) => {
+      if (path.length === 1) {
+        return [paragraph, path] as any
+      }
+
+      return [{ text: 'x' }, path] as any
+    })
+    vi.spyOn(Editor, 'insertText').mockImplementation(() => {})
+
+    handleCompositionStart(startEvent, textarea, editor)
+    oldStartContainer.textContent = 'mutated-after-start'
+    handleCompositionEnd(endEvent, textarea, editor)
+    vi.runAllTimers()
+
+    expect(Editor.insertText).toHaveBeenCalledWith(editor, '拼')
+    expect(oldStartContainer.textContent).toBe('mutated-after-start')
   })
 })

--- a/packages/core/src/text-area/event-handlers/composition.ts
+++ b/packages/core/src/text-area/event-handlers/composition.ts
@@ -226,9 +226,11 @@ export function handleCompositionEnd(e: Event, textarea: TextArea, editor: IDomE
       const oldStartContainer = EDITOR_TO_START_CONTAINER.get(editor) // 拼音输入开始时的 text node
 
       if (oldStartContainer == null) { return }
+      if (oldStartContainer.nodeType !== Node.TEXT_NODE) { return }
       const curStartContainer = getDOMSelectionStartContainer(editor)
 
       if (curStartContainer == null) { return } // 拼音输入结束时的 text node
+      if (curStartContainer.nodeType !== Node.TEXT_NODE) { return }
 
       if (curStartContainer === oldStartContainer) {
         // 拼音输入的开始和结束，都在同一个 text node ，则不做处理

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -192,6 +192,82 @@ test.describe('Basic Editor', () => {
     expect(domPointErrors).toEqual([])
   })
 
+  test('regression #861: composing insertText after backspace clear should commit once and stay visible', async ({ page }) => {
+    const pageErrors: string[] = []
+
+    page.on('pageerror', err => {
+      pageErrors.push(err?.stack || err?.message || String(err))
+    })
+
+    await page.evaluate(() => {
+      const editor = (window as any).wangEditorExampleBridge?.editor
+      const el = document.querySelector('[data-testid="editor-textarea"] [contenteditable="true"]') as HTMLElement | null
+
+      if (!editor || !el) {
+        throw new Error('editor or editable not found')
+      }
+
+      const fire = (event: Event) => el.dispatchEvent(event)
+      const composeCommitAsInsertText = (text: string) => {
+        fire(new CompositionEvent('compositionstart', { data: '' }))
+        fire(new CompositionEvent('compositionupdate', { data: 'nihao' }))
+        fire(new InputEvent('beforeinput', {
+          inputType: 'insertText',
+          data: text,
+          bubbles: true,
+          cancelable: true,
+          isComposing: true,
+        }))
+        fire(new CompositionEvent('compositionend', { data: '' }))
+      }
+      const backspaceDeleteAll = () => {
+        let guard = 200
+
+        while (editor.getText().length > 0 && guard > 0) {
+          fire(new InputEvent('beforeinput', {
+            inputType: 'deleteContentBackward',
+            data: null,
+            bubbles: true,
+            cancelable: true,
+          }))
+          guard -= 1
+        }
+      }
+
+      editor.focus()
+      editor.clear()
+      composeCommitAsInsertText('你好')
+      backspaceDeleteAll()
+      composeCommitAsInsertText('中文')
+    })
+
+    await page.waitForTimeout(200)
+
+    const settled = await page.evaluate(() => {
+      const editor = (window as any).wangEditorExampleBridge?.editor
+      const el = document.querySelector('[data-testid="editor-textarea"] [contenteditable="true"]')
+
+      if (!editor || !el) {
+        throw new Error('editor or editable not found')
+      }
+
+      return {
+        modelText: editor.getText(),
+        modelHtml: editor.getHtml(),
+        domText: (el as HTMLElement).innerText,
+      }
+    })
+
+    expect(settled.modelText).toBe('中文')
+    expect(settled.modelHtml).toContain('<p>中文</p>')
+    expect(settled.domText).toContain('中文')
+    expect(settled.domText).not.toContain('中文中文')
+    await expect(page.getByTestId('editor-html')).toContainText('<p>中文</p>')
+    await expect(page.getByTestId('editor-html')).not.toContainText('中文中文')
+    await expect(getEditable(page)).toContainText('中文')
+    expect(pageErrors).toEqual([])
+  })
+
   test('regression #282: first-line superscript with large font should not be clipped', async ({ page }) => {
     await page.evaluate(() => {
       const editor = (window as any).wangEditorExampleBridge?.editor


### PR DESCRIPTION
## Summary
- narrow composition post-cleanup to text nodes only
- prevent non-text startContainer rewrite from clearing editable DOM echo
- add core + e2e regression coverage for #861 path

## Why this is the minimal effective fix
- reverted earlier experimental beforeinput/composition adjustments
- kept only the change that directly affects the reproduced no-echo symptom

## Verification
- pnpm test packages/core/__tests__/text-area/event-handlers/before-input.test.ts packages/core/__tests__/text-area/event-handlers/composition.test.ts
- pnpm e2e --grep "regression #861|regression #813|regression #793"

Fixes #861

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed composition event handling to properly validate DOM node types before applying text corrections, preventing unintended overwrites.

* **Tests**
  * Added regression test ensuring editor clear functionality works correctly with composed text input to prevent future regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/862?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->