### PR TITLE
chore(infra): 对齐 monorepo/rollup 基建与验证策略

### DIFF
--- a/.changeset/green-trains-sparkle.md
+++ b/.changeset/green-trains-sparkle.md
@@ -1,0 +1,19 @@
+---
+'@wangeditor-next/basic-modules': patch
+'@wangeditor-next/code-highlight': patch
+'@wangeditor-next/editor-for-react': patch
+'@wangeditor-next/list-module': patch
+'@wangeditor-next/plugin-float-image': patch
+'@wangeditor-next/plugin-formula': patch
+'@wangeditor-next/plugin-link-card': patch
+'@wangeditor-next/plugin-markdown': patch
+'@wangeditor-next/plugin-mention': patch
+'@wangeditor-next/table-module': patch
+'@wangeditor-next/upload-image-module': patch
+'@wangeditor-next/video-module': patch
+'@wangeditor-next/yjs': patch
+'@wangeditor-next/yjs-for-react': patch
+'@wangeditor-next/yjs-for-vue': patch
+---
+
+chore: relax internal peer dependency ranges to reduce forced lockstep upgrades.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,11 @@ concurrency:
 
 jobs:
   test:
+    name: Unit Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ['20.19.0', '22.13.0']
 
     steps:
       # 检出代码库
@@ -53,7 +57,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22.13.0
+          node-version: ${{ matrix.node-version }}
           registry-url: https://registry.npmjs.com
           cache: pnpm
 
@@ -74,15 +78,15 @@ jobs:
 
       # 在 master 上顺带产出覆盖率，避免额外 workflow 重复跑一轮
       - name: Unit test with coverage
-        if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref_name == 'master')
+        if: matrix.node-version == '22.13.0' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref_name == 'master'))
         run: pnpm run test-c
 
       - name: Unit test
-        if: github.event_name != 'workflow_dispatch' && !(github.event_name == 'push' && github.ref_name == 'master')
+        if: matrix.node-version != '22.13.0' || (github.event_name != 'workflow_dispatch' && !(github.event_name == 'push' && github.ref_name == 'master'))
         run: pnpm run test
 
       - name: Upload coverage reports to Codecov
-        if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref_name == 'master')
+        if: matrix.node-version == '22.13.0' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref_name == 'master'))
         uses: codecov/codecov-action@v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@
 
 ## 环境与工具
 
-- Node: `^22.13.0`（以 `package.json#engines` 为准）
+- Node: `^20.19.0 || ^22.13.0`（以 `package.json#engines` 为准）
 - Package Manager: `pnpm@9.15.0`
 - Monorepo: `pnpm workspaces` + `turbo`
 - Versioning/Release: `changesets`

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -5,7 +5,7 @@
 - 了解 slate.js
 - 了解 vdom 和 snabbdom.js
 - 了解 turbo 和 changeset
-- 已安装 Node.js `^22.13.0`
+- 已安装 Node.js `^20.19.0 || ^22.13.0`
 - 已安装 pnpm `9.15.0`
 
 ## 本地启动

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "packageManager": "pnpm@9.15.0",
   "engines": {
-    "node": "^22.13.0"
+    "node": "^20.19.0 || ^22.13.0"
   },
   "browserslist": [
     "defaults",

--- a/packages/basic-modules/package.json
+++ b/packages/basic-modules/package.json
@@ -44,7 +44,7 @@
     "url": "https://github.com/wangeditor-next/wangeditor-next/issues"
   },
   "peerDependencies": {
-    "@wangeditor-next/core": "1.9.1",
+    "@wangeditor-next/core": ">=1.9.1 <2",
     "dom7": "^3.0.0 || ^4.0.0",
     "lodash.throttle": "^4.1.1",
     "nanoid": "^5.0.0",

--- a/packages/code-highlight/package.json
+++ b/packages/code-highlight/package.json
@@ -44,7 +44,7 @@
     "url": "https://github.com/wangeditor-next/wangeditor-next/issues"
   },
   "peerDependencies": {
-    "@wangeditor-next/core": "1.9.1",
+    "@wangeditor-next/core": ">=1.9.1 <2",
     "dom7": "^3.0.0 || ^4.0.0",
     "slate": "^0.124.0",
     "snabbdom": "^3.6.0"

--- a/packages/editor-for-react/package.json
+++ b/packages/editor-for-react/package.json
@@ -47,7 +47,7 @@
     "react-dom": "^17.0.2"
   },
   "peerDependencies": {
-    "@wangeditor-next/editor": ">=5.7.6",
+    "@wangeditor-next/editor": ">=5.7.6 <6",
     "react": ">=17.0.2",
     "react-dom": ">=17.0.2"
   }

