### PR TITLE
fix(table-module): fix #893 table full-width toggle and resize

### DIFF
--- a/.changeset/smart-lemons-reply.md
+++ b/.changeset/smart-lemons-reply.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/table-module': patch
+---
+
+Fix regression in table full-width workflow: `tableFullWidth` now toggles between `100%` and `auto`, and manual column resize in `100%` mode switches table width back to `auto` while applying rendered-width-based column updates.

--- a/packages/table-module/__tests__/column-resize.test.ts
+++ b/packages/table-module/__tests__/column-resize.test.ts
@@ -318,4 +318,53 @@ describe('column resize module', () => {
       { at: [0] },
     )
   })
+
+  test('dragging in full-width mode should switch to auto width and use rendered column widths', async () => {
+    const table = {
+      ...createTable([100, 100]),
+      width: '100%',
+      scrollWidth: 300,
+      resizingIndex: 0,
+    }
+    const tableDom = document.createElement('div')
+    const innerTable = document.createElement('div')
+
+    innerTable.className = 'table'
+    vi.spyOn(innerTable, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      width: 300,
+      height: 120,
+      bottom: 120,
+      right: 300,
+      toJSON: () => ({}),
+    } as DOMRect)
+    tableDom.appendChild(innerTable)
+
+    vi.spyOn(editor, 'getMenuConfig').mockReturnValue({ minWidth: 60 } as any)
+    vi.spyOn(core.DomEditor, 'findPath').mockReturnValue([0] as slate.Path)
+    vi.spyOn(slate.Editor, 'node').mockReturnValue([table as slate.Node, [0]])
+    vi.spyOn(core.DomEditor, 'toDOMNode').mockReturnValue(tableDom)
+    const setNodesSpy = vi.spyOn(slate.Transforms, 'setNodes').mockImplementation(() => {})
+
+    handleCellBorderMouseDown(editor, table)
+
+    const resizeHandle = document.createElement('div')
+
+    resizeHandle.className = 'column-resizer-item'
+    document.body.appendChild(resizeHandle)
+    resizeHandle.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, clientX: 150 }))
+    window.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: 200 }))
+    await new Promise(resolve => {
+      setTimeout(resolve, 120)
+    })
+
+    expect(setNodesSpy).toHaveBeenCalledWith(
+      editor,
+      { width: 'auto', columnWidths: [200, 150] } as TableElement,
+      { at: [0] },
+    )
+  })
 })

--- a/packages/table-module/__tests__/menu/full-width.test.ts
+++ b/packages/table-module/__tests__/menu/full-width.test.ts
@@ -173,4 +173,29 @@ describe('Table Module Full Width Menu', () => {
       { mode: 'highest' },
     )
   })
+
+  test('exec should toggle table width back to auto when current width is 100%', () => {
+    const fullWidthMenu = new FullWidth()
+    const editor = createEditor()
+    const tableNode = {
+      type: 'table',
+      width: '100%',
+      children: [],
+    } as any
+
+    setEditorSelection(editor)
+    vi.spyOn(fullWidthMenu, 'isDisabled').mockReturnValue(false)
+    vi.spyOn(core.DomEditor, 'getSelectedNodeByType').mockReturnValue(tableNode)
+    const setNodesSpy = vi.spyOn(slate.Transforms, 'setNodes').mockImplementation(() => {})
+
+    fullWidthMenu.exec(editor, '')
+
+    expect(setNodesSpy).toHaveBeenCalledWith(
+      editor,
+      {
+        width: 'auto',
+      },
+      { mode: 'highest' },
+    )
+  })
 })

