### PR TITLE
feat(table): support configurable insertTableCol before/after

### DIFF
--- a/.changeset/shiny-lies-flow.md
+++ b/.changeset/shiny-lies-flow.md
@@ -1,0 +1,6 @@
+---
+'@wangeditor-next/core': patch
+'@wangeditor-next/table-module': patch
+---
+
+add configurable table column insert position (before/after current column)

--- a/packages/core/src/config/interface.ts
+++ b/packages/core/src/config/interface.ts
@@ -124,6 +124,10 @@ interface IInsertTableConfig {
   }
 }
 
+interface IInsertTableColConfig {
+  insertPosition: 'before' | 'after';
+}
+
 interface ILinkConfig {
   checkLink: (text:string, url:string)=> string | boolean | undefined
   parseLinkUrl: (url: string) => string
@@ -203,7 +207,7 @@ export interface IMenuConfig {
   deleteTable: ISingleMenuConfig;
   insertTableRow: IInsertTableConfig;
   deleteTableRow: ISingleMenuConfig;
-  insertTableCol: ISingleMenuConfig;
+  insertTableCol: IInsertTableColConfig;
   deleteTableCol: ISingleMenuConfig;
   tableHeader: ISingleMenuConfig;
   tableFullWidth: ISingleMenuConfig;

--- a/packages/table-module/__tests__/menu/insert-col.test.ts
+++ b/packages/table-module/__tests__/menu/insert-col.test.ts
@@ -162,7 +162,7 @@ describe('Table Module Insert Col Menu', () => {
           type: 'table-cell',
           children: [],
         } as slate.Element,
-        [0, 1],
+        [0, 0, 0],
       ] as slate.NodeEntry<slate.Element>
     }
 
@@ -184,7 +184,7 @@ describe('Table Module Insert Col Menu', () => {
           type: 'table-cell',
           children: [],
         } as slate.Element,
-        [0, 1],
+        [0, 0, 0],
       ] as slate.NodeEntry<slate.Element>
     }
 
@@ -208,7 +208,7 @@ describe('Table Module Insert Col Menu', () => {
           type: 'table-cell',
           children: [],
         } as slate.Element,
-        [0, 1],
+        [0, 0, 0],
       ] as slate.NodeEntry<slate.Element>
     }
 