--- a/packages/list-module/package.json
+++ b/packages/list-module/package.json
@@ -44,7 +44,7 @@
     "url": "https://github.com/wangeditor-next/wangeditor-next/issues"
   },
   "peerDependencies": {
-    "@wangeditor-next/core": "1.9.1",
+    "@wangeditor-next/core": ">=1.9.1 <2",
     "dom7": "^3.0.0 || ^4.0.0",
     "slate": "^0.124.0",
     "snabbdom": "^3.6.0"

--- a/packages/plugin-float-image/package.json
+++ b/packages/plugin-float-image/package.json
@@ -41,7 +41,7 @@
     "url": "https://github.com/wangeditor-next/wangeditor-next/issues"
   },
   "peerDependencies": {
-    "@wangeditor-next/editor": "5.7.7",
+    "@wangeditor-next/editor": ">=5.7.7 <6",
     "dom7": "^3.0.0 || ^4.0.0",
     "slate": "^0.124.0",
     "snabbdom": "^3.6.0"

--- a/packages/plugin-formula/package.json
+++ b/packages/plugin-formula/package.json
@@ -45,7 +45,7 @@
     "katex": "^0.16.0"
   },
   "peerDependencies": {
-    "@wangeditor-next/editor": "5.7.7",
+    "@wangeditor-next/editor": ">=5.7.7 <6",
     "katex": "^0.16.0",
     "snabbdom": "^3.6.0"
   },

