### PR TITLE
feat(core): add clearHistory api

### DIFF
--- a/.changeset/new-lobsters-fry.md
+++ b/.changeset/new-lobsters-fry.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/core': patch
+---
+
+add `clearHistory` api on editor instances to clear slate undo/redo stacks

--- a/packages/core/__tests__/editor/plugins/with-content.test.ts
+++ b/packages/core/__tests__/editor/plugins/with-content.test.ts
@@ -362,6 +362,30 @@ describe('editor content API', () => {
     expect(editor.getText()).toBe('hello')
   })
 
+  it('clearHistory', () => {
+    const editor = createEditor()
+
+    editor.select(getStartLocation(editor))
+    editor.insertText('hello')
+
+    // @ts-ignore
+    editor.undo()
+    expect(editor.getText()).toBe('')
+
+    // @ts-ignore
+    editor.clearHistory()
+    // @ts-ignore
+    editor.redo()
+    expect(editor.getText()).toBe('')
+
+    editor.insertText('world')
+    // @ts-ignore
+    editor.clearHistory()
+    // @ts-ignore
+    editor.undo()
+    expect(editor.getText()).toBe('world')
+  })
+
   describe('dangerouslyInsertHtml API', () => {
     beforeEach(() => {
       baseEditor = createEditor()

--- a/packages/core/src/create/create-editor.ts
+++ b/packages/core/src/create/create-editor.ts
@@ -4,7 +4,6 @@
  */
 
 import { createEditor } from 'slate'
-import { withHistory } from 'slate-history'
 
 import { genEditorConfig } from '../config/index'
 import { EditorEvents, ICreateOption } from '../config/interface'
@@ -14,6 +13,7 @@ import { withContent } from '../editor/plugins/with-content'
 import { withDOM } from '../editor/plugins/with-dom'
 import { withEmitter } from '../editor/plugins/with-emitter'
 import { withEventData } from '../editor/plugins/with-event-data'
+import { withHistory } from '../editor/plugins/with-history'
 import { withMaxLength } from '../editor/plugins/with-max-length'
 import { withSelection } from '../editor/plugins/with-selection'
 import HoverBar from '../menus/bar/HoverBar'

--- a/packages/core/src/editor/interface.ts
+++ b/packages/core/src/editor/interface.ts
@@ -89,4 +89,5 @@ export interface IDomEditor extends Editor {
   // undo redo - 不用自己实现，使用 slate-history 扩展
   undo?: () => void
   redo?: () => void
+  clearHistory?: () => void
 }

--- a/packages/core/src/editor/plugins/with-history.ts
+++ b/packages/core/src/editor/plugins/with-history.ts
@@ -1,0 +1,19 @@
+/**
+ * @description slate 插件 - history
+ */
+
+import { Editor } from 'slate'
+import { HistoryEditor, withHistory as withSlateHistory } from 'slate-history'
+
+import { IDomEditor } from '../interface'
+
+export const withHistory = <T extends Editor>(editor: T) => {
+  const historyEditor = withSlateHistory(editor) as T & IDomEditor & HistoryEditor
+
+  historyEditor.clearHistory = () => {
+    historyEditor.history.undos = []
+    historyEditor.history.redos = []
+  }
+
+  return historyEditor
+}


### PR DESCRIPTION
## Summary
- add `editor.clearHistory()` to clear slate history stacks (`undos` and `redos`)
- wrap `slate-history` via `with-history` plugin so the API is attached consistently when editor is created
- keep behavior aligned with existing undo/redo model, only adding explicit stack reset capability

## Tests
- add `clearHistory` regression in `packages/core/__tests__/editor/plugins/with-content.test.ts`
- verify clearing redo stack (undo -> clear -> redo should do nothing)
- verify clearing undo stack (insert -> clear -> undo should do nothing)

## Verification
- `pnpm --filter @wangeditor-next/core test -- __tests__/editor/plugins/with-content.test.ts`
- `pnpm exec eslint packages/core/src/editor/interface.ts packages/core/src/editor/plugins/with-history.ts packages/core/src/create/create-editor.ts packages/core/__tests__/editor/plugins/with-content.test.ts --max-warnings=0`
- `pnpm --filter @wangeditor-next/core build && pnpm --filter @wangeditor-next/editor build`

Related: wangeditor-team/wangEditor#5932
Closes #138


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `clearHistory` API to editor instances, enabling users to clear the undo/redo history stack.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/871?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->