### PR TITLE
feat(code-block): add optional copy button for code blocks

### DIFF
--- a/.changeset/fuzzy-kids-yell.md
+++ b/.changeset/fuzzy-kids-yell.md
@@ -1,0 +1,6 @@
+---
+'@wangeditor-next/basic-modules': patch
+'@wangeditor-next/core': patch
+---
+
+add optional code-block copy button support via MENU_CONF.codeBlock.showCopyButton

--- a/packages/basic-modules/__tests__/code-block/render-elem.test.ts
+++ b/packages/basic-modules/__tests__/code-block/render-elem.test.ts
@@ -30,4 +30,34 @@ describe('code-block render elem', () => {
 
     expect(vnode.sel).toBe('pre')
   })
+
+  it('render pre elem should include copy button when enabled by config', () => {
+    const editorWithCopyButton = createEditor({
+      config: {
+        MENU_CONF: {
+          codeBlock: {
+            showCopyButton: true,
+          },
+        },
+      },
+    })
+
+    const elem = {
+      type: 'pre',
+      children: [
+        {
+          type: 'code',
+          language: '',
+          children: [{ text: 'const a = 1' }],
+        },
+      ],
+    }
+    const vnode = renderPreConf.renderElem(elem, null, editorWithCopyButton) as any
+    const buttonVNode = vnode.children?.[0]
+
+    expect(vnode.sel).toBe('pre')
+    expect(vnode.data?.className).toBe('w-e-code-block')
+    expect(buttonVNode.sel).toBe('button')
+    expect(buttonVNode.data?.className).toBe('w-e-code-block-copy-button')
+  })
 })

--- a/packages/basic-modules/src/assets/code-block.less
+++ b/packages/basic-modules/src/assets/code-block.less
@@ -1,3 +1,27 @@
-// pre>code 样式已移至 code-highlight 模块以避免重复
-// 此文件保留为空，但不删除以保持模块结构完整
+.w-e-text-container [data-slate-editor] pre.w-e-code-block {
+  position: relative;
 
+  .w-e-code-block-copy-button {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    z-index: 1;
+    min-width: 56px;
+    height: 24px;
+    padding: 0 8px;
+    border: 1px solid var(--w-e-textarea-slight-border-color);
+    border-radius: 4px;
+    background-color: #fff;
+    color: #666;
+    font-size: 12px;
+    line-height: 1;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity .15s ease;
+  }
+
+  &:hover .w-e-code-block-copy-button,
+  .w-e-code-block-copy-button:focus {
+    opacity: 1;
+  }
+}

