### PR TITLE
fix(plugin-formula): 修复公式绝对值分隔符长度异常

### DIFF
--- a/.changeset/four-owls-type.md
+++ b/.changeset/four-owls-type.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/plugin-formula': patch
+---
+
+fix formula absolute value delimiter rendering by switching formula card output to htmlAndMathml and documenting required css import

--- a/packages/plugin-formula/README-en.md
+++ b/packages/plugin-formula/README-en.md
@@ -23,11 +23,14 @@ pnpm add @wangeditor-next/plugin-formula
 ```js
 import { Boot, IEditorConfig, IToolbarConfig } from '@wangeditor-next/editor'
 import formulaModule from '@wangeditor-next/plugin-formula'
+import 'katex/dist/katex.min.css'
 
 // Register
 // You should register this before create editor, and register only once (not repeatedly).
 Boot.registerModule(formulaModule)
 ```
+
+Ensure KaTeX stylesheet is loaded on the page, otherwise formulas will render as untypeset text.
 
 ### Menu config
 

--- a/packages/plugin-formula/README.md
+++ b/packages/plugin-formula/README.md
@@ -22,10 +22,13 @@ pnpm add @wangeditor-next/plugin-formula
 ```js
 import { Boot, IEditorConfig, IToolbarConfig } from '@wangeditor-next/editor'
 import formulaModule from '@wangeditor-next/plugin-formula'
+import 'katex/dist/katex.min.css'
 
 // 注册。要在创建编辑器之前注册，且只能注册一次，不可重复注册。
 Boot.registerModule(formulaModule)
 ```
+
+需要确保页面引入 KaTeX 样式，否则公式会退化为未排版状态。
 
 ### 配置
 

--- a/packages/plugin-formula/__tests__/register-custom-elem.test.ts
+++ b/packages/plugin-formula/__tests__/register-custom-elem.test.ts
@@ -1,0 +1,18 @@
+import '../src/register-custom-elem'
+
+describe('plugin-formula custom element', () => {
+  it('renders htmlAndMathml output and keeps stretchy absolute delimiters', () => {
+    const elem = document.createElement('w-e-formula-card')
+    const formula = String.raw`\left|-2\frac{4}{7}\right|`
+
+    elem.setAttribute('data-value', formula)
+    document.body.appendChild(elem)
+
+    expect(elem.shadowRoot).toBeNull()
+    expect(elem.querySelector('.katex')).not.toBeNull()
+    expect(elem.querySelector('.katex-html')).not.toBeNull()
+    expect(elem.querySelector('.katex-html .delimsizing.mult')).not.toBeNull()
+
+    elem.remove()
+  })
+})

--- a/packages/plugin-formula/src/register-custom-elem/index.ts
+++ b/packages/plugin-formula/src/register-custom-elem/index.ts
@@ -8,7 +8,7 @@ import './native-shim'
 import katex from 'katex'
 
 class WangEditorFormulaCard extends HTMLElement {
-  private span: HTMLElement
+  private span: HTMLElement | null = null
 
   // 监听的 attr
   static get observedAttributes() {
@@ -17,13 +17,6 @@ class WangEditorFormulaCard extends HTMLElement {
 
   constructor() {
     super()
-    const shadow = this.attachShadow({ mode: 'open' })
-    const document = shadow.ownerDocument
-    const span = document.createElement('span')
-
-    span.style.display = 'inline-block'
-    shadow.appendChild(span)
-    this.span = span
   }
 
   // connectedCallback() {
@@ -45,10 +38,25 @@ class WangEditorFormulaCard extends HTMLElement {
     }
   }
 
+  private ensureSpan() {
+    if (this.span) { return this.span }
+
+    const document = this.ownerDocument || window.document
+    const span = document.createElement('span')
+
+    span.style.display = 'inline-block'
+    this.appendChild(span)
+    this.span = span
+
+    return span
+  }
+
   private render(value: string) {
-    katex.render(value, this.span, {
+    const span = this.ensureSpan()
+
+    katex.render(value, span, {
       throwOnError: false,
-      output: 'mathml',
+      output: 'htmlAndMathml',
     })
   }
 }


### PR DESCRIPTION
## 关联 issue
- closes #881

## 变更说明
- `plugin-formula` 自定义元素渲染从 `output: 'mathml'` 调整为 `output: 'htmlAndMathml'`，避免绝对值分隔符在编辑态回显过短
- 移除公式卡片的 Shadow DOM 容器，改为 light DOM 挂载，确保 KaTeX HTML 渲染样式可正确生效
- 新增回归测试，覆盖 `\left|...\right|` 场景并校验存在可拉伸分隔符节点
- README（中/英）补充 KaTeX 样式引入说明
- 添加 changeset（patch）

## 验证
- `pnpm test packages/plugin-formula/__tests__/module.test.ts packages/plugin-formula/__tests__/register-custom-elem.test.ts`
- `pnpm --filter @wangeditor-next/plugin-formula build`
- `pnpm typecheck`

## 说明
- 本地用于验收的 `apps/demo-react` 与 `pnpm-lock.yaml` 临时改动未包含在本 PR 内。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed incorrect rendering of absolute value delimiters in mathematical formulas.

* **Documentation**
  * Updated installation guide to include KaTeX CSS import (`katex.min.css`) before plugin registration.
  * Added clarification that the KaTeX stylesheet must be loaded on the page for formulas to render properly; missing styles result in unformatted text display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/882?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->