### PR TITLE
fix(table): auto-fit imported auto-width fixed-layout columns

### DIFF
--- a/.changeset/fancy-garlics-learn.md
+++ b/.changeset/fancy-garlics-learn.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/table-module': patch
+---
+
+Fix table import for `width:auto; table-layout: fixed` HTML so initial column widths are auto-fitted from rendered content when no explicit column/cell widths are provided.

--- a/packages/table-module/__tests__/parse-html.test.ts
+++ b/packages/table-module/__tests__/parse-html.test.ts
@@ -3,6 +3,7 @@
  * @author wangfupeng
  */
 import { $ } from 'dom7'
+import { vi } from 'vitest'
 
 import createEditor from '../../../tests/utils/create-editor'
 import { registerParseElemHtmlConf } from '../../core/src/parse-html'
@@ -90,6 +91,109 @@ describe('table - pre parse html', () => {
         '</td></tr></table>',
       ].join(''),
     )
+  })
+
+  it('should infer column widths for imported fixed-layout auto-width table', () => {
+    const $table = $(
+      [
+        '<table style="width:auto;table-layout: fixed;">',
+        '<tbody>',
+        '<tr>',
+        '<td data-measure-width="120">名称</td>',
+        '<td data-measure-width="360">影响</td>',
+        '</tr>',
+        '<tr>',
+        '<td>鸦片战争</td>',
+        '<td>中国开始沦为半殖民地半封建社会；成为中国近代史的开端</td>',
+        '</tr>',
+        '</tbody>',
+        '</table>',
+      ].join(''),
+    )
+
+    const boundingClientRectSpy = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: HTMLElement) {
+        const widthAttr = this.getAttribute('data-measure-width')
+        const width = widthAttr ? parseInt(widthAttr, 10) : 0
+
+        return {
+          x: 0,
+          y: 0,
+          top: 0,
+          left: 0,
+          right: width,
+          bottom: 20,
+          width,
+          height: 20,
+          toJSON() {
+            return {}
+          },
+        } as DOMRect
+      })
+
+    try {
+      const res = preParseTableHtmlConf.preParseHtml($table[0])
+      const $res = $(res)
+      const cols = $res.find('colgroup col')
+
+      expect(cols.length).toBe(2)
+      expect($(cols[0]).attr('width')).toBe('120')
+      expect($(cols[1]).attr('width')).toBe('360')
+      expect($res.find('td')[0].getAttribute('width')).toBe('auto')
+      expect($res.find('td')[1].getAttribute('width')).toBe('auto')
+    } finally {
+      boundingClientRectSpy.mockRestore()
+    }
+  })
+
+  it('should skip inferred widths when table already has explicit colgroup widths', () => {
+    const $table = $(
+      [
+        '<table style="width:auto;table-layout: fixed;">',
+        '<colgroup>',
+        '<col width="80"></col>',
+        '<col width="120"></col>',
+        '</colgroup>',
+        '<tbody>',
+        '<tr><td data-measure-width="999">A</td><td data-measure-width="999">B</td></tr>',
+        '</tbody>',
+        '</table>',
+      ].join(''),
+    )
+
+    const boundingClientRectSpy = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: HTMLElement) {
+        const widthAttr = this.getAttribute('data-measure-width')
+        const width = widthAttr ? parseInt(widthAttr, 10) : 0
+
+        return {
+          x: 0,
+          y: 0,
+          top: 0,
+          left: 0,
+          right: width,
+          bottom: 20,
+          width,
+          height: 20,
+          toJSON() {
+            return {}
+          },
+        } as DOMRect
+      })
+
+    try {
+      const res = preParseTableHtmlConf.preParseHtml($table[0])
+      const $res = $(res)
+      const cols = $res.find('colgroup col')
+
+      expect(cols.length).toBe(2)
+      expect($(cols[0]).attr('width')).toBe('80')
+      expect($(cols[1]).attr('width')).toBe('120')
+    } finally {
+      boundingClientRectSpy.mockRestore()
+    }
   })
 })
 

