### PR TITLE
chore(editor): 减小包体积并补充 sourcemap release 资产

### DIFF
--- a/.changeset/tiny-peaches-know.md
+++ b/.changeset/tiny-peaches-know.md
@@ -1,0 +1,9 @@
+---
+'@wangeditor-next/editor': patch
+---
+
+Optimize `@wangeditor-next/editor` package distribution and lightweight entry ergonomics:
+
+- Exclude `.map` files from npm publish artifacts to reduce install size.
+- Upload editor sourcemaps as GitHub Release assets for debugging workflows.
+- Add a package-size CI guard (`pnpm run check:editor:pack-size`) to prevent regressions.

--- a/.github/scripts/create-consolidated-release.js
+++ b/.github/scripts/create-consolidated-release.js
@@ -187,3 +187,7 @@ execSync(
 )
 
 console.log(`\nConsolidated GitHub release created: ${tag}`)
+
+if (process.env.GITHUB_OUTPUT) {
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, `tag=${tag}\n`)
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,7 @@ jobs:
       # Create one consolidated GitHub Release that aggregates all published
       # packages into a single entry instead of one release per package.
       - name: Create consolidated GitHub Release
+        id: consolidated_release
         if: steps.changesets.outputs.published == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -125,6 +126,31 @@ jobs:
           fi
 
           echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Upload editor sourcemaps to GitHub Release assets
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.consolidated_release.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${RELEASE_TAG}" ]; then
+            echo "::warning::Missing release tag output. Skip sourcemap upload."
+            exit 0
+          fi
+
+          map_count="$(find packages/editor/dist -type f -name '*.map' | wc -l | tr -d ' ')"
+          if [ "${map_count}" = "0" ]; then
+            echo "::warning::No sourcemap files found under packages/editor/dist. Skip upload."
+            exit 0
+          fi
+
+          asset_name="editor-sourcemaps-${RELEASE_TAG}.tar.gz"
+          find packages/editor/dist -type f -name '*.map' -print0 \
+            | tar --null -T - -czf "${asset_name}"
+
+          gh release upload "${RELEASE_TAG}" "${asset_name}" --clobber
 
       - name: Trigger docs site deployment for released editor version
         if: steps.changesets.outputs.published == 'true' && github.ref_name == 'master' && env.DOCS_REPO_DISPATCH_TOKEN != ''

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Build packages
         run: pnpm build
 
+      - name: Check editor package size budget
+        run: pnpm run check:editor:pack-size
+
       # 在 master 上顺带产出覆盖率，避免额外 workflow 重复跑一轮
       - name: Unit test with coverage
         if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref_name == 'master')

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "smoke:demo:vue3": "pnpm --filter @wangeditor-next/demo-vue3 run smoke",
     "smoke:demo:yjs:react": "pnpm --filter @wangeditor-next/demo-yjs-react run smoke",
     "smoke:demo:yjs:vue3": "pnpm --filter @wangeditor-next/demo-yjs-vue3 run smoke",
