### PR TITLE
chore(deps): align slate to ^0.124.0 across workspace

### DIFF
--- a/.changeset/famous-goats-fail.md
+++ b/.changeset/famous-goats-fail.md
@@ -1,0 +1,22 @@
+---
+'@wangeditor-next/basic-modules': patch
+'@wangeditor-next/code-highlight': patch
+'@wangeditor-next/core': patch
+'@wangeditor-next/editor': patch
+'@wangeditor-next/list-module': patch
+'@wangeditor-next/plugin-float-image': patch
+'@wangeditor-next/plugin-link-card': patch
+'@wangeditor-next/plugin-markdown': patch
+'@wangeditor-next/table-module': patch
+'@wangeditor-next/upload-image-module': patch
+'@wangeditor-next/video-module': patch
+'@wangeditor-next/yjs': patch
+'@wangeditor-next/yjs-for-react': patch
+'@wangeditor-next/yjs-for-vue': patch
+---
+
+Align Slate to `^0.124.0` across the monorepo to avoid mixed Slate type sources.
+
+- upgrade all internal `slate` dependency and peer dependency ranges from `^0.123.0` to `^0.124.0`
+- remove dual installation of `slate@0.123.x` and `slate@0.124.x` in workspace builds
+- fix `@wangeditor-next/yjs-for-react` build failures caused by cross-version Slate type incompatibilities

--- a/packages/basic-modules/package.json
+++ b/packages/basic-modules/package.json
@@ -48,7 +48,7 @@
     "dom7": "^3.0.0 || ^4.0.0",
     "lodash.throttle": "^4.1.1",
     "nanoid": "^5.0.0",
-    "slate": "^0.123.0",
+    "slate": "^0.124.0",
     "snabbdom": "^3.6.0"
   },
   "dependencies": {

--- a/packages/code-highlight/package.json
+++ b/packages/code-highlight/package.json
@@ -46,7 +46,7 @@
   "peerDependencies": {
     "@wangeditor-next/core": "1.8.5",
     "dom7": "^3.0.0 || ^4.0.0",
-    "slate": "^0.123.0",
+    "slate": "^0.124.0",
     "snabbdom": "^3.6.0"
   },
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,7 +60,7 @@
     "lodash.throttle": "^4.1.1",
     "lodash.toarray": "^4.4.0",
     "nanoid": "^5.0.0",
-    "slate": "^0.123.0",
+    "slate": "^0.124.0",
     "snabbdom": "^3.6.0"
   },
   "dependencies": {

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -82,7 +82,7 @@
     "lodash.throttle": "^4.1.1",
     "lodash.toarray": "^4.4.0",
     "nanoid": "^5.0.0",
-    "slate": "^0.123.0",
+    "slate": "^0.124.0",
     "snabbdom": "^3.6.0"
   },
   "devDependencies": {

--- a/packages/list-module/package.json
+++ b/packages/list-module/package.json
@@ -46,7 +46,7 @@
   "peerDependencies": {
     "@wangeditor-next/core": "1.8.5",
     "dom7": "^3.0.0 || ^4.0.0",
-    "slate": "^0.123.0",
+    "slate": "^0.124.0",
     "snabbdom": "^3.6.0"
   },
   "devDependencies": {

--- a/packages/plugin-float-image/package.json
+++ b/packages/plugin-float-image/package.json
@@ -43,7 +43,7 @@
   "peerDependencies": {
     "@wangeditor-next/editor": "5.7.5",
     "dom7": "^3.0.0 || ^4.0.0",
-    "slate": "^0.123.0",
+    "slate": "^0.124.0",
     "snabbdom": "^3.6.0"
   },
   "devDependencies": {

--- a/packages/plugin-link-card/package.json
+++ b/packages/plugin-link-card/package.json
@@ -43,7 +43,7 @@
   "peerDependencies": {
     "@wangeditor-next/editor": "5.7.5",
     "dom7": "^3.0.0 || ^4.0.0",
-    "slate": "^0.123.0",
+    "slate": "^0.124.0",
     "snabbdom": "^3.6.0"
   },
   "devDependencies": {

--- a/packages/plugin-markdown/package.json
+++ b/packages/plugin-markdown/package.json
@@ -43,7 +43,7 @@
   "peerDependencies": {
     "@wangeditor-next/editor": "5.7.5",
     "dom7": "^3.0.0 || ^4.0.0",
-    "slate": "^0.123.0",
+    "slate": "^0.124.0",
     "snabbdom": "^3.6.0"
   },
   "devDependencies": {

--- a/packages/table-module/package.json
+++ b/packages/table-module/package.json
@@ -49,7 +49,7 @@
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",
     "nanoid": "^5.0.0",
-    "slate": "^0.123.0",
+    "slate": "^0.124.0",
     "snabbdom": "^3.6.0"
   },
   "devDependencies": {

--- a/packages/upload-image-module/package.json
+++ b/packages/upload-image-module/package.json
@@ -50,7 +50,7 @@
     "@wangeditor-next/core": "1.8.5",
     "dom7": "^3.0.0 || ^4.0.0",
     "lodash.foreach": "^4.5.0",
-    "slate": "^0.123.0",
+    "slate": "^0.124.0",
     "snabbdom": "^3.6.0"
   },
   "devDependencies": {

--- a/packages/video-module/package.json
+++ b/packages/video-module/package.json
@@ -49,7 +49,7 @@
     "@wangeditor-next/core": "1.8.5",
     "dom7": "^3.0.0 || ^4.0.0",
     "nanoid": "^5.0.0",
-    "slate": "^0.123.0",
+    "slate": "^0.124.0",
     "snabbdom": "^3.6.0"
   },
   "devDependencies": {

--- a/packages/yjs-for-react/package.json
+++ b/packages/yjs-for-react/package.json
@@ -62,7 +62,7 @@
     "@wangeditor-next/editor": "5.7.5",
     "@wangeditor-next/yjs": "^1.0.5",
     "react": ">=17.0.2",
-    "slate": "^0.123.0",
+    "slate": "^0.124.0",
     "yjs": "^13.5.29"
   }
 }

--- a/packages/yjs-for-vue/package.json
+++ b/packages/yjs-for-vue/package.json
@@ -60,7 +60,7 @@
     "@wangeditor-next/editor": "5.7.5",
     "@wangeditor-next/yjs": "^1.0.5",
     "vue": ">=3.5.18",
-    "slate": "^0.123.0",
+    "slate": "^0.124.0",
     "yjs": "^13.5.29"
   }
 }

--- a/packages/yjs/package.json
+++ b/packages/yjs/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@wangeditor-next-shared/rollup-config": "workspace:^",
-    "slate": "^0.123.0",
+    "slate": "^0.124.0",
     "typescript": "^5.0.0",
     "yjs": "^13.5.29"
   }

