### PR TITLE
fix(table): preserve table caption in parse/render/html round-trip

### DIFF
--- a/.changeset/wild-bikes-heal.md
+++ b/.changeset/wild-bikes-heal.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/table-module': patch
+---
+
+fix table caption parse/render/toHtml round-trip support

--- a/packages/table-module/__tests__/elem-to-html.test.ts
+++ b/packages/table-module/__tests__/elem-to-html.test.ts
@@ -128,6 +128,19 @@ describe('TableModule module', () => {
       )
     })
 
+    test('tableToHtmlConf should include caption when present', () => {
+      const element = {
+        type: 'table',
+        caption: 'Table 2: Effects of contact',
+        children: [],
+      }
+      const res = tableToHtmlConf.elemToHtml(element, '<tr><td>123</td></tr>')
+
+      expect(res).toBe(
+        '<table style="width: auto;table-layout: fixed;height:auto"><caption>Table 2: Effects of contact</caption><tbody><tr><td>123</td></tr></tbody></table>',
+      )
+    })
+
     test('tableToHtmlConf should export explicit pixel width when columnWidths are present', () => {
       const element = {
         type: 'table',
@@ -188,6 +201,26 @@ describe('TableModule module', () => {
         '<table class="w-e-table-layout-fixed" width="100%" height="60px" data-w-e-table-height="60px"><tbody><tr><td>123</td></tr></tbody></table>',
       )
       expect(res).not.toContain('style=')
+    })
+
+    test('tableToHtmlConf should escape caption html', () => {
+      const element = {
+        type: 'table',
+        caption: '<script>alert(1)</script>',
+        width: '100%',
+        height: '60px',
+        children: [],
+      }
+      const mockEditor = {
+        getConfig() {
+          return { textStyleMode: 'class' }
+        },
+      } as any
+      const res = tableToHtmlConf.elemToHtml(element, '<tr><td>123</td></tr>', mockEditor)
+
+      expect(res).toBe(
+        '<table class="w-e-table-layout-fixed" width="100%" height="60px" data-w-e-table-height="60px"><caption>&lt;script&gt;alert(1)&lt;/script&gt;</caption><tbody><tr><td>123</td></tr></tbody></table>',
+      )
     })
   })
 })

--- a/packages/table-module/__tests__/parse-html.test.ts
+++ b/packages/table-module/__tests__/parse-html.test.ts
@@ -247,6 +247,38 @@ describe('table - parse html', () => {
       ],
     })
   })