--- a/packages/basic-modules/src/locale/en.ts
+++ b/packages/basic-modules/src/locale/en.ts
@@ -16,6 +16,9 @@ export default {
   },
   codeBlock: {
     title: 'Code block',
+    copy: 'Copy',
+    copied: 'Copied',
+    copyFailed: 'Copy failed',
   },
   color: {
     color: 'Font color',

--- a/packages/basic-modules/src/locale/zh-CN.ts
+++ b/packages/basic-modules/src/locale/zh-CN.ts
@@ -16,6 +16,9 @@ export default {
   },
   codeBlock: {
     title: '代码块',
+    copy: '复制',
+    copied: '已复制',
+    copyFailed: '复制失败',
   },
   color: {
     color: '文字颜色',

--- a/packages/basic-modules/src/modules/code-block/menu/index.ts
+++ b/packages/basic-modules/src/modules/code-block/menu/index.ts
@@ -7,6 +7,9 @@ import CodeBlockMenu from './CodeBlockMenu'
 
 export const codeBlockMenuConf = {
   key: 'codeBlock',
+  config: {
+    showCopyButton: false,
+  },
   factory() {
     return new CodeBlockMenu()
   },

--- a/packages/basic-modules/src/modules/code-block/render-elem.tsx
+++ b/packages/basic-modules/src/modules/code-block/render-elem.tsx
@@ -3,13 +3,115 @@
  * @author wangfupeng
  */
 
-import { IDomEditor } from '@wangeditor-next/core'
+import { IDomEditor, t } from '@wangeditor-next/core'
 import { Element as SlateElement } from 'slate'
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { jsx, VNode } from 'snabbdom'
 
-function renderPre(_elemNode: SlateElement, children: VNode[] | null, _editor: IDomEditor): VNode {
-  const vnode = <pre>{children}</pre>
+import { CodeElement, PreElement } from './custom-types'
+
+function getCodeText(elemNode: SlateElement): string {
+  const { children = [] } = elemNode as PreElement
+
+  return (children as CodeElement[])
+    .map(codeElem => {
+      const codeTextChildren = codeElem.children || []
+
+      return codeTextChildren.map(textNode => textNode.text || '').join('')
+    })
+    .join('\n')
+}
+
+function copyWithExecCommand(text: string): boolean {
+  const textarea = document.createElement('textarea')
+
+  textarea.value = text
+  textarea.setAttribute('readonly', 'readonly')
+  textarea.style.position = 'fixed'
+  textarea.style.top = '-9999px'
+  textarea.style.left = '-9999px'
+  document.body.appendChild(textarea)
+  textarea.select()
+  textarea.setSelectionRange(0, textarea.value.length)
+  const copied = document.execCommand('copy')
+
+  document.body.removeChild(textarea)
+  return copied
+}
+
+async function copyCodeText(text: string): Promise<boolean> {
+  if (text === '') { return true }
+
+  try {
+    if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text)
+      return true
+    }
+  } catch (err) {
+    // ignore
+  }
+
+  try {
+    return copyWithExecCommand(text)
+  } catch (err) {
+    return false
+  }
+}
+
+function setButtonText(buttonElem: HTMLButtonElement, text: string, defaultText: string) {
+  const timerId = Number(buttonElem.dataset.copyResetTimer || 0)
+
+  if (timerId) {
+    window.clearTimeout(timerId)
+  }
+
+  buttonElem.textContent = text
+  const resetTimerId = window.setTimeout(() => {
+    buttonElem.textContent = defaultText
+    delete buttonElem.dataset.copyResetTimer
+  }, 1200)
+
+  buttonElem.dataset.copyResetTimer = `${resetTimerId}`
+}
+
+function renderPre(elemNode: SlateElement, children: VNode[] | null, editor: IDomEditor): VNode {
+  const { showCopyButton = false } = editor.getMenuConfig('codeBlock') || {}
+
+  if (!showCopyButton) {
+    return <pre>{children}</pre>
+  }
+
+  const codeText = getCodeText(elemNode)
+  const copyText = t('codeBlock.copy')
+  const copiedText = t('codeBlock.copied')
+  const copyFailedText = t('codeBlock.copyFailed')
+  const vnode = (
+    <pre className="w-e-code-block">
+      <button
+        className="w-e-code-block-copy-button"
+        contentEditable={false}
+        on={{
+          mousedown: (e: MouseEvent) => {
+            e.preventDefault()
+            e.stopPropagation()
+          },
+          click: async (e: MouseEvent) => {
+            e.preventDefault()
+            e.stopPropagation()
+            const buttonElem = (e.currentTarget || e.target) as HTMLButtonElement | null
+
+            if (buttonElem == null) { return }
+            const copied = await copyCodeText(codeText)
+
+            setButtonText(buttonElem, copied ? copiedText : copyFailedText, copyText)
+          },
+        }}
+      >
+        {copyText}
+      </button>
+      {children}
+    </pre>
+  )
 
   return vnode
 }

--- a/packages/core/src/config/interface.ts
+++ b/packages/core/src/config/interface.ts
@@ -150,6 +150,10 @@ interface ICodeLangConfig {
   codeLangs: { text: string; value: string; selected?: boolean }[];
 }
 
+interface ICodeBlockConfig {
+  showCopyButton?: boolean;
+}
+
 export interface IMenuConfig {
   bold: ISingleMenuConfig;
   underline: ISingleMenuConfig;
@@ -185,7 +189,7 @@ export interface IMenuConfig {
   editLink: ILinkConfig;
   unLink: ISingleMenuConfig;
   viewLink: ISingleMenuConfig;
-  codeBlock: ISingleMenuConfig;
+  codeBlock: ICodeBlockConfig;
   blockquote: ISingleMenuConfig;
   headerSelect: ISingleMenuConfig;
   header1: ISingleMenuConfig;

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -1280,6 +1280,57 @@ test.describe('Basic Editor', () => {
     await expect(page.getByTestId('editor-html')).toContainText('<code')
   })
 
+  test('regression #173: code block copy button should copy code text when enabled', async ({ page }) => {
+    await page.evaluate(() => {
+      const editor = (window as any).wangEditorExampleBridge?.editor
+
+      if (!editor) {
+        throw new Error('editor not ready')
+      }
+      const editorConfig = editor.getConfig?.()
+
+      if (!editorConfig?.MENU_CONF) {
+        throw new Error('editor config not ready')
+      }
+      const win = window as any
+
+      editorConfig.MENU_CONF.codeBlock = {
+        ...(editorConfig.MENU_CONF.codeBlock || {}),
+        showCopyButton: true,
+      }
+
+      win.e2eCopiedCodeText = ''
+
+      const clipboardMock = {
+        writeText: async (text: string) => {
+          win.e2eCopiedCodeText = text
+        },
+      }
+
+      try {
+        Object.defineProperty(window.navigator, 'clipboard', {
+          configurable: true,
+          value: clipboardMock,
+        })
+      } catch (err) {
+        // @ts-ignore
+        window.navigator.clipboard = clipboardMock
+      }
+
+      editor.setHtml(`<pre><code>const a = 1
+console.log(a)</code></pre>`)
+    })
+
+    const copyButton = page.locator('[data-testid="editor-textarea"] .w-e-code-block-copy-button')
+
+    await expect(copyButton).toBeVisible()
+    await copyButton.click()
+
+    const copiedText = await page.evaluate(() => (window as any).e2eCopiedCodeText || '')
+
+    expect(copiedText).toBe('const a = 1\nconsole.log(a)')
+  })
+
   test('toggles readOnly via button', async ({ page }) => {
     await expect(page.locator('#w-e-textarea-1')).toHaveAttribute('contenteditable', 'true')
     await page.getByTestId('btn-toggle-enable').dispatchEvent('mousedown')


### PR DESCRIPTION
## Summary
- add optional code-block copy button support (GitHub-style) for `pre` blocks
- expose config: `MENU_CONF.codeBlock.showCopyButton` (`false` by default)
- copy uses `navigator.clipboard.writeText` first, with `execCommand('copy')` fallback
- add copy status text (`Copy/Copied/Copy failed`) in zh/en locales
- add style for top-right hover copy button in code blocks

## Tests
- unit: `pnpm --filter @wangeditor-next/basic-modules test -- __tests__/code-block/render-elem.test.ts`
- e2e: `PLAYWRIGHT_SKIP_BUILD=1 pnpm exec playwright test tests/e2e/editor.spec.ts -g "regression #173"`
- lint: `pnpm exec eslint packages/core/src/config/interface.ts packages/basic-modules/src/modules/code-block/menu/index.ts packages/basic-modules/src/modules/code-block/render-elem.tsx packages/basic-modules/src/locale/zh-CN.ts packages/basic-modules/src/locale/en.ts packages/basic-modules/__tests__/code-block/render-elem.test.ts tests/e2e/editor.spec.ts --max-warnings=0`

## Usage
```ts
editorConfig.MENU_CONF['codeBlock'] = {
  showCopyButton: true,
}
```

Closes #173


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Code blocks now support an optional copy button with automatic clipboard integration
  * Copy button displays localized status messages (copied/copy failed) and can be toggled via configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/867?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->