### PR TITLE
feat(table): add configurable table width export mode

### DIFF
--- a/.changeset/calm-news-prove.md
+++ b/.changeset/calm-news-prove.md
@@ -1,0 +1,11 @@
+---
+'@wangeditor-next/core': patch
+'@wangeditor-next/editor': patch
+'@wangeditor-next/table-module': patch
+---
+
+feat(table): add configurable width export mode for table html
+
+- Added `insertTable.widthExportMode` with `adaptive | explicit`.
+- Default mode remains `explicit` for backward compatibility.
+- `adaptive` mode can be enabled to keep `width:auto` on table export.

--- a/packages/core/src/config/interface.ts
+++ b/packages/core/src/config/interface.ts
@@ -25,6 +25,7 @@ interface IHoverbarConf {
 export type AlertType = 'success' | 'info' | 'warning' | 'error'
 export type TextStyleMode = 'inline' | 'class'
 export type ClassStylePolicy = 'preserve-data' | 'fallback-inline' | 'strict'
+export type TableWidthExportMode = 'adaptive' | 'explicit'
 export type StyleClassTokenType =
   | 'color'
   | 'bgColor'
@@ -116,12 +117,14 @@ interface IEmotionConfig {
 
 interface IInsertTableConfig {
   minWidth: number;
+  minRowHeight: number;
   tableHeader: {
     selected: boolean;
   };
   tableFullWidth: {
     selected: boolean;
-  }
+  };
+  widthExportMode: TableWidthExportMode;
 }
 
 interface IInsertTableColConfig {

--- a/packages/editor/__tests__/create.test.ts
+++ b/packages/editor/__tests__/create.test.ts
@@ -185,7 +185,39 @@ describe('create editor and toolbar', () => {
     expect(exportedHtml).toContain('<p>123</p>')
   })
 
-  test('getHtml exports explicit table width when imported table uses colgroup widths', () => {
+  test('getHtml keeps auto table width when imported table uses colgroup widths in adaptive mode', () => {
+    const html = `<table style="width: auto;table-layout: fixed;height:auto">
+      <colgroup contentEditable="false">
+        <col width="120"></col>
+        <col width="80"></col>
+      </colgroup>
+      <tbody>
+        <tr><td>A</td><td>B</td></tr>
+      </tbody>
+    </table>`
+
+    const editor = customCreateEditor({
+      html,
+      config: {
+        MENU_CONF: {
+          insertTable: {
+            widthExportMode: 'adaptive',
+          },
+        },
+      },
+    })
+    const exportedHtml = editor.getHtml()
+
+    editor.setHtml(exportedHtml)
+    const roundTripHtml = editor.getHtml()
+
+    expect(exportedHtml).toContain('style="width: auto;table-layout: fixed;')
+    expect(roundTripHtml).toContain('style="width: auto;table-layout: fixed;')
+    expect(exportedHtml).not.toContain('height:NaN')
+    expect(exportedHtml).toContain('<colgroup contentEditable="false"><col width=120></col><col width=80></col></colgroup>')
+  })
+
+  test('getHtml exports explicit table width by default for imported colgroup widths', () => {
     const html = `<table style="width: auto;table-layout: fixed;height:auto">
       <colgroup contentEditable="false">
         <col width="120"></col>
@@ -200,7 +232,6 @@ describe('create editor and toolbar', () => {
     const exportedHtml = editor.getHtml()
 
     expect(exportedHtml).toContain('style="width: 200px;table-layout: fixed;')
-    expect(exportedHtml).not.toContain('height:NaN')
     expect(exportedHtml).toContain('<colgroup contentEditable="false"><col width=120></col><col width=80></col></colgroup>')
   })
 

--- a/packages/table-module/src/module/elem-to-html.ts
+++ b/packages/table-module/src/module/elem-to-html.ts
@@ -8,6 +8,8 @@ import { Element } from 'slate'
 
 import { TableCellElement, TableElement, TableRowElement } from './custom-types'
 
+type TableWidthExportMode = 'adaptive' | 'explicit'
+
 function escapeHtml(raw: string): string {
   return raw
     .replace(/&/g, '&amp;')
@@ -17,11 +19,29 @@ function escapeHtml(raw: string): string {
     .replace(/'/g, '&#39;')
 }
 
-function getExportTableWidth(tableNode: TableElement): string {
+function getTableWidthExportMode(editor?: IDomEditor): TableWidthExportMode {
+  if (!editor || typeof editor.getMenuConfig !== 'function') {
+    return 'explicit'
+  }
+
+  const menuConf = editor.getMenuConfig('insertTable') as { widthExportMode?: TableWidthExportMode }
+
+  return menuConf?.widthExportMode === 'explicit' ? 'explicit' : 'adaptive'
+}
+
+function getExportTableWidth(tableNode: TableElement, editor?: IDomEditor): string {
   const { width = 'auto', columnWidths = [] } = tableNode
 
   if (width && width !== 'auto') {
     return width
+  }
+
+  const widthExportMode = getTableWidthExportMode(editor)
+
+  // In adaptive mode, keep imported or generated auto-width tables as auto
+  // and only persist explicit fixed widths when width is not auto.
+  if (widthExportMode === 'adaptive') {
+    return 'auto'
   }
 
   const totalWidth = columnWidths.reduce((sum, columnWidth) => {
@@ -48,7 +68,7 @@ function tableToHtml(elemNode: Element, childrenHtml: string, editor?: IDomEdito
 
   const captionStr = caption ? `<caption>${escapeHtml(caption)}</caption>` : ''
   const colgroupStr = cols ? `<colgroup contentEditable="false">${cols}</colgroup>` : ''
-  const exportedWidth = getExportTableWidth(tableNode)
+  const exportedWidth = getExportTableWidth(tableNode, editor)
   const textStyleMode = getTextStyleMode(editor)
 
   if (textStyleMode === 'class') {

--- a/packages/table-module/src/module/menu/index.ts
+++ b/packages/table-module/src/module/menu/index.ts
@@ -18,6 +18,17 @@ import TableProperty from './TableProperty'
 
 export const insertTableMenuConf = {
   key: 'insertTable',
+  config: {
+    minWidth: 60,
+    minRowHeight: 30,
+    tableHeader: {
+      selected: true,
+    },
+    tableFullWidth: {
+      selected: false,
+    },
+    widthExportMode: 'explicit',
+  },
   factory() {
     return new InsertTable()
   },


### PR DESCRIPTION
## Summary

This PR adds a configurable table width export strategy and keeps backward compatibility by default.

- Added `MENU_CONF.insertTable.widthExportMode` with two modes:
  - `explicit` (default, legacy-compatible)
  - `adaptive` (preserve `width:auto` on export)
- Kept default behavior as `explicit` to avoid breaking existing integrations.
- Added regression tests for both modes.
- Added changeset.

Closes #885

## Why

Issue #885 reports that imported `width:auto; table-layout: fixed` tables become fixed pixel width after export. Some users expect auto width to be preserved, while others rely on explicit pixel-width export. This PR supports both via config.

## Behavior

- Default (`explicit`): unchanged behavior.
- Optional (`adaptive`): when table model width is `auto`, export keeps `width:auto` instead of converting from `columnWidths` to px.

## Risk

- Low risk for existing users: default remains `explicit`.
- Moderate risk only for users who opt into `adaptive` (changed export contract by configuration).

## Rollback

- Safe rollback path:
  - Runtime: set `MENU_CONF.insertTable.widthExportMode = 'explicit'`.
  - Code rollback: revert this PR commit.

## Validation

- `pnpm --filter @wangeditor-next/editor exec vitest run __tests__/create.test.ts -t "table width|explicit mode|adaptive mode|colgroup widths|by default" --reporter=dot`
- `pnpm --filter @wangeditor-next/table-module exec vitest run __tests__/elem-to-html.test.ts --reporter=dot`
- `pnpm --filter @wangeditor-next/table-module exec vitest run __tests__/parse-html.test.ts -t "colgroup widths|auto height|class mode attrs|width 100%" --reporter=dot`
- `pnpm exec eslint packages/core/src/config/interface.ts packages/editor/__tests__/create.test.ts packages/table-module/src/module/elem-to-html.ts packages/table-module/src/module/menu/index.ts`
- `pnpm turbo build --filter=@wangeditor-next/table-module --filter=@wangeditor-next/editor`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Table width export behavior is now configurable with two modes: `adaptive` (preserves flexible `width:auto` styling) and `explicit` (applies computed fixed widths). Default is `explicit` for backward compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/888?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->