+
+  it('table should parse caption text', () => {
+    const html = [
+      '<table style="width:100%;table-layout:fixed">',
+      '<caption>Table 2: Effects of contact</caption>',
+      '<tr><td>1</td></tr>',
+      '</table>',
+    ].join('')
+    const $table = $(html)
+    const stubEditor = {
+      isInline: () => false,
+    } as any
+    const rows = Array.from($table.find('tr'))
+      .map(row => {
+        const cells = Array.from(row.children).map(cell => parseCellHtmlConf.parseElemHtml(cell as HTMLTableCellElement, [], stubEditor))
+
+        return parseRowHtmlConf.parseElemHtml(row as HTMLTableRowElement, cells, stubEditor)
+      })
+    const table = parseTableHtmlConf.parseElemHtml($table[0], rows as any, stubEditor)
+
+    expect(table).toMatchObject({
+      type: 'table',
+      width: '100%',
+      caption: 'Table 2: Effects of contact',
+      children: [
+        {
+          type: 'table-row',
+          children: [{ ...TABLE_CELL_BASE_PROPS, children: [{ text: '1' }] }],
+        },
+      ],
+    })
+  })
   // ============== 测试table的border相关属性 start ==============
 
   it('table cell (TD) without border style should use default border (1px)', () => {

--- a/packages/table-module/__tests__/render-elem.test.ts
+++ b/packages/table-module/__tests__/render-elem.test.ts
@@ -75,6 +75,23 @@ describe('table module - render elem', () => {
     expect(tableVnode.sel).toBe('table')
   })
 
+  it('render table caption when caption is provided', () => {
+    const elem = {
+      type: 'table',
+      caption: 'Table 2: Effects of contact',
+      children: [],
+    }
+
+    const observerVnode = renderTableConf.renderElem(elem, null, editor) as any
+    const containerVnode = observerVnode.children[0] as any
+    const tableVnode = containerVnode.children[0] as any
+    const captionVnode = tableVnode.children[0] as any
+
+    expect(captionVnode.sel).toBe('caption')
+    expect(captionVnode.data?.contentEditable).toBe(false)
+    expect(captionVnode.text).toBe('Table 2: Effects of contact')
+  })
+
   it('render table elem with full with', () => {
     const elem = { type: 'table', children: [], width: '100%' }
 

--- a/packages/table-module/src/module/custom-types.ts
+++ b/packages/table-module/src/module/custom-types.ts
@@ -36,6 +36,7 @@ export type TableRowElement = {
 export type TableElement = {
   type: 'table'
   width: string
+  caption?: string
   children: TableRowElement[]
 
   /** resize bar */

--- a/packages/table-module/src/module/elem-to-html.ts
+++ b/packages/table-module/src/module/elem-to-html.ts
@@ -8,6 +8,15 @@ import { Element } from 'slate'
 
 import { TableCellElement, TableElement, TableRowElement } from './custom-types'
 
+function escapeHtml(raw: string): string {
+  return raw
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
 function getExportTableWidth(tableNode: TableElement): string {
   const { width = 'auto', columnWidths = [] } = tableNode
 
@@ -30,13 +39,14 @@ function getExportTableWidth(tableNode: TableElement): string {
 
 function tableToHtml(elemNode: Element, childrenHtml: string, editor?: IDomEditor): string {
   const tableNode = elemNode as TableElement
-  const { columnWidths, height = 'auto' } = tableNode
+  const { columnWidths, caption, height = 'auto' } = tableNode
   const cols = columnWidths
     ?.map(colWidth => {
       return `<col width=${colWidth}></col>`
     })
     .join('')
 
+  const captionStr = caption ? `<caption>${escapeHtml(caption)}</caption>` : ''
   const colgroupStr = cols ? `<colgroup contentEditable="false">${cols}</colgroup>` : ''
   const exportedWidth = getExportTableWidth(tableNode)
   const textStyleMode = getTextStyleMode(editor)
@@ -47,10 +57,10 @@ function tableToHtml(elemNode: Element, childrenHtml: string, editor?: IDomEdito
     const heightAttr = heightValue && heightValue !== 'auto' ? ` height="${heightValue}"` : ''
     const heightDataAttr = heightValue ? ` data-w-e-table-height="${heightValue}"` : ''
 
-    return `<table class="w-e-table-layout-fixed"${widthAttr}${heightAttr}${heightDataAttr}>${colgroupStr}<tbody>${childrenHtml}</tbody></table>`
+    return `<table class="w-e-table-layout-fixed"${widthAttr}${heightAttr}${heightDataAttr}>${captionStr}${colgroupStr}<tbody>${childrenHtml}</tbody></table>`
   }
 
-  return `<table style="width: ${exportedWidth};table-layout: fixed;height:${height}">${colgroupStr}<tbody>${childrenHtml}</tbody></table>`
+  return `<table style="width: ${exportedWidth};table-layout: fixed;height:${height}">${captionStr}${colgroupStr}<tbody>${childrenHtml}</tbody></table>`
 }
 
 function tableRowToHtml(elem: Element, childrenHtml: string, editor?: IDomEditor): string {

--- a/packages/table-module/src/module/parse-elem-html.ts
+++ b/packages/table-module/src/module/parse-elem-html.ts
@@ -131,6 +131,7 @@ function parseTableHtml(
   _editor: IDomEditor,
 ): TableElement {
   const $elem = $(elem)
+  const caption = ($elem.find('caption').text() || '').replace(/\s+/gm, ' ').trim() || undefined
 
   // 计算宽度
   let tableWidth = 'auto'
@@ -154,6 +155,7 @@ function parseTableHtml(
   const tableELement: TableElement = {
     type: 'table',
     width: tableWidth,
+    caption,
     height,
     // @ts-ignore
     children: children.filter(child => DomEditor.getNodeType(child) === 'table-row'),

--- a/packages/table-module/src/module/render-elem/render-table.tsx
+++ b/packages/table-module/src/module/render-elem/render-table.tsx
@@ -67,6 +67,7 @@ function renderTable(elemNode: SlateElement, children: VNode[] | null, editor: I
   // 宽度和高度
   const {
     width: tableWidth = 'auto',
+    caption,
     height,
     columnWidths = [],
     rowHeights = [],
@@ -145,6 +146,11 @@ function renderTable(elemNode: SlateElement, children: VNode[] | null, editor: I
           ),
         }}
       >
+        {
+          caption ? (
+            <caption contentEditable={false}>{caption}</caption>
+          ) : null
+        }
         <colgroup contentEditable={false}>
           {
             /**

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -1066,6 +1066,40 @@ test.describe('Basic Editor', () => {
     await expect(page.getByTestId('editor-html')).toContainText('<table')
   })
 
+  test('regression #335: table caption should render and survive setHtml(getHtml())', async ({ page }) => {
+    const snapshot = await page.evaluate(() => {
+      const editor = (window as any).wangEditorExampleBridge?.editor
+
+      if (!editor) {
+        throw new Error('editor not ready')
+      }
+
+      editor.setHtml(`
+        <table style="width: 100%;">
+          <caption>Table 2: Effects of contact</caption>
+          <tbody>
+            <tr><td>A</td><td>B</td></tr>
+          </tbody>
+        </table>
+      `)
+      const firstPassHtml = editor.getHtml()
+
+      editor.setHtml(firstPassHtml)
+      const secondPassHtml = editor.getHtml()
+      const domCaption = document.querySelector('[data-testid="editor-textarea"] table caption')?.textContent || ''
+
+      return {
+        firstPassHtml,
+        secondPassHtml,
+        domCaption: domCaption.trim(),
+      }
+    })
+
+    expect(snapshot.firstPassHtml).toContain('<caption>Table 2: Effects of contact</caption>')
+    expect(snapshot.secondPassHtml).toContain('<caption>Table 2: Effects of contact</caption>')
+    expect(snapshot.domCaption).toBe('Table 2: Effects of contact')
+  })
+
   test('regression #47: first inserted table should be first node and removable by select-all delete/cut', async ({ page }) => {
     await clearEditor(page)
     await waitForMenuEnabled(page, 'insertTable')


### PR DESCRIPTION
## Summary
- support parsing `<caption>` into table slate node (`caption?: string`)
- render table caption in editor DOM (`<caption contentEditable="false">`)
- include caption in exported HTML for both inline/class style modes, with escaping
- add regressions for parse/toHtml/render and Playwright round-trip

## Regression
- unit: `packages/table-module/__tests__/parse-html.test.ts`
- unit: `packages/table-module/__tests__/elem-to-html.test.ts`
- unit: `packages/table-module/__tests__/render-elem.test.ts`
- e2e: `tests/e2e/editor.spec.ts` (`regression #335`)

## Verification
- `pnpm --filter @wangeditor-next/table-module test -- __tests__/parse-html.test.ts __tests__/elem-to-html.test.ts __tests__/render-elem.test.ts`
- `PLAYWRIGHT_SKIP_BUILD=1 pnpm exec playwright test tests/e2e/editor.spec.ts -g "regression #335"`
- `pnpm --filter @wangeditor-next/table-module build && pnpm --filter @wangeditor-next/editor build`

Closes #335


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for table captions with full parsing and rendering
  * Captions are imported from HTML and correctly parsed into tables
  * Captions render in the editor for viewing and editing
  * Captions export back to HTML maintaining data integrity
  * Caption text is HTML-escaped to ensure security against injection
  * Round-trip conversions fully supported: captions persist through edit/save cycles

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/864?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->