### PR TITLE
fix(core): 修复 #892 divider 撤销后输入报错

### DIFF
--- a/.changeset/tough-snails-dance.md
+++ b/.changeset/tough-snails-dance.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/core': patch
+---
+
+fix beforeinput target range mapping after divider undo to tolerate stale DOM nodes and avoid "Cannot resolve a Slate node from DOM node" errors when typing

--- a/packages/core/__tests__/text-area/event-handlers/before-input.test.ts
+++ b/packages/core/__tests__/text-area/event-handlers/before-input.test.ts
@@ -289,6 +289,62 @@ describe('handleBeforeInput', () => {
     expect(Editor.insertText).toHaveBeenCalledWith(editor, 'same')
   })
 
+  it('skips reselection when target range cannot be mapped to Slate', () => {
+    const editor = {
+      selection: createSelection(false),
+      getConfig: () => ({ readOnly: false }),
+      insertData: vi.fn(),
+    } as any
+    const targetRange = { startContainer: document.createTextNode('x') }
+    const event = {
+      inputType: 'insertText',
+      data: 'hello',
+      dataTransfer: null,
+      target: {},
+      preventDefault: vi.fn(),
+      getTargetRanges: () => [targetRange],
+    } as any
+
+    vi.spyOn(helpers, 'hasEditableTarget').mockReturnValue(true)
+    vi.spyOn(DomEditor, 'toSlateRange').mockReturnValue(null as any)
+    vi.spyOn(Transforms, 'select').mockImplementation(() => {})
+    vi.spyOn(Editor, 'insertText').mockImplementation(() => {})
+
+    expect(() => handleBeforeInput(event, {} as any, editor)).not.toThrow()
+    expect(DomEditor.toSlateRange).toHaveBeenCalledWith(editor, targetRange, {
+      exactMatch: false,
+      suppressThrow: true,
+    })
+    expect(Transforms.select).not.toHaveBeenCalled()
+    expect(Editor.insertText).toHaveBeenCalledWith(editor, 'hello')
+  })
+
+  it('does not throw when target range points to stale DOM nodes', () => {
+    const editor = {
+      selection: createSelection(false),
+      getConfig: () => ({ readOnly: false }),
+      insertData: vi.fn(),
+    } as any
+    const targetRange = { startContainer: document.createTextNode('x') }
+    const event = {
+      inputType: 'insertText',
+      data: 'hello',
+      dataTransfer: null,
+      target: {},
+      preventDefault: vi.fn(),
+      getTargetRanges: () => [targetRange],
+    } as any
+
+    vi.spyOn(helpers, 'hasEditableTarget').mockReturnValue(true)
+    vi.spyOn(DomEditor, 'toSlateRange').mockImplementation(() => {
+      throw new Error('Cannot resolve a Slate node from DOM node')
+    })
+    vi.spyOn(Editor, 'insertText').mockImplementation(() => {})
+
+    expect(() => handleBeforeInput(event, {} as any, editor)).not.toThrow()
+    expect(Editor.insertText).toHaveBeenCalledWith(editor, 'hello')
+  })
+
   it('does not delete when selection partially covers a table', () => {
     const editor = {
       selection: createSelection(true),

--- a/packages/core/src/text-area/event-handlers/beforeInput.ts
+++ b/packages/core/src/text-area/event-handlers/beforeInput.ts
@@ -56,12 +56,20 @@ function handleBeforeInput(e: Event, textarea: TextArea, editor: IDomEditor) {
     const [targetRange] = event.getTargetRanges()
 
     if (targetRange) {
-      const range = DomEditor.toSlateRange(editor, targetRange, {
-        exactMatch: false,
-        suppressThrow: false,
-      })
+      let range: Range | null = null
 
-      if (!selection || !Range.equals(selection, range)) {
+      try {
+        range = DomEditor.toSlateRange(editor, targetRange, {
+          exactMatch: false,
+          suppressThrow: true,
+        })
+      } catch {
+        // Undo/redo or IME transitions can leave beforeinput target ranges
+        // pointing to stale DOM nodes for a short time.
+        range = null
+      }
+
+      if (range && (!selection || !Range.equals(selection, range))) {
         Transforms.select(editor, range)
       }
     }


### PR DESCRIPTION
## 背景

修复 issue #892：在默认 demo 中执行“插入分割线 -> 撤销 -> 重新输入”时，偶发抛出 `Cannot resolve a Slate node from DOM node`。

## 变更

 在 `beforeinput` 中将 `targetRange -> Slate range` 的映射改为容错模式：
  - 使用 `suppressThrow: true`\n  - 对 stale DOM 导致的映射异常进行兜底（跳过重选区，不中断输入）
  - 新增回归测试：
  - target range 无法映射时不抛错且继续输入
  - target range 指向 stale DOM 时不抛错且继续输入
  - 增加 changeset（`@wangeditor-next/core` patch）
 
 ## 验证

- `pnpm --filter @wangeditor-next/core test -- __tests__/text-area/event-handlers/before-input.test.ts`
- `pnpm --filter @wangeditor-next/core test -- __tests__/text-area/event-handlers/composition.test.ts __tests__/text-area/syncSelection.test.ts`
- `pnpm --filter @wangeditor-next/core exec eslint src/text-area/event-handlers/beforeInput.ts __tests__/text-area/event-handlers/before-input.test.ts`
- `pnpm --filter @wangeditor-next/core build`

Closes #892

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed text input errors that could occur after using undo on divider operations, ensuring a smooth typing experience after these actions.
* Improved error handling for DOM node references that may become stale during text input to prevent interruption and crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->