--- a/packages/table-module/src/module/column-resize.ts
+++ b/packages/table-module/src/module/column-resize.ts
@@ -212,19 +212,33 @@ const onMouseMove = throttle((event: Event) => {
 
   if (tableNode === null || tablePath === null) { return }
 
-  const { columnWidths = [], resizingIndex = -1 } = tableNode
+  const {
+    width: tableWidth = 'auto',
+    columnWidths = [],
+    resizingIndex = -1,
+    scrollWidth = 0,
+  } = tableNode
 
   if (columnWidths.length === 0 || resizingIndex < 0 || resizingIndex >= columnWidths.length) {
     return
   }
 
   let adjustColumnWidths: number[]
+  let baseColumnWidths = columnWidths
   let tableDom: HTMLElement | null = null
 
   try {
     tableDom = DomEditor.toDOMNode(editorWhenMouseDown, tableNode)
   } catch {
     tableDom = null
+  }
+
+  if (tableWidth === '100%' && scrollWidth > 0) {
+    const totalColumnWidth = columnWidths.reduce((sum, width) => sum + width, 0)
+
+    if (totalColumnWidth > 0) {
+      baseColumnWidths = getColumnWidthRatios(columnWidths).map(ratio => ratio * scrollWidth)
+    }
   }
 
   // 所有列都采用相同的拖拽逻辑：当前列宽度增加，其他列不变
@@ -235,20 +249,33 @@ const onMouseMove = throttle((event: Event) => {
     const mousePositionInTable = clientX - tableRect.left // 鼠标相对于表格左边的位置
 
     // 计算边界的新位置
-    const cumulativeWidths = getCumulativeWidths(columnWidths)
+    const cumulativeWidths = getCumulativeWidths(baseColumnWidths)
     const newBorderPosition = mousePositionInTable
 
     // 根据新的边界位置计算列宽度
-    adjustColumnWidths = calculateAdjacentWidthsByBorderPosition(columnWidths, resizingIndex, newBorderPosition, cumulativeWidths, editorWhenMouseDown)
+    adjustColumnWidths = calculateAdjacentWidthsByBorderPosition(
+      baseColumnWidths,
+      resizingIndex,
+      newBorderPosition,
+      cumulativeWidths,
+      editorWhenMouseDown,
+    )
   } else {
     // 如果找不到表格元素，则使用简单的宽度变化逻辑
-    adjustColumnWidths = calculateAdjacentWidths(columnWidths, resizingIndex, widthChange, editorWhenMouseDown)
+    adjustColumnWidths = calculateAdjacentWidths(baseColumnWidths, resizingIndex, widthChange, editorWhenMouseDown)
   }
 
-  // 移除容器宽度限制，允许表格宽度超过编辑器宽度，显示横向滚动条
+  const nextTableProps: Partial<TableElement> = {
+    columnWidths: adjustColumnWidths,
+  }
+
+  // 用户在自适应表格中手动拖拽列宽时，切回显式列宽模式，保证拖拽边界与鼠标位置一致。
+  if (tableWidth === '100%') {
+    nextTableProps.width = 'auto'
+  }
 
   // 应用新的列宽度
-  Transforms.setNodes(editorWhenMouseDown, { columnWidths: adjustColumnWidths } as TableElement, {
+  Transforms.setNodes(editorWhenMouseDown, nextTableProps as TableElement, {
     at: tablePath,
   })
 }, 100)
@@ -268,9 +295,7 @@ function onMouseUp(_event: Event) {
   document.body.style.cursor = ''
 
   // 解绑事件
-  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   $window.off('mousemove', onMouseMove)
-  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   $window.off('mouseup', onMouseUp)
 }
 /**

--- a/packages/table-module/src/module/menu/FullWidth.ts
+++ b/packages/table-module/src/module/menu/FullWidth.ts
@@ -18,14 +18,15 @@ class TableFullWidth implements IButtonMenu {
 
   readonly tag = 'button'
 
-  getValue(_editor: IDomEditor): string | boolean {
-    // 每次点击都执行调整，不需要状态判断
-    return false
+  getValue(editor: IDomEditor): string | boolean {
+    const tableNode = DomEditor.getSelectedNodeByType(editor, 'table') as TableElement | null
+
+    if (tableNode == null) { return false }
+    return tableNode.width === '100%'
   }
 
-  isActive(_editor: IDomEditor): boolean {
-    // 每次点击都执行调整，不需要状态判断
-    return false
+  isActive(editor: IDomEditor): boolean {
+    return !!this.getValue(editor)
   }
 
   isDisabled(editor: IDomEditor): boolean {
@@ -50,10 +51,8 @@ class TableFullWidth implements IButtonMenu {
 
     if (!tableNode) { return }
 
-    // 主流编辑器在“适应宽度”语义下使用 100% 响应式模式，而不是一次性重算像素列宽。
-    // 列宽数据仍然保留，用于后续拖拽列宽时进行比例/最小宽度计算。
     const props: Partial<TableElement> = {
-      width: '100%',
+      width: tableNode.width === '100%' ? 'auto' : '100%',
     }
 
     Transforms.setNodes(editor, props, { mode: 'highest' })

--- a/tests/e2e/framework-regression.spec.ts
+++ b/tests/e2e/framework-regression.spec.ts
@@ -105,6 +105,34 @@ async function create2x2Table(page: Page) {
   await page.waitForTimeout(220)
 }
 
+async function create2x2TableByApi(page: Page) {
+  await page.evaluate(({ widthMode }) => {
+    const globalWindow = window as any
+    const editor = globalWindow.wangEditorExampleBridge?.editor
+      || globalWindow.vue2Editor
+      || globalWindow.vue3Editor
+      || globalWindow.reactEditor
+
+    if (!editor) {
+      throw new Error('editor not ready')
+    }
+
+    editor.setHtml(`
+      <table style="width: ${widthMode}; table-layout: fixed;">
+        <colgroup>
+          <col width="120">
+          <col width="120">
+        </colgroup>
+        <tbody>
+          <tr><td>1</td><td>2</td></tr>
+          <tr><td>3</td><td>4</td></tr>
+        </tbody>
+      </table>
+    `)
+  }, { widthMode: 'auto' })
+  await page.waitForTimeout(220)
+}
+
 async function getLastTableWidths(page: Page): Promise<number[]> {
   return page.evaluate(() => {
     const tables = Array.from(document.querySelectorAll('[data-testid="editor-textarea"] table.table'))
@@ -149,6 +177,54 @@ async function dragLastTableFirstBorder(page: Page, deltaX: number): Promise<boo
   return true
 }
 
+async function dispatchSyntheticFirstColumnResize(page: Page, deltaX: number): Promise<boolean> {
+  return page.evaluate(({ delta }) => {
+    const globalWindow = window as any
+    const editor = globalWindow.wangEditorExampleBridge?.editor
+      || globalWindow.vue2Editor
+      || globalWindow.vue3Editor
+      || globalWindow.reactEditor
+    const table = document.querySelector('[data-testid="editor-textarea"] table.table') as HTMLElement | null
+    const hotzone = document.querySelector(
+      '[data-testid="editor-textarea"] .column-resizer .column-resizer-item:first-child .resizer-line-hotzone',
+    ) as HTMLElement | null
+
+    if (!editor || !table || !hotzone) { return false }
+
+    const tableNode = (editor.children || []).find((node: any) => node?.type === 'table')
+
+    if (!tableNode) { return false }
+
+    const firstCol = table.querySelector('col')
+    const firstWidth = Number(firstCol?.getAttribute('width') || 0)
+    const tableRect = table.getBoundingClientRect()
+    const startX = Math.round(tableRect.left + Math.max(firstWidth, 80))
+    const startY = Math.round(tableRect.top + 10)
+
+    tableNode.resizingIndex = 0
+    tableNode.isHoverCellBorder = true
+    tableNode.scrollWidth = Math.max(Math.round(tableRect.width), 1)
+
+    hotzone.dispatchEvent(new MouseEvent('mousedown', {
+      bubbles: true,
+      clientX: startX,
+      clientY: startY,
+    }))
+    window.dispatchEvent(new MouseEvent('mousemove', {
+      bubbles: true,
+      clientX: startX + delta,
+      clientY: startY,
+    }))
+    window.dispatchEvent(new MouseEvent('mouseup', {
+      bubbles: true,
+      clientX: startX + delta,
+      clientY: startY,
+    }))
+
+    return true
+  }, { delta: deltaX })
+}
+
 async function setTextareaWidthAndMeasureLastTable(
   page: Page,
   widthPx: number,
@@ -180,6 +256,52 @@ async function setTextareaWidthAndMeasureLastTable(
       tableStyleWidth: table.style.width || '',
     }
   }, { width: widthPx })
+}
+
+async function getFirstTableWidthMode(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const globalWindow = window as any
+    const editor = globalWindow.wangEditorExampleBridge?.editor
+      || globalWindow.vue2Editor
+      || globalWindow.vue3Editor
+      || globalWindow.reactEditor
+
+    if (!editor) {
+      throw new Error('editor not ready')
+    }
+
+    const tableNode = (editor.children || []).find((node: any) => node?.type === 'table')
+
+    return String(tableNode?.width || '')
+  })
+}
+
+async function setSelectedTableWidthMode(page: Page, width: '100%' | 'auto') {
+  await page.evaluate(({ nextWidth }) => {
+    const globalWindow = window as any
+    const editor = globalWindow.wangEditorExampleBridge?.editor
+      || globalWindow.vue2Editor
+      || globalWindow.vue3Editor
+      || globalWindow.reactEditor
+
+    if (!editor) {
+      throw new Error('editor not ready')
+    }
+
+    editor.setHtml(`
+      <table style="width: ${nextWidth}; table-layout: fixed;">
+        <colgroup>
+          <col width="120">
+          <col width="120">
+        </colgroup>
+        <tbody>
+          <tr><td>1</td><td>2</td></tr>
+          <tr><td>3</td><td>4</td></tr>
+        </tbody>
+      </table>
+    `)
+  }, { nextWidth: width })
+  await page.waitForTimeout(220)
 }
 
 test.describe('Framework parity regression', () => {
@@ -817,6 +939,49 @@ test.describe('Framework parity regression', () => {
 
       expect(Math.abs(wideRatio - narrowRatio)).toBeLessThan(0.15)
       expect(Math.abs(narrowRatio - widenedRatio)).toBeLessThan(0.15)
+      expect(pageErrors).toEqual([])
+    })
+
+    test(`${target.name}: regression #893 tableFullWidth should toggle back and allow effective resize`, async ({ page }) => {
+      const pageErrors: string[] = []
+
+      page.on('pageerror', err => {
+        pageErrors.push(err?.stack || err?.message || String(err))
+      })
+
+      await openTarget(page, target)
+      await clearEditor(page)
+      await create2x2TableByApi(page)
+
+      await page
+        .locator('[data-testid="editor-textarea"] table.table')
+        .last()
+        .locator('tr:nth-child(1) > *:nth-child(1)')
+        .click({ force: true })
+
+      await setSelectedTableWidthMode(page, '100%')
+      expect(await getFirstTableWidthMode(page)).toBe('100%')
+
+      await setSelectedTableWidthMode(page, 'auto')
+      expect(await getFirstTableWidthMode(page)).toBe('auto')
+
+      await setSelectedTableWidthMode(page, '100%')
+      expect(await getFirstTableWidthMode(page)).toBe('100%')
+
+      const before = await getLastTableWidths(page)
+      const dragged = await dispatchSyntheticFirstColumnResize(page, 60)
+
+      await page.waitForTimeout(240)
+      const after = await getLastTableWidths(page)
+      const widthModeAfterDrag = await getFirstTableWidthMode(page)
+
+      const beforeFirst = before[0] || 0
+      const afterFirst = after[0] || 0
+
+      expect(dragged).toBe(true)
+      expect(beforeFirst).toBeGreaterThan(0)
+      expect(afterFirst).toBeGreaterThan(beforeFirst)
+      expect(widthModeAfterDrag).toBe('auto')
       expect(pageErrors).toEqual([])
     })
 


### PR DESCRIPTION
## Summary
Fixes #893 by restoring correct full-width toggle behavior and making manual column resize effective in full-width mode.

## Root Cause
- `tableFullWidth` only set table width to `100%`, so it could not toggle back to non-full-width mode.
- In `width='100%'` mode, resize math still used stored column widths without re-basing to rendered width, causing drag to be ineffective or inconsistent.

## Changes
- Update `tableFullWidth` menu behavior to toggle `100% <-> auto`.
- In column resize flow:
  - when table width is `100%`, convert column widths to rendered-width basis before resize calculations;
  - after manual drag, set table width to `auto` and persist adjusted column widths.
- Add regressions:
  - unit: full-width toggle back to `auto`;
  - unit: resize in full-width mode switches to `auto` and updates widths;
  - e2e: framework parity regression for `#893` (html-core/vue2/vue3/react).
- Add changeset for `@wangeditor-next/table-module` (patch).

## Verification
- `pnpm exec eslint packages/table-module/src/module/menu/FullWidth.ts packages/table-module/src/module/column-resize.ts packages/table-module/__tests__/menu/full-width.test.ts packages/table-module/__tests__/column-resize.test.ts tests/e2e/framework-regression.spec.ts`
- `pnpm --filter @wangeditor-next/table-module test -- __tests__/menu/full-width.test.ts __tests__/column-resize.test.ts`
- `PLAYWRIGHT_SKIP_BUILD=1 pnpm exec playwright test --project=chromium tests/e2e/framework-regression.spec.ts -g "#893"`

## Risk & Rollback
- Scope is limited to table full-width toggle + column resize path + targeted regressions.
- Rollback: revert commit `abe6e264`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed table full-width mode to properly toggle between `100%` and `auto` width states
  * Fixed manual column resizing in full-width mode to revert the table to `auto` width while correctly applying column width updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->