### PR TITLE
chore(ci): 补齐 typecheck gate 与安全扫描基线

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,58 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: '25 19 * * 1'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: javascript-typescript
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 9.15.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.13.0
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm build
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,19 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dependency review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,73 @@
+name: Type Check
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'dev'
+      - 'dev-*'
+      - 'dev/**'
+      - 'feature-*'
+      - 'feature/**'
+      - 'fix-*'
+      - 'fix/**'
+      - 'hotfix-*'
+      - 'hotfix/**'
+      - 'refactor-*'
+      - 'refactor/**'
+      - 'test-*'
+      - 'test/**'
+    paths:
+      - '.github/workflows/*'
+      - 'apps/**'
+      - 'packages/**'
+      - 'tests/**'
+      - 'scripts/typecheck-all.js'
+      - 'tsconfig.json'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/*'
+      - 'apps/**'
+      - 'packages/**'
+      - 'tests/**'
+      - 'scripts/typecheck-all.js'
+      - 'tsconfig.json'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 9.15.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.13.0
+          registry-url: https://registry.npmjs.com
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm run typecheck

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -69,5 +69,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # editor-for-react 依赖 @wangeditor-next/editor 的 dist 类型产物
+      - name: Build editor package for type declarations
+        run: pnpm turbo build --filter=@wangeditor-next/editor
+
       - name: Type check
         run: pnpm run typecheck

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "dev": "cross-env FORCE_COLOR=1 turbo dev",
     "dev:sh": "sh scripts/build-base.sh dev",
     "build": "cross-env FORCE_COLOR=1 turbo build",
+    "typecheck": "node scripts/typecheck-all.js",
     "publish": "pnpm changeset publish",
     "prerelease": "pnpm build",
     "format": "pnpm prettier --write",

--- a/scripts/typecheck-all.js
+++ b/scripts/typecheck-all.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs')
+const path = require('node:path')
+const { spawnSync } = require('node:child_process')
+
+const rootDir = path.resolve(__dirname, '..')
+const scanDirs = ['packages']
+const ignoredDirs = new Set(['node_modules', 'dist', 'lib', 'coverage', '.turbo', '.git'])
+
+function collectTsconfigFiles(startDir) {
+  const result = []
+
+  function walk(dir) {
+    const entries = fs.readdirSync(dir, { withFileTypes: true })
+
+    for (const entry of entries) {
+      const absolutePath = path.join(dir, entry.name)
+
+      if (entry.isDirectory()) {
+        if (ignoredDirs.has(entry.name)) {
+          continue
+        }
+
+        walk(absolutePath)
+        continue
+      }
+
+      if (!entry.isFile()) {
+        continue
+      }
+
+      if (entry.name !== 'tsconfig.json') {
+        continue
+      }
+
+      result.push(absolutePath)
+    }
+  }
+
+  walk(startDir)
+  return result
+}
+
+function runTypecheck(tsconfigPath) {
+  const relativePath = path.relative(rootDir, tsconfigPath).replace(/\\/g, '/')
+
+  console.log(`[typecheck] ${relativePath}`)
+
+  const res = spawnSync(
+    'pnpm',
+    ['exec', 'tsc', '--noEmit', '--pretty', 'false', '--skipLibCheck', '-p', relativePath],
+    {
+      cwd: rootDir,
+      stdio: 'inherit',
+    }
+  )
+
+  if (res.status !== 0) {
+    process.exit(res.status ?? 1)
+  }
+}
+
+function main() {
+  const tsconfigFiles = []
+
+  scanDirs.forEach(dirName => {
+    const dirPath = path.join(rootDir, dirName)
+
+    if (!fs.existsSync(dirPath)) {
+      return
+    }
+
+    tsconfigFiles.push(...collectTsconfigFiles(dirPath))
+  })
+
+  const uniqueFiles = Array.from(new Set(tsconfigFiles)).sort((a, b) => a.localeCompare(b))
+
+  uniqueFiles.forEach(runTypecheck)
+
+  console.log(`[typecheck] done, checked ${uniqueFiles.length} projects`)
+}
+
+main()


### PR DESCRIPTION
## 背景
当前仓库已有 lint/build/test/e2e gate，但缺少独立 typecheck gate 与基础安全扫描 workflow。

## 变更
- 新增根命令 `pnpm typecheck`（脚本：`scripts/typecheck-all.js`）
  - 扫描并检查 `packages/*/tsconfig.json`
  - 使用 `tsc --noEmit --skipLibCheck`，聚焦发布核心包类型安全
- 新增 CI：`.github/workflows/typecheck.yml`
- 新增安全扫描：`.github/workflows/codeql.yml`
- 新增依赖风险检查：`.github/workflows/dependency-review.yml`

## 验证
- `pnpm lint`
- `pnpm run typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated code security analysis workflow to run regular vulnerability scans.
  * Implemented dependency review workflow to flag and fail on high-severity dependency issues.
  * Added type-checking automation and a script to run comprehensive TypeScript checks across packages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/880?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->