### PR TITLE
feat(core): add getHtmlWithId api

### DIFF
--- a/.changeset/sweet-rice-shake.md
+++ b/.changeset/sweet-rice-shake.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/core': minor
+---
+
+add `editor.getHtmlWithId(idKey?)` to export HTML with generated unique element ids

--- a/packages/core/__tests__/editor/plugins/with-content.test.ts
+++ b/packages/core/__tests__/editor/plugins/with-content.test.ts
@@ -79,6 +79,53 @@ describe('editor content API', () => {
     expect(html).toBe('<div>hello</div><div></div>')
   })
 
+  it('getHtmlWithId', () => {
+    const editor = createEditor({
+      content: [
+        { type: 'paragraph', children: [{ text: 'hello' }] },
+        {
+          type: 'table',
+          children: [
+            {
+              type: 'table-row',
+              children: [
+                {
+                  type: 'table-cell',
+                  children: [{ text: 'A' }],
+                } as any,
+              ],
+            } as any,
+          ],
+        } as any,
+      ],
+    })
+
+    const html = editor.getHtmlWithId?.() || ''
+
+    expect(html).toContain('<div data-w-e-id="w-e-element-paragraph-')
+    expect(html).toContain('data-w-e-id="w-e-element-table-')
+    expect(html).toContain('data-w-e-id="w-e-element-table-row-')
+    expect(html).toContain('data-w-e-id="w-e-element-table-cell-')
+
+    const rawHtml = editor.getHtml()
+
+    expect(rawHtml).not.toContain('data-w-e-id=')
+  })
+
+  it('getHtmlWithId with custom id attribute key', () => {
+    const editor = createEditor({
+      content: [{ type: 'paragraph', children: [{ text: 'hello' }] }],
+    })
+
+    const html = editor.getHtmlWithId?.('data-node-id') || ''
+
+    expect(html).toContain('data-node-id="w-e-element-paragraph-')
+
+    const htmlWithInvalidKey = editor.getHtmlWithId?.('invalid key') || ''
+
+    expect(htmlWithInvalidKey).toContain('data-w-e-id="w-e-element-paragraph-')
+  })
+
   it('getText', () => {
     const editor = createEditor({
       content: [

--- a/packages/core/src/editor/interface.ts
+++ b/packages/core/src/editor/interface.ts
@@ -37,6 +37,7 @@ export interface IDomEditor extends Editor {
   // 内容处理
   handleTab: () => void
   getHtml: () => string
+  getHtmlWithId?: (idKey?: string) => string
   getText: () => string
   getSelectionText: () => string // 获取选区文字
   getElemsByTypePrefix: (typePrefix: string) => ElementWithId[]

--- a/packages/core/src/editor/plugins/with-content.ts
+++ b/packages/core/src/editor/plugins/with-content.ts
@@ -273,6 +273,16 @@ export const withContent = <T extends Editor>(editor: T) => {
     return html
   }
 
+  /**
+   * 获取带元素 id 的 html（用于外部定位/标识）
+   * @param idKey 自定义 id 属性名，默认 data-w-e-id
+   */
+  e.getHtmlWithId = (idKey = 'data-w-e-id'): string => {
+    const { children = [] } = e
+
+    return children.map(child => node2html(child, e, { includeId: true, idKey })).join('')
+  }
+
   // 获取 text
   e.getText = (): string => {
     const { children = [] } = e

--- a/packages/core/src/to-html/elem2html.ts
+++ b/packages/core/src/to-html/elem2html.ts
@@ -5,8 +5,11 @@
 
 import { Editor, Element } from 'slate'
 
+import { DomEditor } from '../editor/dom-editor'
 import { IDomEditor } from '../editor/interface'
+import { genElemId } from '../render/helper'
 import { ELEM_TO_HTML_CONF, ElemToHtmlFnType, STYLE_TO_HTML_FN_LIST } from './index'
+import type { INodeToHtmlOptions } from './node2html'
 import node2html from './node2html'
 
 /**
@@ -32,7 +35,53 @@ function getParser(type: string): ElemToHtmlFnType {
   return fn || defaultParser
 }
 
-function elemToHtml(elemNode: Element, editor: IDomEditor): string {
+const DEFAULT_ID_KEY = 'data-w-e-id'
+const HTML_ATTR_KEY_REGEXP = /^[A-Za-z_:-][A-Za-z0-9_:.-]*$/
+
+function normalizeIdKey(idKey?: string): string {
+  if (!idKey) { return DEFAULT_ID_KEY }
+  if (!HTML_ATTR_KEY_REGEXP.test(idKey)) { return DEFAULT_ID_KEY }
+
+  return idKey
+}
+
+function addAttrToFirstTag(html: string, key: string, value: string): string {
+  if (!html) { return html }
+
+  const match = html.match(/^<([A-Za-z][A-Za-z0-9-]*)([^>]*)>/)
+
+  if (!match) { return html }
+
+  const [fullTag, tagName, rawAttrs = ''] = match
+
+  if (new RegExp(`\\s${key}=`).test(rawAttrs)) { return html }
+
+  const hasTrailingSlash = /\/\s*$/.test(rawAttrs)
+  const attrsWithoutTrailingSlash = rawAttrs.replace(/\s*\/\s*$/, '')
+  const normalizedAttrs = attrsWithoutTrailingSlash.trim() ? ` ${attrsWithoutTrailingSlash.trim()}` : ''
+  const suffix = hasTrailingSlash ? ' /' : ''
+  const newStartTag = `<${tagName}${normalizedAttrs} ${key}="${value}"${suffix}>`
+
+  return newStartTag + html.slice(fullTag.length)
+}
+
+function maybeAttachElemId(
+  elemHtml: string,
+  elemNode: Element,
+  editor: IDomEditor,
+  options: INodeToHtmlOptions,
+): string {
+  if (!options.includeId) { return elemHtml }
+
+  const idKey = normalizeIdKey(options.idKey)
+  const key = DomEditor.findKey(editor, elemNode)
+  const nodeType = DomEditor.getNodeType(elemNode)
+  const elemId = genElemId(nodeType, key.id)
+
+  return addAttrToFirstTag(elemHtml, idKey, elemId)
+}
+
+function elemToHtml(elemNode: Element, editor: IDomEditor, options: INodeToHtmlOptions = {}): string {
   const { type = '', children = [] } = elemNode
   const isVoid = Editor.isVoid(editor, elemNode)
 
@@ -41,7 +90,7 @@ function elemToHtml(elemNode: Element, editor: IDomEditor): string {
 
   if (!isVoid) {
     // 非 void node
-    childrenHtml = children.map(child => node2html(child, editor)).join('')
+    childrenHtml = children.map(child => node2html(child, editor, options)).join('')
   }
 
   // 生成 html
@@ -56,6 +105,8 @@ function elemToHtml(elemNode: Element, editor: IDomEditor): string {
   if (!isVoid) {
     STYLE_TO_HTML_FN_LIST.forEach(fn => (elemHtml = fn(elemNode, elemHtml, editor)))
   }
+
+  elemHtml = maybeAttachElemId(elemHtml, elemNode, editor, options)
 
   // 直接返回 html 字符串
   if (typeof res === 'string') { return elemHtml }

--- a/packages/core/src/to-html/node2html.ts
+++ b/packages/core/src/to-html/node2html.ts
@@ -3,19 +3,25 @@
  * @author wangfupeng
  */
 
-import { Element, Descendant } from 'slate'
-import { IDomEditor } from '../editor/interface'
+import { Descendant, Element } from 'slate'
+
+import type { IDomEditor } from '../editor/interface'
 import elemToHtml from './elem2html'
 import textToHtml from './text2html'
 
-function node2html(node: Descendant, editor: IDomEditor): string {
+export interface INodeToHtmlOptions {
+  includeId?: boolean
+  idKey?: string
+}
+
+function node2html(node: Descendant, editor: IDomEditor, options: INodeToHtmlOptions = {}): string {
   if (Element.isElement(node)) {
     // elem node
-    return elemToHtml(node, editor)
-  } else {
-    // text node
-    return textToHtml(node, editor)
+    return elemToHtml(node, editor, options)
   }
+
+  // text node
+  return textToHtml(node, editor, options)
 }
 
 export default node2html

--- a/packages/core/src/to-html/text2html.ts
+++ b/packages/core/src/to-html/text2html.ts
@@ -9,8 +9,9 @@ import { DomEditor } from '../editor/dom-editor'
 import { IDomEditor } from '../editor/interface'
 import { replaceHtmlSpecialSymbols } from '../utils/util'
 import { STYLE_TO_HTML_FN_LIST } from './index'
+import type { INodeToHtmlOptions } from './node2html'
 
-function textToHtml(textNode: Text, editor: IDomEditor): string {
+function textToHtml(textNode: Text, editor: IDomEditor, _options: INodeToHtmlOptions = {}): string {
   const { text } = textNode
 
   if (text == null) { throw new Error(`Current node is not slate Text ${JSON.stringify(textNode)}`) }


### PR DESCRIPTION
## Summary
- add `editor.getHtmlWithId(idKey?)` in core content API
- generate element ids using existing `w-e-element-<type>-<key>` convention and inject them into exported HTML root tags
- support custom id attribute key (e.g. `data-node-id`) with invalid-key fallback to `data-w-e-id`
- keep existing `editor.getHtml()` behavior unchanged (no extra id attributes)

## Why
Issue #287 asks for unique identifiers in exported HTML (`span/table/img...`) for downstream mapping/positioning use cases.

## Regression
- add `getHtmlWithId` test coverage in `with-content.test.ts`
- verify nested element ids are injected (`paragraph/table/table-row/table-cell`)
- verify custom key and invalid-key fallback behavior
- verify `getHtml()` output remains unchanged

## Verification
- `pnpm --filter @wangeditor-next/core test -- __tests__/editor/plugins/with-content.test.ts`
- `pnpm exec eslint packages/core/src/to-html/node2html.ts packages/core/src/to-html/elem2html.ts packages/core/src/to-html/text2html.ts packages/core/src/editor/interface.ts packages/core/src/editor/plugins/with-content.ts packages/core/__tests__/editor/plugins/with-content.test.ts --max-warnings=0`
- `pnpm --filter @wangeditor-next/core build && pnpm --filter @wangeditor-next/editor build`

Closes #287


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new HTML export method that generates unique element IDs (data-w-e-id attributes) for all content nodes, including paragraphs, tables, rows, and cells.
  * Supports optional custom ID attribute key configuration for flexible integration.

* **Tests**
  * Added test coverage validating the new HTML export with ID generation functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/873?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->