### PR TITLE
fix(indent): limit indent to paragraph and header blocks

### DIFF
--- a/.changeset/thin-cobras-fry.md
+++ b/.changeset/thin-cobras-fry.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/basic-modules': patch
+---
+
+limit indent behavior to paragraph and header nodes to avoid affecting other block elements

--- a/packages/basic-modules/__tests__/indent/menu/decrease-indent-menu.test.ts
+++ b/packages/basic-modules/__tests__/indent/menu/decrease-indent-menu.test.ts
@@ -48,4 +48,24 @@ describe('decrease indent menu', () => {
     menu.exec(editor, '')
     expect(menu.getValue(editor)).toBe('')
   })
+
+  it('exec should only clear indent from paragraph/header nodes', () => {
+    editor = createEditor({
+      content: [
+        { type: 'paragraph', indent: '2em', children: [{ text: 'hello' }] },
+        {
+          type: 'blockquote',
+          indent: '2em',
+          children: [{ text: 'quote' }],
+        },
+      ] as any,
+    })
+
+    editor.select([])
+    menu.exec(editor, '')
+
+    expect((editor.children[0] as any).indent).toBeFalsy()
+    expect((editor.children[1] as any).type).toBe('blockquote')
+    expect((editor.children[1] as any).indent).toBe('2em')
+  })
 })

--- a/packages/basic-modules/__tests__/indent/menu/increase-indent-menu.test.ts
+++ b/packages/basic-modules/__tests__/indent/menu/increase-indent-menu.test.ts
@@ -57,4 +57,23 @@ describe('increase indent menu', () => {
 
     expect(menu.getValue(editor)).toBe('36px')
   })
+
+  it('exec should only apply indent to paragraph/header nodes', () => {
+    editor = createEditor({
+      content: [
+        { type: 'paragraph', children: [{ text: 'hello' }] },
+        {
+          type: 'blockquote',
+          children: [{ text: 'quote' }],
+        },
+      ] as any,
+    })
+
+    editor.select([])
+    menu.exec(editor, '')
+
+    expect((editor.children[0] as any).indent).toBe('2em')
+    expect((editor.children[1] as any).type).toBe('blockquote')
+    expect((editor.children[1] as any).indent).toBeUndefined()
+  })
 })

--- a/packages/basic-modules/__tests__/indent/parse-html.test.ts
+++ b/packages/basic-modules/__tests__/indent/parse-html.test.ts
@@ -44,6 +44,21 @@ describe('indent - parse style', () => {
       children: [{ text: 'hello' }],
     })
   })
+
+  it('should ignore non-indent target elements', () => {
+    const $img = $('<img style="text-indent: 2em;" />')
+    const image = {
+      type: 'image',
+      src: 'https://example.com/1.png',
+      href: '',
+      alt: '',
+      style: {},
+      children: [{ text: '' }],
+    } as any
+    const res = parseStyleHtml($img[0], image, editor) as any
+
+    expect(res.indent).toBeUndefined()
+  })
 })
 
 describe('indent - pre parse html', () => {

--- a/packages/basic-modules/__tests__/indent/render-text-style.test.tsx
+++ b/packages/basic-modules/__tests__/indent/render-text-style.test.tsx
@@ -41,4 +41,15 @@ describe('indent - render text style', () => {
     // @ts-ignore
     expect(newVnode.data.dataset.wEIndent).toBe(indent)
   })
+
+  it('should not render indent style for non-target elements', () => {
+    const elem = { type: 'image', indent: '2em', children: [{ text: '' }] }
+    const vnode = <img src="https://example.com/1.png" />
+
+    // @ts-ignore
+    const newVnode = renderStyle(elem, vnode)
+
+    // @ts-ignore
+    expect(newVnode.data?.style?.textIndent).toBeUndefined()
+  })
 })

--- a/packages/basic-modules/__tests__/indent/text-style-to-html.test.ts
+++ b/packages/basic-modules/__tests__/indent/text-style-to-html.test.ts
@@ -28,4 +28,16 @@ describe('indent - text style to html', () => {
     expect(html).toContain('data-w-e-indent="2em"')
     expect(html).not.toContain('style=')
   })
+
+  it('should keep non-target html unchanged', () => {
+    const elem = {
+      type: 'image',
+      indent: '2em',
+      src: 'https://example.com/1.png',
+      children: [{ text: '' }],
+    } as any
+    const html = styleToHtml(elem, '<img src="https://example.com/1.png">')
+
+    expect(html).toBe('<img src="https://example.com/1.png">')
+  })
 })

--- a/packages/basic-modules/src/modules/indent/is-indent-target.ts
+++ b/packages/basic-modules/src/modules/indent/is-indent-target.ts
@@ -1,0 +1,16 @@
+/**
+ * @description indent target matcher
+ */
+
+import { Element } from 'slate'
+
+export function isIndentTargetElement(node: unknown): boolean {
+  if (!Element.isElement(node)) { return false }
+
+  const type = (node as any).type
+
+  if (type === 'paragraph') { return true }
+  if (typeof type === 'string' && type.startsWith('header')) { return true }
+
+  return false
+}

