### PR TITLE
feat(editor-for-react): add built-in loading overlay

### DIFF
--- a/.changeset/calm-points-wave.md
+++ b/.changeset/calm-points-wave.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/editor-for-react': patch
+---
+
+add built-in `loading`/`loadingText` overlay props on `Editor` to avoid wrapper-induced DOM changes

--- a/packages/editor-for-react/README.md
+++ b/packages/editor-for-react/README.md
@@ -34,6 +34,21 @@ import { Editor, Toolbar } from '@wangeditor-next/editor-for-react'
 
 详情参考[wangEditor react使用文档](https://wangeditor-next.github.io/docs/guide/for-frame#react)。
 
+### Editor 内置 loading
+
+为避免外层 `Spin/Loader` 包裹导致编辑器节点结构变化，可直接使用内置 `loading` 覆盖层：
+
+```tsx
+<Editor
+  defaultConfig={editorConfig}
+  onChange={setEditorState}
+  loading={uploading}
+  loadingText="Uploading..."
+/>
+```
+
+`loading` 只控制可视化遮罩，不会重建 editor 实例。
+
 ### 在Next.js下使用
 ```js
 import dynamic  from 'next/dynamic'

--- a/packages/editor-for-react/__tests__/editor.test.tsx
+++ b/packages/editor-for-react/__tests__/editor.test.tsx
@@ -175,4 +175,51 @@ describe('editor-for-react onChange behavior', () => {
       ReactDOM.unmountComponentAtNode(container)
     })
   })
+
+  it('supports built-in loading overlay without recreating editor instance', async () => {
+    const onChange = vi.fn()
+    const container = document.createElement('div')
+
+    document.body.appendChild(container)
+    await act(async () => {
+      ReactDOM.render(
+        React.createElement(Editor as any, {
+          value: '<p>123</p>',
+          onChange,
+          defaultConfig: {},
+          mode: 'default',
+          loading: true,
+          loadingText: 'Uploading...',
+        }),
+        container,
+      )
+    })
+    await flushPromises()
+    await flushPromises()
+
+    expect(createEditor).toHaveBeenCalledTimes(1)
+    expect(container.querySelector('[data-w-e-loading-overlay="true"]')?.textContent).toBe('Uploading...')
+
+    await act(async () => {
+      ReactDOM.render(
+        React.createElement(Editor as any, {
+          value: '<p>123</p>',
+          onChange,
+          defaultConfig: {},
+          mode: 'default',
+          loading: false,
+        }),
+        container,
+      )
+    })
+    await flushPromises()
+    await flushPromises()
+
+    expect(createEditor).toHaveBeenCalledTimes(1)
+    expect(container.querySelector('[data-w-e-loading-overlay="true"]')).toBeNull()
+
+    await act(async () => {
+      ReactDOM.unmountComponentAtNode(container)
+    })
+  })
 })

--- a/packages/editor-for-react/src/components/Editor.tsx
+++ b/packages/editor-for-react/src/components/Editor.tsx
@@ -7,7 +7,9 @@ import type { IDomEditor, IEditorConfig } from '@wangeditor-next/editor'
 import {
   createEditor, SlateDescendant,
 } from '@wangeditor-next/editor'
-import React, { useEffect, useRef, useState } from 'react'
+import React, {
+  useCallback, useEffect, useRef, useState,
+} from 'react'
 
 interface IProps {
   defaultContent?: SlateDescendant[]
@@ -19,6 +21,8 @@ interface IProps {
   mode?: string
   style?: React.CSSProperties
   className?: string
+  loading?: boolean
+  loadingText?: React.ReactNode
 }
 
 interface ICustomDomEditor extends IDomEditor {
@@ -28,13 +32,14 @@ interface ICustomDomEditor extends IDomEditor {
 function EditorComponent(props: Partial<IProps>) {
   const {
     defaultContent = [], onCreated, defaultHtml = '', value = '', onChange, defaultConfig = {}, mode = 'default', style = {}, className,
+    loading = false, loadingText = 'Loading...',
   } = props
   const ref = useRef<HTMLDivElement>(null)
   const latestHtmlRef = useRef('')
   const isSyncingFromPropsRef = useRef(false)
   const [editor, setEditor] = useState<ICustomDomEditor | null>(null)
 
-  const handleCreated = (createdEditor: IDomEditor) => {
+  const handleCreated = useCallback((createdEditor: IDomEditor) => {
     // 组件属性 onCreated
     if (onCreated) { onCreated(createdEditor) }
 
@@ -42,16 +47,16 @@ function EditorComponent(props: Partial<IProps>) {
     const { onCreated: onCreatedFromConfig } = defaultConfig
 
     if (onCreatedFromConfig) { onCreatedFromConfig(createdEditor) }
-  }
+  }, [defaultConfig, onCreated])
 
-  const handleDestroyed = (destroyedEditor: IDomEditor) => {
+  const handleDestroyed = useCallback((destroyedEditor: IDomEditor) => {
     const { onDestroyed } = defaultConfig
 
     setEditor(null)
     if (onDestroyed) {
       onDestroyed(destroyedEditor)
     }
-  }
+  }, [defaultConfig])
 
   useEffect(() => {
     if (editor == null) { return }
@@ -123,9 +128,45 @@ function EditorComponent(props: Partial<IProps>) {
 
     latestHtmlRef.current = newEditor.getHtml()
     setEditor(newEditor)
-  }, [editor])
+  }, [
+    editor,
+    defaultConfig,
+    defaultContent,
+    defaultHtml,
+    handleCreated,
+    handleDestroyed,
+    mode,
+    value,
+  ])
 
-  return <div style={style} ref={ref} className={className}></div>
+  return (
+    <div
+      style={{ ...style, position: style.position || 'relative' }}
+      className={className}
+      data-w-e-react-editor-container="true"
+    >
+      <div style={{ minHeight: '1px' }} ref={ref}></div>
+      {loading && (
+      <div
+        data-w-e-loading-overlay="true"
+        style={{
+          position: 'absolute',
+          top: 0,
+          right: 0,
+          bottom: 0,
+          left: 0,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: 'rgba(255, 255, 255, 0.6)',
+          zIndex: 10,
+        }}
+      >
+        {loadingText}
+      </div>
+      )}
+    </div>
+  )
 }
 
 export default EditorComponent


### PR DESCRIPTION
## Summary
- add built-in `loading` and `loadingText` props in `@wangeditor-next/editor-for-react` `Editor`
- render loading as an internal absolute overlay, so caller no longer needs to wrap editor with external `Spin/Loader` and change DOM nesting
- keep editor mount node stable and avoid recreating editor instance when toggling loading

## Regression
- add test `supports built-in loading overlay without recreating editor instance`
- verify loading toggle only shows/hides overlay and `createEditor` remains called exactly once

## Verification
- `pnpm --filter @wangeditor-next/editor-for-react exec vitest run __tests__/editor.test.tsx`
- `pnpm exec eslint packages/editor-for-react/src/components/Editor.tsx packages/editor-for-react/__tests__/editor.test.tsx --max-warnings=0`
- `pnpm --filter @wangeditor-next/editor-for-react build`

## Notes
- docs note added in `packages/editor-for-react/README.md`

Closes #595


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `loading` and `loadingText` props to the Editor component, enabling a built-in loading overlay that prevents unintended DOM structure changes compared to external wrapper solutions.

* **Documentation**
  * Updated README with practical usage examples and comprehensive guidance on implementing and customizing the new loading overlay feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/872?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->