--- a/packages/table-module/src/module/pre-parse-html.ts
+++ b/packages/table-module/src/module/pre-parse-html.ts
@@ -5,6 +5,180 @@
 
 import $, { DOMElement, getTagName } from '../utils/dom'
 
+function hasExplicitColgroupWidths($table: ReturnType<typeof $>): boolean {
+  const colgroupElements = $table.find('colgroup')
+
+  for (let i = 0; i < colgroupElements.length; i += 1) {
+    const colgroup = colgroupElements[i] as HTMLTableColElement
+
+    for (let j = 0; j < colgroup.children.length; j += 1) {
+      const col = colgroup.children[j] as HTMLTableColElement
+      const widthAttr = (col.getAttribute('width') || '').trim().toLowerCase()
+      const styleWidth = (col.style.width || '').trim().toLowerCase()
+
+      if (widthAttr && widthAttr !== 'auto') {
+        return true
+      }
+      if (styleWidth && styleWidth !== 'auto') {
+        return true
+      }
+    }
+  }
+
+  return false
+}
+
+function hasExplicitCellWidths($table: ReturnType<typeof $>): boolean {
+  const $cells = $table.find('td, th')
+
+  for (let i = 0; i < $cells.length; i += 1) {
+    const cell = $cells[i] as HTMLTableCellElement
+    const widthAttr = (cell.getAttribute('width') || '').trim().toLowerCase()
+    const styleWidth = (cell.style.width || '').trim().toLowerCase()
+
+    if (widthAttr && widthAttr !== 'auto') {
+      return true
+    }
+    if (styleWidth && styleWidth !== 'auto') {
+      return true
+    }
+  }
+
+  return false
+}
+
+function isAutoWidthFixedLayoutTable($table: ReturnType<typeof $>): boolean {
+  const widthAttr = ($table.attr('width') || '').trim().toLowerCase()
+  const styleWidth = ($table[0] as HTMLTableElement).style.width.trim().toLowerCase()
+  const tableLayout = ($table[0] as HTMLTableElement).style.tableLayout.trim().toLowerCase()
+
+  const isClassModeTable =
+    $table.hasClass('w-e-table-layout-fixed') || !!$table.attr('data-w-e-table-height')
+  const isAutoWidth = widthAttr === 'auto' || styleWidth === 'auto'
+
+  if (isClassModeTable) {
+    return false
+  }
+  if (!isAutoWidth) {
+    return false
+  }
+  if (tableLayout !== 'fixed') {
+    return false
+  }
+
+  return true
+}
+
+function measureColumnWidthsFromLayout(tableElem: HTMLTableElement): number[] {
+  if (typeof document === 'undefined' || !document.body) {
+    return []
+  }
+
+  const sandbox = document.createElement('div')
+
+  sandbox.style.position = 'fixed'
+  sandbox.style.top = '-10000px'
+  sandbox.style.left = '0'
+  sandbox.style.visibility = 'hidden'
+  sandbox.style.pointerEvents = 'none'
+
+  const tableClone = tableElem.cloneNode(true) as HTMLTableElement
+
+  sandbox.appendChild(tableClone)
+  document.body.appendChild(sandbox)
+
+  try {
+    const firstRow = tableClone.querySelector('tr')
+
+    if (!firstRow) {
+      return []
+    }
+
+    const cells = Array.from(firstRow.children).filter(cell => {
+      const tag = cell.tagName.toLowerCase()
+
+      return tag === 'td' || tag === 'th'
+    }) as HTMLTableCellElement[]
+
+    if (cells.length === 0) {
+      return []
+    }
+
+    const measuredWidths: number[] = []
+
+    for (let i = 0; i < cells.length; i += 1) {
+      const cell = cells[i]
+      const span = parseInt(cell.getAttribute('colspan') || '1', 10)
+      const safeSpan = Number.isFinite(span) && span > 0 ? span : 1
+      const cellWidth = cell.getBoundingClientRect().width
+
+      if (!Number.isFinite(cellWidth) || cellWidth <= 0) {
+        return []
+      }
+
+      const widthPerColumn = Math.max(1, Math.round(cellWidth / safeSpan))
+
+      for (let j = 0; j < safeSpan; j += 1) {
+        measuredWidths.push(widthPerColumn)
+      }
+    }
+
+    return measuredWidths
+  } finally {
+    sandbox.remove()
+  }
+}
+
+function applyMeasuredColumnWidths(tableElem: HTMLTableElement, columnWidths: number[]) {
+  if (columnWidths.length === 0) {
+    return
+  }
+
+  const existingColgroup = tableElem.querySelector('colgroup')
+
+  if (existingColgroup) {
+    existingColgroup.remove()
+  }
+
+  const colgroupElem = document.createElement('colgroup')
+
+  colgroupElem.setAttribute('contentEditable', 'false')
+  columnWidths.forEach(width => {
+    const colElem = document.createElement('col')
+
+    colElem.setAttribute('width', `${width}`)
+    colgroupElem.appendChild(colElem)
+  })
+
+  const firstRow = tableElem.querySelector('tr')
+
+  if (firstRow) {
+    tableElem.insertBefore(colgroupElem, firstRow)
+  } else {
+    tableElem.appendChild(colgroupElem)
+  }
+}
+
+function tryApplyAutoFittedColumnWidths($table: ReturnType<typeof $>) {
+  if (!isAutoWidthFixedLayoutTable($table)) {
+    return
+  }
+  if (hasExplicitColgroupWidths($table)) {
+    return
+  }
+  if (hasExplicitCellWidths($table)) {
+    return
+  }
+
+  const columnWidths = measureColumnWidthsFromLayout($table[0] as HTMLTableElement)
+
+  if (columnWidths.length === 0) {
+    return
+  }
+
+  applyMeasuredColumnWidths($table[0] as HTMLTableElement, columnWidths)
+}
+
 function normalizeCellParagraphs(cellHtml: string): string {
   const container = document.createElement('div')
 
@@ -31,7 +205,9 @@ function normalizeCellParagraphs(cellHtml: string): string {
     const paragraphHtml = node.innerHTML
     const trimmedHtml = paragraphHtml.trim()
 
-    if (!trimmedHtml || trimmedHtml === '&nbsp;') { return }
+    if (!trimmedHtml || trimmedHtml === '&nbsp;') {
+      return
+    }
 
     if (hasMeaningfulContent) {
       normalizedNodes.push(document.createElement('br'))
@@ -60,12 +236,16 @@ function preParse(tableElem: DOMElement): DOMElement {
   const $table = $(tableElem)
   const tagName = getTagName($table)
 
-  if (tagName !== 'table') { return tableElem }
+  if (tagName !== 'table') {
+    return tableElem
+  }
 
   // 没有 <tbody> 则直接返回
   const $tbody = $table.find('tbody')
 
-  if ($tbody.length === 0) { return tableElem }
+  if ($tbody.length === 0) {
+    return tableElem
+  }
 
   // 去掉 <tbody> ，把 <tr> 移动到 <table> 下面
   const $tr = $table.find('tr')
@@ -93,6 +273,8 @@ function preParse(tableElem: DOMElement): DOMElement {
 
     $cell.html(cellHtml)
   }
+
+  tryApplyAutoFittedColumnWidths($table)
 
   return $table[0]
 }


### PR DESCRIPTION
## Summary
- auto-fit imported table column widths during pre-parse when HTML table is `width:auto` + `table-layout: fixed`
- only applies when no explicit column/cell widths exist, so existing explicit width behavior is preserved
- keep editor runtime on the current fixed-width + resize model after import

## Tests
- `pnpm exec eslint packages/table-module/src/module/pre-parse-html.ts packages/table-module/__tests__/parse-html.test.ts`
- `pnpm --dir packages/table-module test`
- `pnpm --dir packages/core test -- __tests__/editor/plugins/with-content.test.ts`
- `pnpm --dir packages/editor test -- create.test.ts`

Fixes #885


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed HTML table rendering for fixed-layout tables with auto width, ensuring column widths are automatically fitted based on rendered content when no explicit widths are provided.

* **Tests**
  * Added test coverage for automatic column width inference in fixed-layout tables.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/wangEditor-next/pull/890?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->