--- a/packages/basic-modules/src/modules/indent/menu/BaseMenu.ts
+++ b/packages/basic-modules/src/modules/indent/menu/BaseMenu.ts
@@ -3,8 +3,10 @@
  * @author wangfupeng
  */
 
-import { DomEditor, IButtonMenu, IDomEditor } from '@wangeditor-next/core'
+import { IButtonMenu, IDomEditor } from '@wangeditor-next/core'
 import { Editor, Node } from 'slate'
+
+import { isIndentTargetElement } from '../is-indent-target'
 
 abstract class BaseMenu implements IButtonMenu {
   abstract readonly title: string
@@ -42,15 +44,7 @@ abstract class BaseMenu implements IButtonMenu {
    */
   protected getMatchNode(editor: IDomEditor): Node | null {
     const [nodeEntry] = Editor.nodes(editor, {
-      match: n => {
-        const type = DomEditor.getNodeType(n)
-
-        // 只可用于 p 和 header
-        if (type === 'paragraph') { return true }
-        if (type.startsWith('header')) { return true }
-
-        return false
-      },
+      match: isIndentTargetElement,
       universal: true,
       mode: 'highest', // 匹配最高层级
     })

--- a/packages/basic-modules/src/modules/indent/menu/DecreaseIndentMenu.ts
+++ b/packages/basic-modules/src/modules/indent/menu/DecreaseIndentMenu.ts
@@ -4,10 +4,11 @@
  */
 
 import { IDomEditor, t } from '@wangeditor-next/core'
-import { Element, Transforms } from 'slate'
+import { Transforms } from 'slate'
 
 import { INDENT_LEFT_SVG } from '../../../constants/icon-svg'
 import { IndentElement } from '../custom-types'
+import { isIndentTargetElement } from '../is-indent-target'
 import BaseMenu from './BaseMenu'
 
 class DecreaseIndentMenu extends BaseMenu {
@@ -36,7 +37,10 @@ class DecreaseIndentMenu extends BaseMenu {
       {
         indent: null,
       },
-      { match: n => Element.isElement(n) },
+      {
+        match: isIndentTargetElement,
+        mode: 'highest',
+      },
     )
   }
 }

--- a/packages/basic-modules/src/modules/indent/menu/IncreaseIndentMenu.ts
+++ b/packages/basic-modules/src/modules/indent/menu/IncreaseIndentMenu.ts
@@ -11,6 +11,7 @@ import {
 import { INDENT_RIGHT_SVG } from '../../../constants/icon-svg'
 import type { FontSizeAndFamilyText } from '../../font-size-family/custom-types'
 import { IndentElement } from '../custom-types'
+import { isIndentTargetElement } from '../is-indent-target'
 import BaseMenu from './BaseMenu'
 
 class IncreaseIndentMenu extends BaseMenu {
@@ -62,7 +63,7 @@ class IncreaseIndentMenu extends BaseMenu {
         indent,
       },
       {
-        match: n => Element.isElement(n),
+        match: isIndentTargetElement,
         mode: 'highest',
       },
     )

--- a/packages/basic-modules/src/modules/indent/parse-style-html.ts
+++ b/packages/basic-modules/src/modules/indent/parse-style-html.ts
@@ -9,11 +9,13 @@ import { Descendant, Element } from 'slate'
 import $, { DOMElement, getStyleValue } from '../../utils/dom'
 import { getStyleValueFromDataOrClass } from '../../utils/style-class'
 import { IndentElement } from './custom-types'
+import { isIndentTargetElement } from './is-indent-target'
 
 export function parseStyleHtml(elem: DOMElement, node: Descendant, _editor: IDomEditor): Descendant {
   const $elem = $(elem)
 
   if (!Element.isElement(node)) { return node }
+  if (!isIndentTargetElement(node)) { return node }
 
   const elemNode = node as IndentElement
 

--- a/packages/basic-modules/src/modules/indent/render-style.tsx
+++ b/packages/basic-modules/src/modules/indent/render-style.tsx
@@ -10,6 +10,7 @@ import { VNode } from 'snabbdom'
 import { appendVnodeStyleClassAndData, getTextStyleMode } from '../../utils/style-class'
 import { addVnodeStyle } from '../../utils/vdom'
 import { IndentElement } from './custom-types'
+import { isIndentTargetElement } from './is-indent-target'
 
 /**
  * 添加样式
@@ -20,6 +21,7 @@ import { IndentElement } from './custom-types'
  */
 export function renderStyle(node: Descendant, vnode: VNode, editor?: IDomEditor): VNode {
   if (!Element.isElement(node)) { return vnode }
+  if (!isIndentTargetElement(node)) { return vnode }
 
   const { indent } = node as IndentElement // 如 '2em'
   const styleVnode: VNode = vnode

--- a/packages/basic-modules/src/modules/indent/style-to-html.ts
+++ b/packages/basic-modules/src/modules/indent/style-to-html.ts
@@ -9,9 +9,11 @@ import { Descendant, Element } from 'slate'
 import $, { getOuterHTML } from '../../utils/dom'
 import { appendStyleClassAndData, getTextStyleMode } from '../../utils/style-class'
 import { IndentElement } from './custom-types'
+import { isIndentTargetElement } from './is-indent-target'
 
 export function styleToHtml(node: Descendant, elemHtml: string, editor?: IDomEditor): string {
   if (!Element.isElement(node)) { return elemHtml }
+  if (!isIndentTargetElement(node)) { return elemHtml }
 
   const { indent } = node as IndentElement // 如 '2em'
 

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -1280,6 +1280,44 @@ test.describe('Basic Editor', () => {
     await expect(page.getByTestId('editor-html')).toContainText('<code')
   })
 
+  test('regression #58: indent should only affect paragraph/header when selecting mixed blocks', async ({ page }) => {
+    await page.evaluate(() => {
+      const editor = (window as any).wangEditorExampleBridge?.editor
+
+      if (!editor) {
+        throw new Error('editor not ready')
+      }
+
+      editor.setHtml('<p>before image</p><img src="https://example.com/1.png">')
+    })
+
+    await selectAll(page)
+    const groupIndent = await waitForMenuEnabled(page, 'group-indent')
+
+    await groupIndent.hover()
+    const groupPanel = groupIndent.locator('..').locator('.w-e-bar-item-menus-container')
+
+    await groupPanel.waitFor({ state: 'visible' })
+    await groupPanel.locator('[data-menu-key="indent"]').click({ force: true })
+
+    const snapshot = await page.evaluate(() => {
+      const editor = (window as any).wangEditorExampleBridge?.editor
+      const paragraphNode = editor?.children?.find((node: any) => node?.type === 'paragraph')
+      const imageNode = editor?.children?.find((node: any) => node?.type === 'image')
+      const html = editor?.getHtml?.() || ''
+
+      return {
+        paragraphIndent: paragraphNode?.indent || '',
+        imageIndent: imageNode?.indent || '',
+        html,
+      }
+    })
+
+    expect(snapshot.paragraphIndent).toBe('2em')
+    expect(snapshot.imageIndent).toBe('')
+    expect(snapshot.html).not.toMatch(/<img[^>]*text-indent/i)
+  })
+
   test('regression #173: code block copy button should copy code text when enabled', async ({ page }) => {
     await page.evaluate(() => {
       const editor = (window as any).wangEditorExampleBridge?.editor


### PR DESCRIPTION
## Summary
- restrict indent behavior to paragraph/header nodes only
- avoid applying `indent` to non-target blocks (for example image/blockquote/table)
- make render/toHtml/parseHtml indent pipeline ignore non-target nodes
- keep backward compatibility for existing paragraph/header indent behavior

## Why
Issue #58 (related #5911) reports odd indent behavior in mixed-content selections. Mainstream editors typically scope paragraph indent to text block containers, not every element node.

## Tests
- `pnpm --filter @wangeditor-next/basic-modules test -- __tests__/indent/menu/increase-indent-menu.test.ts __tests__/indent/menu/decrease-indent-menu.test.ts __tests__/indent/parse-html.test.ts __tests__/indent/render-text-style.test.tsx __tests__/indent/text-style-to-html.test.ts`
- `PLAYWRIGHT_SKIP_BUILD=1 pnpm exec playwright test tests/e2e/editor.spec.ts -g "regression #58"`
- `pnpm exec eslint packages/basic-modules/src/modules/indent/is-indent-target.ts packages/basic-modules/src/modules/indent/menu/BaseMenu.ts packages/basic-modules/src/modules/indent/menu/IncreaseIndentMenu.ts packages/basic-modules/src/modules/indent/menu/DecreaseIndentMenu.ts packages/basic-modules/src/modules/indent/render-style.tsx packages/basic-modules/src/modules/indent/style-to-html.ts packages/basic-modules/src/modules/indent/parse-style-html.ts packages/basic-modules/__tests__/indent/menu/increase-indent-menu.test.ts packages/basic-modules/__tests__/indent/menu/decrease-indent-menu.test.ts packages/basic-modules/__tests__/indent/parse-html.test.ts packages/basic-modules/__tests__/indent/render-text-style.test.tsx packages/basic-modules/__tests__/indent/text-style-to-html.test.ts tests/e2e/editor.spec.ts --max-warnings=0`

Closes #58


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted indent functionality to paragraph and header nodes only, preventing unintended indentation effects on other block elements such as blockquotes and images.

* **Tests**
  * Added comprehensive unit tests verifying indent behavior with different node types.
  * Added end-to-end regression test for indent toolbar when selecting mixed block types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/869?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->