--- a/packages/yjs/package.json
+++ b/packages/yjs/package.json
@@ -49,7 +49,7 @@
   },
   "peerDependencies": {
     "@wangeditor-next/core": "1.8.5",
-    "slate": "^0.123.0",
+    "slate": "^0.124.0",
     "yjs": "^13.5.29"
   },
   "bugs": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -442,8 +442,8 @@ importers:
         specifier: ^5.0.0
         version: 5.1.6
       slate:
-        specifier: ^0.123.0
-        version: 0.123.0
+        specifier: ^0.124.0
+        version: 0.124.1
       snabbdom:
         specifier: ^3.6.0
         version: 3.6.3
@@ -467,8 +467,8 @@ importers:
         specifier: ^1.23.0
         version: 1.30.0
       slate:
-        specifier: ^0.123.0
-        version: 0.123.0
+        specifier: ^0.124.0
+        version: 0.124.1
       snabbdom:
         specifier: ^3.6.0
         version: 3.6.3
@@ -525,11 +525,11 @@ importers:
         specifier: ^3.0.0
         version: 3.1.0
       slate:
-        specifier: ^0.123.0
-        version: 0.123.0
+        specifier: ^0.124.0
+        version: 0.124.1
       slate-history:
         specifier: ^0.115.0
-        version: 0.115.0(slate@0.123.0)
+        version: 0.115.0(slate@0.124.1)
       snabbdom:
         specifier: ^3.6.0
         version: 3.6.3
@@ -604,8 +604,8 @@ importers:
         specifier: ^5.0.0
         version: 5.1.6
       slate:
-        specifier: ^0.123.0
-        version: 0.123.0
+        specifier: ^0.124.0
+        version: 0.124.1
       snabbdom:
         specifier: ^3.6.0
         version: 3.6.3
@@ -644,8 +644,8 @@ importers:
         specifier: ^3.0.0 || ^4.0.0
         version: 4.0.6
       slate:
-        specifier: ^0.123.0
-        version: 0.123.0
+        specifier: ^0.124.0
+        version: 0.124.1
       snabbdom:
         specifier: ^3.6.0
         version: 3.6.3
@@ -663,8 +663,8 @@ importers:
         specifier: ^3.0.0 || ^4.0.0
         version: 4.0.6
       slate:
-        specifier: ^0.123.0
-        version: 0.123.0
+        specifier: ^0.124.0
+        version: 0.124.1
       snabbdom:
         specifier: ^3.6.0
         version: 3.6.3
@@ -704,8 +704,8 @@ importers:
         specifier: ^3.0.0 || ^4.0.0
         version: 4.0.6
       slate:
-        specifier: ^0.123.0
-        version: 0.123.0
+        specifier: ^0.124.0
+        version: 0.124.1
       snabbdom:
         specifier: ^3.6.0
         version: 3.6.3
@@ -723,8 +723,8 @@ importers:
         specifier: ^3.0.0 || ^4.0.0
         version: 4.0.6
       slate:
-        specifier: ^0.123.0
-        version: 0.123.0
+        specifier: ^0.124.0
+        version: 0.124.1
       snabbdom:
         specifier: ^3.6.0
         version: 3.6.3