-    "smoke:demos": "pnpm exec turbo build --filter=@wangeditor-next/demo-react --filter=@wangeditor-next/demo-vue3 --filter=@wangeditor-next/demo-yjs-react --filter=@wangeditor-next/demo-yjs-vue3"
+    "smoke:demos": "pnpm exec turbo build --filter=@wangeditor-next/demo-react --filter=@wangeditor-next/demo-vue3 --filter=@wangeditor-next/demo-yjs-react --filter=@wangeditor-next/demo-yjs-vue3",
+    "check:editor:pack-size": "node scripts/check-editor-pack-size.js"
   },
   "workspaces": [
     "apps/*",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -40,7 +40,8 @@
     "test": "__tests__"
   },
   "files": [
-    "dist"
+    "dist",
+    "!dist/**/*.map"
   ],
   "publishConfig": {
     "access": "public"

--- a/scripts/check-editor-pack-size.js
+++ b/scripts/check-editor-pack-size.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs')
+const path = require('node:path')
+const { execFileSync } = require('node:child_process')
+
+const rootDir = path.resolve(__dirname, '..')
+const editorDir = path.join(rootDir, 'packages', 'editor')
+
+const MAX_TARBALL_SIZE = Number(process.env.EDITOR_PACK_TARBALL_MAX || 1500000)
+const MAX_UNPACKED_SIZE = Number(process.env.EDITOR_PACK_UNPACKED_MAX || 3500000)
+const MAX_MAP_SIZE = Number(process.env.EDITOR_PACK_MAP_MAX || 0)
+
+function formatBytes(bytes) {
+  return `${(bytes / 1024 / 1024).toFixed(2)}MB`
+}
+
+function run() {
+  const output = execFileSync('npm', ['pack', '--json'], {
+    cwd: editorDir,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  const result = JSON.parse(output)[0]
+  const files = result.files || []
+  const mapBytes = files
+    .filter(file => file.path.endsWith('.map'))
+    .reduce((sum, file) => sum + (file.size || 0), 0)
+
+  const summary = {
+    tarball: result.size || 0,
+    unpacked: result.unpackedSize || 0,
+    mapBytes,
+    entryCount: result.entryCount || files.length,
+  }
+
+  // Clean the generated tgz to avoid dirty workspace artifacts.
+  const tgzPath = path.join(editorDir, result.filename || '')
+
+  if (result.filename && fs.existsSync(tgzPath)) {
+    fs.unlinkSync(tgzPath)
+  }
+
+  console.log('[check-editor-pack-size] summary')
+  console.log(
+    JSON.stringify(
+      {
+        ...summary,
+        human: {
+          tarball: formatBytes(summary.tarball),
+          unpacked: formatBytes(summary.unpacked),
+          mapBytes: formatBytes(summary.mapBytes),
+        },
+      },
+      null,
+      2,
+    ),
+  )
+
+  const failedReasons = []
+
+  if (summary.tarball > MAX_TARBALL_SIZE) {
+    failedReasons.push(
+      `tarball size ${summary.tarball} exceeds limit ${MAX_TARBALL_SIZE}`,
+    )
+  }
+  if (summary.unpacked > MAX_UNPACKED_SIZE) {
+    failedReasons.push(
+      `unpacked size ${summary.unpacked} exceeds limit ${MAX_UNPACKED_SIZE}`,
+    )
+  }
+  if (summary.mapBytes > MAX_MAP_SIZE) {
+    failedReasons.push(`.map bytes ${summary.mapBytes} exceeds limit ${MAX_MAP_SIZE}`)
+  }
+
+  if (failedReasons.length > 0) {
+    failedReasons.forEach(reason => console.error(`[check-editor-pack-size] ${reason}`))
+    process.exit(1)
+  }
+}
+
+run()


### PR DESCRIPTION
## Summary

- exclude `dist/**/*.map` from `@wangeditor-next/editor` npm publish artifacts to reduce install size
- add `pnpm run check:editor:pack-size` with CI gate in `test.yml` to prevent package size regressions
- keep debugging path by uploading editor sourcemaps to GitHub Release assets in `release.yml`
- expose consolidated release tag from `.github/scripts/create-consolidated-release.js` via `$GITHUB_OUTPUT`

## Validation

- `pnpm run check:editor:pack-size`
  - tarball: `0.72MB`
  - unpacked: `2.47MB`
  - map bytes: `0`

## Notes

- this PR keeps `@wangeditor-next/editor/core` as the lightweight entry and does not add a new public subpath.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Editor sourcemaps now available as GitHub Release assets for enhanced debugging

* **Chores**
  * Optimized npm package distribution by excluding sourcemap files
  * Added continuous integration checks to validate editor package size against defined thresholds and prevent regressions
  * Updated release workflow to automatically capture and manage release tag outputs for downstream CI steps

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/863?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->