@@ -373,6 +373,92 @@ describe('Table Module Insert Col Menu', () => {
     expect(table.children[0].children).toHaveLength(3)
     expect(table.children[0].children[0].isHeader).toBe(true)
     expect(table.children[1].children).toHaveLength(3)
+  })
+
+  test('exec should insert column after current column when insertPosition is after', () => {
+    const insertColMenu = new InsertCol()
+    const editor = createEditor({
+      content: [
+        {
+          type: 'table',
+          columnWidths: [120, 80],
+          children: [
+            {
+              type: 'table-row',
+              children: [
+                { type: 'table-cell', isHeader: true, children: [{ text: 'h1' }] },
+                { type: 'table-cell', isHeader: true, children: [{ text: 'h2' }] },
+              ],
+            },
+            {
+              type: 'table-row',
+              children: [
+                { type: 'table-cell', children: [{ text: 'a1' }] },
+                { type: 'table-cell', children: [{ text: 'a2' }] },
+              ],
+            },
+          ],
+        },
+      ],
+      config: {
+        MENU_CONF: {
+          insertTable: {
+            minWidth: '60',
+          },
+          insertTableCol: {
+            insertPosition: 'after',
+          },
+        },
+      },
+    })
+
+    editor.selection = {
+      anchor: { path: [0, 0, 0, 0], offset: 0 },
+      focus: { path: [0, 0, 0, 0], offset: 0 },
+    }
+
+    mockedUtils.filledMatrix.mockImplementation(() => {
+      return [
+        [
+          [
+            [{ type: 'table-cell', isHeader: true, children: [{ text: 'h1' }] }, [0, 0, 0]],
+            {
+              rtl: 1, ltr: 1, ttb: 1, btt: 1,
+            },
+          ],
+          [
+            [{ type: 'table-cell', isHeader: true, children: [{ text: 'h2' }] }, [0, 0, 1]],
+            {
+              rtl: 1, ltr: 1, ttb: 1, btt: 1,
+            },
+          ],
+        ],
+        [
+          [
+            [{ type: 'table-cell', children: [{ text: 'a1' }] }, [0, 1, 0]],
+            {
+              rtl: 1, ltr: 1, ttb: 1, btt: 1,
+            },
+          ],
+          [
+            [{ type: 'table-cell', children: [{ text: 'a2' }] }, [0, 1, 1]],
+            {
+              rtl: 1, ltr: 1, ttb: 1, btt: 1,
+            },
+          ],
+        ],
+      ]
+    })
+
+    insertColMenu.exec(editor, '')
+
+    const table = editor.children[0] as any
+
+    expect(table.columnWidths).toEqual([60, 60, 80])
+    expect(table.children[0].children).toHaveLength(3)
+    expect(table.children[0].children[1].isHeader).toBe(true)
+    expect(table.children[0].children.map((cell: any) => cell.children[0]?.text ?? '')).toEqual(['h1', '', 'h2'])
+    expect(table.children[1].children.map((cell: any) => cell.children[0]?.text ?? '')).toEqual(['a1', '', 'a2'])
   })
 
   test('isDisabled should fail closed when matrix inspection throws', () => {

--- a/packages/table-module/src/module/menu/InsertCol.ts
+++ b/packages/table-module/src/module/menu/InsertCol.ts
@@ -113,7 +113,7 @@ class InsertCol implements IButtonMenu {
     if (tableNode == null) { return }
 
     const matrix = filledMatrix(editor)
-    let tdIndex = 0
+    let tdIndex = -1
 
     for (let x = 0; x < matrix.length; x += 1) {
       for (let y = 0; y < matrix[x].length; y += 1) {
@@ -124,7 +124,19 @@ class InsertCol implements IButtonMenu {
           break
         }
       }
+      if (tdIndex !== -1) { break }
     }
+
+    if (tdIndex === -1) { return }
+
+    const selectedColSpan = (selectedCellNode as TableCellElement).colSpan || 1
+    const { insertPosition = 'before' } = editor.getMenuConfig('insertTableCol') || {}
+    const normalizedInsertPosition = insertPosition === 'after' ? 'after' : 'before'
+    const totalCols = matrix[0]?.length || 0
+    const insertColIndex = normalizedInsertPosition === 'after'
+      ? Math.min(tdIndex + selectedColSpan, totalCols)
+      : tdIndex
+    const mergeInspectColIndex = insertColIndex < totalCols ? insertColIndex : -1
 
     Editor.withoutNormalizing(editor, () => {
       // 记录已处理的合并单元格和需要跳过插入的行
@@ -133,14 +145,18 @@ class InsertCol implements IButtonMenu {
 
       // 遍历每一行的第 tdIndex 列，处理合并单元格
       for (let x = 0; x < matrix.length; x += 1) {
+        if (mergeInspectColIndex < 0) {
+          continue
+        }
+
         // 安全检查：确保行和列都存在
-        if (!matrix[x] || !matrix[x][tdIndex]) {
+        if (!matrix[x] || !matrix[x][mergeInspectColIndex]) {
           continue
         }
 
         const [[,], {
           rtl, ltr, ttb, btt,
-        }] = matrix[x][tdIndex]
+        }] = matrix[x][mergeInspectColIndex]
 
         // 判断是否是合并单元格
         if (rtl > 1 || ltr > 1 || ttb > 1 || btt > 1) {
@@ -149,7 +165,7 @@ class InsertCol implements IButtonMenu {
           // rtl表示从右到左的距离，所以真实单元格列 = 当前列 - (rtl - 1)
           // ttb表示从上到下的距离，所以真实单元格行 = 当前行 - (ttb - 1)
           const realCellRow = x - (ttb - 1)
-          const realCellCol = tdIndex - (rtl - 1)
+          const realCellCol = mergeInspectColIndex - (rtl - 1)
 
           // 安全检查：确保真实单元格位置存在
           if (realCellRow < 0 || realCellRow >= matrix.length
@@ -197,8 +213,10 @@ class InsertCol implements IButtonMenu {
           continue
         }
 
+        const currentRow = matrix[x]
+
         // 安全检查：确保矩阵位置存在
-        if (!matrix[x] || !matrix[x][tdIndex]) {
+        if (!currentRow || currentRow.length === 0) {
           continue
         }
 
@@ -212,7 +230,17 @@ class InsertCol implements IButtonMenu {
           newCell.isHeader = true
         }
 
-        const [[, insertPath]] = matrix[x][tdIndex]
+        let insertPath: Path
+
+        if (insertColIndex < currentRow.length) {
+          const [[, pathAtInsertCol]] = currentRow[insertColIndex]
+
+          insertPath = pathAtInsertCol as Path
+        } else {
+          const [[, lastCellPath]] = currentRow[currentRow.length - 1]
+
+          insertPath = Path.next(lastCellPath as Path)
+        }
 
         Transforms.insertNodes(editor, newCell, { at: insertPath })
       }
@@ -230,16 +258,22 @@ class InsertCol implements IButtonMenu {
 
         // 获取当前列的宽度，如果没有设置则使用默认宽度
         const { minWidth = 60 } = editor.getMenuConfig('insertTable')
-        const currentColWidth = columnWidths[tdIndex] || parseInt(minWidth, 10) || 60
+        const currentColWidth = columnWidths[tdIndex] || parseInt(minWidth.toString(), 10) || 60
 
         // 将当前列宽度一分为二
         const halfWidth = Math.floor(currentColWidth / 2)
         const remainingWidth = currentColWidth - halfWidth
 
-        // 在当前位置插入新列（左侧），使用一半宽度
-        adjustColumnWidths.splice(tdIndex, 0, halfWidth)
-        // 更新原列宽度为剩余的一半
-        adjustColumnWidths[tdIndex + 1] = remainingWidth
+        if (normalizedInsertPosition === 'after') {
+          // 在当前位置后插入新列（右侧）
+          adjustColumnWidths[tdIndex] = remainingWidth
+          adjustColumnWidths.splice(tdIndex + 1, 0, halfWidth)
+        } else {
+          // 在当前位置前插入新列（左侧）
+          adjustColumnWidths.splice(tdIndex, 0, halfWidth)
+          // 更新原列宽度为剩余的一半
+          adjustColumnWidths[tdIndex + 1] = remainingWidth
+        }
 
         Transforms.setNodes(editor, { columnWidths: adjustColumnWidths } as TableElement, {
           at: tablePath,

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -757,6 +757,53 @@ test.describe('Basic Editor', () => {
     ).toHaveCount(1)
   })
 
+  test('regression #156: insertTableCol should insert after current column when configured', async ({ page }) => {
+    await page.evaluate(() => {
+      const editor = (window as any).wangEditorExampleBridge?.editor
+
+      if (!editor) {
+        throw new Error('editor not ready')
+      }
+
+      const editorConfig = editor.getConfig?.()
+
+      if (!editorConfig?.MENU_CONF) {
+        throw new Error('editor config not ready')
+      }
+
+      editorConfig.MENU_CONF.insertTableCol = {
+        ...(editorConfig.MENU_CONF.insertTableCol || {}),
+        insertPosition: 'after',
+      }
+      editor.setHtml(`
+        <table style="width: 100%;">
+          <tbody>
+            <tr><td>A</td><td>B</td></tr>
+          </tbody>
+        </table>
+      `)
+    })
+
+    await page.locator('[data-testid="editor-textarea"] table td').first().click()
+    await page.locator('.w-e-hover-bar [data-menu-key="insertTableCol"]').click({ force: true })
+    await expect(
+      page.locator('[data-testid="editor-textarea"] table tr').first().locator('th, td'),
+    ).toHaveCount(3)
+
+    const firstRowTexts = await page.evaluate(() => {
+      const editor = (window as any).wangEditorExampleBridge?.editor
+      const tableNode = editor?.children?.find((node: any) => node?.type === 'table')
+
+      if (!tableNode) {
+        throw new Error('table node not found')
+      }
+
+      return tableNode.children[0].children.map((cell: any) => cell?.children?.[0]?.text ?? '')
+    })
+
+    expect(firstRowTexts).toEqual(['A', '', 'B'])
+  })
+
   test('regression #811: row resize hotzone should follow rendered row border after content expands', async ({ page }) => {
     await clearEditor(page)
     await page.keyboard.type('table-resize-probe')


### PR DESCRIPTION
## Summary
- add `insertTableCol.insertPosition` config (`before` | `after`) to support mainstream table UX
- keep backward compatibility by defaulting to `before`
- make insert-col path resolution robust for end-of-row insertion and merged-cell boundaries
- keep column width splitting behavior while supporting both positions

## Tests
- unit: `pnpm --filter @wangeditor-next/table-module test -- __tests__/menu/insert-col.test.ts`
- e2e: `PLAYWRIGHT_SKIP_BUILD=1 pnpm exec playwright test tests/e2e/editor.spec.ts -g "regression #156"`
- lint: `pnpm exec eslint packages/core/src/config/interface.ts packages/table-module/src/module/menu/InsertCol.ts packages/table-module/__tests__/menu/insert-col.test.ts tests/e2e/editor.spec.ts --max-warnings=0`

## Notes
- default behavior is unchanged (`before`), so existing integrations are not broken
- to opt in: `MENU_CONF.insertTableCol = { insertPosition: 'after' }`

Closes #156


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Table column insertion now supports configurable positioning, allowing columns to be inserted before or after the currently selected column for improved table editing flexibility.

* **Tests**
  * Added regression test validating correct column insertion behavior when the insert position is configured to 'after'.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/866?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->