@@ -764,8 +764,8 @@ importers:
         specifier: ^5.0.0
         version: 5.1.6
       slate:
-        specifier: ^0.123.0
-        version: 0.123.0
+        specifier: ^0.124.0
+        version: 0.124.1
       snabbdom:
         specifier: ^3.6.0
         version: 3.6.3
@@ -795,8 +795,8 @@ importers:
         specifier: ^4.5.0
         version: 4.5.0
       slate:
-        specifier: ^0.123.0
-        version: 0.123.0
+        specifier: ^0.124.0
+        version: 0.124.1
       snabbdom:
         specifier: ^3.6.0
         version: 3.6.3
@@ -823,8 +823,8 @@ importers:
         specifier: ^5.0.0
         version: 5.1.6
       slate:
-        specifier: ^0.123.0
-        version: 0.123.0
+        specifier: ^0.124.0
+        version: 0.124.1
       snabbdom:
         specifier: ^3.6.0
         version: 3.6.3
@@ -867,8 +867,8 @@ importers:
         specifier: '>=17.0.2'
         version: 17.0.2
       slate:
-        specifier: ^0.123.0
-        version: 0.123.0
+        specifier: ^0.124.0
+        version: 0.124.1
       use-sync-external-store:
         specifier: ^1.2.0
         version: 1.6.0(react@17.0.2)
@@ -895,8 +895,8 @@ importers:
         specifier: ^1.0.5
         version: link:../yjs
       slate:
-        specifier: ^0.123.0
-        version: 0.123.0
+        specifier: ^0.124.0
+        version: 0.124.1
       vue:
         specifier: '>=3.5.18'
         version: 3.5.24(typescript@5.7.2)
@@ -5789,9 +5789,6 @@ packages:
     resolution: {integrity: sha512-QdUm9aVyQFz6JG4a84Z6Um+tJpZJmsh9bjXwTVTvYiN4rdKbqL6+/4HT94on1WYxe10Q4vY6mA6BCpoYxgF3tQ==}
     peerDependencies:
       slate: '>=0.114.3'
-
-  slate@0.123.0:
-    resolution: {integrity: sha512-Oon3HR/QzJQBjuOUJT1jGGlp8Ff7t3Bkr/rJ2lDqxNT4H+cBnXpEVQ/si6hn1ZCHhD2xY/2N91PQoH/rD7kxTg==}
 
   slate@0.124.1:
     resolution: {integrity: sha512-ii7DwezgvbLAyKtHBIunjTR1kzbNfYLCUKLMzJELlbTZkvHzX4DzN7HKIwcakf6dPxO6AoeT/P7kHOcyTym/hA==}
@@ -11967,11 +11964,9 @@ snapshots:
 
   slash@3.0.0: {}
 
-  slate-history@0.115.0(slate@0.123.0):
+  slate-history@0.115.0(slate@0.124.1):
     dependencies:
-      slate: 0.123.0
-
-  slate@0.123.0: {}
+      slate: 0.124.1
 
   slate@0.124.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -846,8 +846,8 @@ importers:
         specifier: workspace:^
         version: link:../../shared/rollup-config
       slate:
-        specifier: ^0.123.0
-        version: 0.123.0
+        specifier: ^0.124.0
+        version: 0.124.1
       typescript:
         specifier: ^5.0.0
         version: 5.7.2
@@ -5792,6 +5792,9 @@ packages:
 
   slate@0.123.0:
     resolution: {integrity: sha512-Oon3HR/QzJQBjuOUJT1jGGlp8Ff7t3Bkr/rJ2lDqxNT4H+cBnXpEVQ/si6hn1ZCHhD2xY/2N91PQoH/rD7kxTg==}
+
+  slate@0.124.1:
+    resolution: {integrity: sha512-ii7DwezgvbLAyKtHBIunjTR1kzbNfYLCUKLMzJELlbTZkvHzX4DzN7HKIwcakf6dPxO6AoeT/P7kHOcyTym/hA==}
 
   slice-ansi@5.0.0:
     resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
@@ -11969,6 +11972,8 @@ snapshots:
       slate: 0.123.0
 
   slate@0.123.0: {}
+
+  slate@0.124.1: {}
 
   slice-ansi@5.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- supersede the stalled Renovate PR #802 by aligning every internal `slate` range to `^0.124.0`
- remove mixed `slate@0.123.x` + `slate@0.124.x` installs that caused cross-package type incompatibilities
- include a changeset for all affected published packages

## Root Cause
`@wangeditor-next/yjs-for-react` and `@wangeditor-next/yjs` resolved different `slate` major-minor lines in workspace builds (`0.124.x` vs `0.123.x`), so TypeScript treated `Descendant[]` and related types as incompatible across package boundaries.

## Validation
- `pnpm run smoke:demos`
- `pnpm build`
- `pnpm test`

## Notes
- this PR supersedes #802 (maintainer cannot push to renovate branch, and #802 CI stayed red)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed build failures and type incompatibilities across multiple packages.

* **Chores**
  * Updated dependencies across the monorepo to ensure consistent compatibility and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/874?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->