--- a/packages/plugin-link-card/package.json
+++ b/packages/plugin-link-card/package.json
@@ -41,7 +41,7 @@
     "url": "https://github.com/wangeditor-next/wangeditor-next/issues"
   },
   "peerDependencies": {
-    "@wangeditor-next/editor": "5.7.7",
+    "@wangeditor-next/editor": ">=5.7.7 <6",
     "dom7": "^3.0.0 || ^4.0.0",
     "slate": "^0.124.0",
     "snabbdom": "^3.6.0"

--- a/packages/plugin-markdown/package.json
+++ b/packages/plugin-markdown/package.json
@@ -41,7 +41,7 @@
     "url": "https://github.com/wangeditor-next/wangeditor-next/issues"
   },
   "peerDependencies": {
-    "@wangeditor-next/editor": "5.7.7",
+    "@wangeditor-next/editor": ">=5.7.7 <6",
     "dom7": "^3.0.0 || ^4.0.0",
     "slate": "^0.124.0",
     "snabbdom": "^3.6.0"

--- a/packages/plugin-mention/package.json
+++ b/packages/plugin-mention/package.json
@@ -41,7 +41,7 @@
     "url": "https://github.com/wangeditor-next/wangeditor-next/issues"
   },
   "peerDependencies": {
-    "@wangeditor-next/editor": "5.7.7",
+    "@wangeditor-next/editor": ">=5.7.7 <6",
     "snabbdom": "^3.6.0"
   },
   "devDependencies": {

--- a/packages/table-module/package.json
+++ b/packages/table-module/package.json
@@ -44,7 +44,7 @@
     "url": "https://github.com/wangeditor-next/wangeditor-next/issues"
   },
   "peerDependencies": {
-    "@wangeditor-next/core": "1.9.1",
+    "@wangeditor-next/core": ">=1.9.1 <2",
     "dom7": "^3.0.0 || ^4.0.0",
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",

--- a/packages/upload-image-module/package.json
+++ b/packages/upload-image-module/package.json
@@ -47,7 +47,7 @@
     "@uppy/core": "^2.0.3 || ^5.0.0",
     "@uppy/xhr-upload": "^2.0.3 || ^5.0.0",
     "@wangeditor-next/basic-modules": "3.0.1",
-    "@wangeditor-next/core": "1.9.1",
+    "@wangeditor-next/core": ">=1.9.1 <2",
     "dom7": "^3.0.0 || ^4.0.0",
     "lodash.foreach": "^4.5.0",
     "slate": "^0.124.0",

--- a/packages/video-module/package.json
+++ b/packages/video-module/package.json
@@ -46,7 +46,7 @@
   "peerDependencies": {
     "@uppy/core": "^2.1.4 || ^5.0.0",
     "@uppy/xhr-upload": "^2.0.7 || ^5.0.0",
-    "@wangeditor-next/core": "1.9.1",
+    "@wangeditor-next/core": ">=1.9.1 <2",
     "dom7": "^3.0.0 || ^4.0.0",
     "nanoid": "^5.0.0",
     "slate": "^0.124.0",

--- a/packages/yjs-for-react/package.json
+++ b/packages/yjs-for-react/package.json
@@ -59,7 +59,7 @@
     "y-protocols": "^1.0.5"
   },
   "peerDependencies": {
-    "@wangeditor-next/editor": "5.7.7",
+    "@wangeditor-next/editor": ">=5.7.7 <6",
     "@wangeditor-next/yjs": "^2.0.1",
     "react": ">=17.0.2",
     "slate": "^0.124.0",

--- a/packages/yjs-for-vue/package.json
+++ b/packages/yjs-for-vue/package.json
@@ -57,7 +57,7 @@
     "y-protocols": "^1.0.5"
   },
   "peerDependencies": {
-    "@wangeditor-next/editor": "5.7.7",
+    "@wangeditor-next/editor": ">=5.7.7 <6",
     "@wangeditor-next/yjs": "^2.0.1",
     "vue": ">=3.5.18",
     "slate": "^0.124.0",

--- a/packages/yjs/package.json
+++ b/packages/yjs/package.json
@@ -48,7 +48,7 @@
     "size-stats": "cross-env NODE_ENV=production:size_stats rollup -c rollup.config.js"
   },
   "peerDependencies": {
-    "@wangeditor-next/core": "1.9.1",
+    "@wangeditor-next/core": ">=1.9.1 <2",
     "slate": "^0.124.0",
     "yjs": "^13.5.29"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -427,7 +427,7 @@ importers:
   packages/basic-modules:
     dependencies:
       '@wangeditor-next/core':
-        specifier: 1.9.1
+        specifier: '>=1.9.1 <2'
         version: link:../core
       dom7:
         specifier: ^3.0.0 || ^4.0.0
@@ -458,7 +458,7 @@ importers:
   packages/code-highlight:
     dependencies:
       '@wangeditor-next/core':
-        specifier: 1.9.1
+        specifier: '>=1.9.1 <2'
         version: link:../core
       dom7:
         specifier: ^3.0.0 || ^4.0.0
@@ -638,7 +638,7 @@ importers:
   packages/list-module:
     dependencies:
       '@wangeditor-next/core':
-        specifier: 1.9.1
+        specifier: '>=1.9.1 <2'
         version: link:../core
       dom7:
         specifier: ^3.0.0 || ^4.0.0
@@ -683,7 +683,7 @@ importers:
   packages/plugin-float-image:
     dependencies:
       '@wangeditor-next/editor':
-        specifier: 5.7.7
+        specifier: '>=5.7.7 <6'
         version: link:../editor
       dom7:
         specifier: ^3.0.0 || ^4.0.0
@@ -702,7 +702,7 @@ importers:
   packages/plugin-formula:
     dependencies:
       '@wangeditor-next/editor':
-        specifier: 5.7.7
+        specifier: '>=5.7.7 <6'
         version: link:../editor
       dom7:
         specifier: ^4.0.0
@@ -724,7 +724,7 @@ importers:
   packages/plugin-link-card:
     dependencies:
       '@wangeditor-next/editor':
-        specifier: 5.7.7
+        specifier: '>=5.7.7 <6'
         version: link:../editor
       dom7:
         specifier: ^3.0.0 || ^4.0.0
@@ -743,7 +743,7 @@ importers:
   packages/plugin-markdown:
     dependencies:
       '@wangeditor-next/editor':
-        specifier: 5.7.7
+        specifier: '>=5.7.7 <6'
         version: link:../editor
       dom7:
         specifier: ^3.0.0 || ^4.0.0
@@ -762,7 +762,7 @@ importers:
   packages/plugin-mention:
     dependencies:
       '@wangeditor-next/editor':
-        specifier: 5.7.7
+        specifier: '>=5.7.7 <6'
         version: link:../editor
       snabbdom:
         specifier: ^3.6.0
@@ -775,7 +775,7 @@ importers:
   packages/table-module:
     dependencies:
       '@wangeditor-next/core':
-        specifier: 1.9.1
+        specifier: '>=1.9.1 <2'
         version: link:../core
       dom7:
         specifier: ^3.0.0 || ^4.0.0
@@ -812,7 +812,7 @@ importers:
         specifier: 3.0.1
         version: link:../basic-modules
       '@wangeditor-next/core':
-        specifier: 1.9.1
+        specifier: '>=1.9.1 <2'
         version: link:../core
       dom7:
         specifier: ^3.0.0 || ^4.0.0
@@ -840,7 +840,7 @@ importers:
         specifier: ^2.0.7 || ^5.0.0
         version: 2.1.3(@uppy/core@2.3.4)
       '@wangeditor-next/core':
-        specifier: 1.9.1
+        specifier: '>=1.9.1 <2'
         version: link:../core
       dom7:
         specifier: ^3.0.0 || ^4.0.0
@@ -862,7 +862,7 @@ importers:
   packages/yjs:
     dependencies:
       '@wangeditor-next/core':
-        specifier: 1.9.1
+        specifier: '>=1.9.1 <2'
         version: link:../core
       y-protocols:
         specifier: ^1.0.5
@@ -884,7 +884,7 @@ importers:
   packages/yjs-for-react:
     dependencies:
       '@wangeditor-next/editor':
-        specifier: 5.7.7
+        specifier: '>=5.7.7 <6'
         version: link:../editor
       '@wangeditor-next/yjs':
         specifier: ^2.0.1
@@ -915,7 +915,7 @@ importers:
   packages/yjs-for-vue:
     dependencies:
       '@wangeditor-next/editor':
-        specifier: 5.7.7
+        specifier: '>=5.7.7 <6'
         version: link:../editor
       '@wangeditor-next/yjs':
         specifier: ^2.0.1

--- a/scripts/typecheck-all.js
+++ b/scripts/typecheck-all.js
@@ -7,6 +7,8 @@ const { spawnSync } = require('node:child_process')
 const rootDir = path.resolve(__dirname, '..')
 const scanDirs = ['packages']
 const ignoredDirs = new Set(['node_modules', 'dist', 'lib', 'coverage', '.turbo', '.git'])
+const typecheckCacheDir = path.join(rootDir, '.turbo', 'typecheck')
+const disableIncremental = process.env.TYPECHECK_NO_INCREMENTAL === '1'
 
 function collectTsconfigFiles(startDir) {
   const result = []
@@ -44,17 +46,25 @@ function collectTsconfigFiles(startDir) {
 
 function runTypecheck(tsconfigPath) {
   const relativePath = path.relative(rootDir, tsconfigPath).replace(/\\/g, '/')
+  const args = ['exec', 'tsc', '--noEmit', '--pretty', 'false', '--skipLibCheck']
+  const buildInfoPath = path.join(
+    typecheckCacheDir,
+    `${relativePath.replace(/[\\/]/g, '__').replace(/\.json$/, '')}.tsbuildinfo`
+  )
 
   console.log(`[typecheck] ${relativePath}`)
 
-  const res = spawnSync(
-    'pnpm',
-    ['exec', 'tsc', '--noEmit', '--pretty', 'false', '--skipLibCheck', '-p', relativePath],
-    {
-      cwd: rootDir,
-      stdio: 'inherit',
-    }
-  )
+  if (!disableIncremental) {
+    fs.mkdirSync(path.dirname(buildInfoPath), { recursive: true })
+    args.push('--incremental', '--tsBuildInfoFile', path.relative(rootDir, buildInfoPath))
+  }
+
+  args.push('-p', relativePath)
+
+  const res = spawnSync('pnpm', args, {
+    cwd: rootDir,
+    stdio: 'inherit',
+  })
 
   if (res.status !== 0) {
     process.exit(res.status ?? 1)

--- a/turbo.json
+++ b/turbo.json
@@ -1,10 +1,19 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": [
+    "package.json",
+    "pnpm-lock.yaml",
+    "tsconfig.json",
+    "shared/rollup-config/**"
+  ],
   "tasks": {
     "dev": {
       "inputs": [
+        "$TURBO_DEFAULT$",
         "src/**",
-        "rollup.config.js"
+        "rollup.config.js",
+        "tsconfig.json",
+        "package.json"
       ],
       "dependsOn": [
         "^dev"
@@ -15,8 +24,11 @@
     },
     "build": {
       "inputs": [
+        "$TURBO_DEFAULT$",
         "src/**",
-        "rollup.config.js"
+        "rollup.config.js",
+        "tsconfig.json",
+        "package.json"
       ],
       "dependsOn": [
         "^build"

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -64,10 +64,10 @@ export default defineConfig({
         '**/index.ts',
       ], // 忽略覆盖率计算的文件
       thresholds: {
-        lines: 1,
-        functions: 1,
-        branches: 1,
-        statements: 1,
+        lines: 70,
+        functions: 70,
+        branches: 60,
+        statements: 70,
       },
     },
   },


### PR DESCRIPTION
## 背景
对齐 `wangEditor-next` 在 monorepo / rollup / 类型检查 / 依赖策略 / 覆盖率门禁方面的工程基线，降低后续维护和升级成本。

## 改动内容
1. CI Node 版本策略
- `engines.node` 调整为 `^20.19.0 || ^22.13.0`
- `test.yml` 启用 Node `20.19.0` / `22.13.0` 矩阵（覆盖率仅在 `22.13.0` 任务上产出）

2. Turbo 缓存输入对齐
- 为 `turbo.json` 增加 `globalDependencies`
- 为 `build`/`dev` 任务补齐输入键（`$TURBO_DEFAULT$`、`package.json`、`tsconfig.json`）

3. Typecheck 增量化
- `scripts/typecheck-all.js` 启用 `tsc --incremental` 与 `--tsBuildInfoFile`
- 增加 `TYPECHECK_NO_INCREMENTAL=1` 开关，保持兼容可回退

4. 内部 peer 版本策略统一
- 将内部 peer 从精确版本改为有上界区间（如 `>=5.7.7 <6`、`>=1.9.1 <2`）
- 降低插件与核心包“锁步升级”成本
- 含 changeset：`.changeset/green-trains-sparkle.md`

5. 覆盖率阈值提升
- `vitest.config.mts` 阈值从 `1` 提升为：
  - `lines: 70`
  - `functions: 70`
  - `branches: 60`
  - `statements: 70`

## 验证
- `pnpm run typecheck` ✅
- `pnpm run test-c` ✅（210 files / 1039 tests passed）
- `pnpm build` ✅（仅现有 rollup warnings，无新增 error）

## 风险与回滚
- 风险主要在 peer 区间放宽后，外部安装时可能暴露更早/更晚版本组合问题；本次通过 CI + 单测覆盖基础路径。
- 如需回滚，可按 commit 维度逐步 revert（每个 commit 单一目的，便于分步回退）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended Node.js version support to include LTS versions (`20.19.0` and `22.13.0`).
  * Relaxed peer dependency version ranges across packages to reduce forced lockstep upgrades and improve flexibility.
  * Enhanced test infrastructure with multi-version Node.js compatibility testing.
  * Increased test coverage thresholds to improve code quality standards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/889?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->