### PR TITLE
fix(link): trigger custom check on empty URL for insert/edit

### DIFF
--- a/.changeset/curly-rivers-drum.md
+++ b/.changeset/curly-rivers-drum.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/basic-modules': patch
+---
+
+trigger custom link check before empty-url early return for insert and edit link flows

--- a/packages/basic-modules/__tests__/link/helper.test.ts
+++ b/packages/basic-modules/__tests__/link/helper.test.ts
@@ -31,9 +31,13 @@ describe('link module helper', () => {
     return url
   }
 
-  const editorConfig = { MENU_CONF: { insertLink: {} }, maxLength: 20 }
+  const editorConfig = { MENU_CONF: { insertLink: {}, editLink: {} }, maxLength: 20 }
 
   editorConfig.MENU_CONF.insertLink = {
+    checkLink: customCheckLinkFn,
+    parseLinkUrl: customParseLinkUrl,
+  }
+  editorConfig.MENU_CONF.editLink = {
     checkLink: customCheckLinkFn,
     parseLinkUrl: customParseLinkUrl,
   }
@@ -107,6 +111,17 @@ describe('link module helper', () => {
     const linkElem = links[0]
 
     expect(linkElem.url).toBe('https://wangeditor-next.github.io/docs/a%20b')
+  })
+
+  it('insert link should trigger custom check when url is empty', async () => {
+    editor.select(startLocation)
+
+    const alertSpy = vi.spyOn(editor, 'alert')
+
+    await insertLink(editor, 'hello', '')
+
+    expect(alertSpy).toHaveBeenCalledWith('链接必须以 http/https 开头', 'error')
+    expect(editor.getElemsByTypePrefix('link').length).toBe(0)
   })
 
   it('insert link with collapsed max length', async () => {
@@ -276,5 +291,27 @@ describe('link module helper', () => {
     const linkElem = links[0]
 
     expect(linkElem.url).toBe('https://wangeditor-next.github.io/docs/a%20b')
+  })
+
+  it('update link should trigger custom check when url is empty', async () => {
+    editor.select(startLocation)
+
+    const url = 'https://wangeditor-next.github.io/docs/'
+
+    await insertLink(editor, 'hello', url)
+    editor.select({
+      path: [0, 1, 0],
+      offset: 3,
+    })
+
+    const alertSpy = vi.spyOn(editor, 'alert')
+
+    await updateLink(editor, '', '')
+
+    expect(alertSpy).toHaveBeenCalledWith('链接必须以 http/https 开头', 'error')
+    const links = editor.getElemsByTypePrefix('link')
+
+    expect(links).toHaveLength(1)
+    expect(links[0].url).toBe(url)
   })
 })

--- a/packages/basic-modules/src/modules/link/helper.ts
+++ b/packages/basic-modules/src/modules/link/helper.ts
@@ -100,7 +100,6 @@ function genLinkNode(url: string, text?: string): LinkElement {
  * @param url url
  */
 export async function insertLink(editor: IDomEditor, text: string, url: string) {
-  if (!url) { return }
   if (!text) { text = url } // 无 text 则用 url 代替
 
   // 还原选区
@@ -115,6 +114,8 @@ export async function insertLink(editor: IDomEditor, text: string, url: string) 
 
   // 转换 url
   const parsedUrl = await parse('insertLink', editor, url)
+
+  if (!parsedUrl) { return }
 
   // 判断选区是否折叠
   const { selection } = editor
@@ -184,8 +185,6 @@ export async function insertLink(editor: IDomEditor, text: string, url: string) 
  * @param url link url
  */
 export async function updateLink(editor: IDomEditor, text: string, url: string) {
-  if (!url) { return }
-
   // 校验
   const checkRes = await check('editLink', editor, text, url)
 
@@ -193,6 +192,8 @@ export async function updateLink(editor: IDomEditor, text: string, url: string) 
 
   // 转换 url
   const parsedUrl = await parse('editLink', editor, url)
+
+  if (!parsedUrl) { return }
 
   // 修改链接
   const props: Partial<LinkElement> = { url: replaceSymbols(parsedUrl) }


### PR DESCRIPTION
## Summary
- remove early `!url` return in `insertLink` and `updateLink`, so custom `checkLink` always executes first
- keep a post-parse empty guard to avoid inserting/updating invalid empty URLs
- align behavior with upstream discussion in `wangeditor-team/wangEditor#5820`

## Regression
- add `insert link should trigger custom check when url is empty`
- add `update link should trigger custom check when url is empty`
- ensure test helper config includes `MENU_CONF.editLink` custom handlers

## Verification
- `pnpm --filter @wangeditor-next/basic-modules test -- __tests__/link/helper.test.ts`
- `pnpm exec eslint packages/basic-modules/src/modules/link/helper.ts packages/basic-modules/__tests__/link/helper.test.ts --max-warnings=0`
- `pnpm --filter @wangeditor-next/basic-modules build && pnpm --filter @wangeditor-next/editor build`

Closes #49


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed link validation behavior to ensure custom validation checks run consistently when inserting or editing links with empty URLs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/870?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->