### PR TITLE
fix(core): 修复撤销后 stale 选区映射导致的输入报错

### DIFF
--- a/.changeset/hungry-chefs-jam.md
+++ b/.changeset/hungry-chefs-jam.md
@@ -1,0 +1,6 @@
+---
+'@wangeditor-next/core': patch
+'@wangeditor-next/editor': patch
+---
+
+fix beforeinput selection recovery after undo on void blocks (e.g. divider and code block) to avoid stale DOM range crashes and dropped input in demo flows

--- a/packages/core/__tests__/editor/dom-editor.test.ts
+++ b/packages/core/__tests__/editor/dom-editor.test.ts
@@ -25,6 +25,21 @@ describe('Core DomEditor', () => {
     editor.select(genStartLocation())
   })
 
+  function createStaleNonEditableDOMPoint(): [Node, number] {
+    const paragraph = DomEditor.toDOMNode(editor, editor.children[0] as CustomElement)
+    const textNodeWrapper = paragraph.querySelector('[data-slate-node="text"]') as HTMLElement
+    const staleTextNodeWrapper = textNodeWrapper.cloneNode(true) as HTMLElement
+    const leaf = staleTextNodeWrapper.querySelector('[data-slate-leaf]') as HTMLElement
+    const nonEditable = document.createElement('span')
+
+    nonEditable.setAttribute('contenteditable', 'false')
+    nonEditable.textContent = 'x'
+    staleTextNodeWrapper.insertBefore(nonEditable, leaf)
+    textNodeWrapper.replaceWith(staleTextNodeWrapper)
+
+    return [nonEditable.firstChild as Node, 0]
+  }
+
   afterEach(() => {
     editor.destroy()
   })
@@ -294,6 +309,39 @@ describe('Core DomEditor', () => {
     })
 
     expect(slatePoint).toBeNull()
+  })
+
+  test('toSlatePoint returns null when suppressThrow is enabled and dom mapping is stale', async () => {
+    editor.insertText('hello')
+    await flushPromises()
+
+    const staleDomPoint = createStaleNonEditableDOMPoint()
+    const slatePoint = DomEditor.toSlatePoint(editor, staleDomPoint, {
+      exactMatch: false,
+      suppressThrow: true,
+      searchDirection: 'forward',
+    })
+
+    expect(slatePoint).toBeNull()
+  })
+
+  test('toSlateRange returns null when suppressThrow is enabled and dom mapping is stale', async () => {
+    editor.insertText('hello')
+    await flushPromises()
+
+    const staleDomPoint = createStaleNonEditableDOMPoint()
+    const { document } = DomEditor.getWindow(editor)
+    const staleDomRange = document.createRange()
+
+    staleDomRange.setStart(staleDomPoint[0], staleDomPoint[1])
+    staleDomRange.setEnd(staleDomPoint[0], staleDomPoint[1])
+
+    const slateRange = DomEditor.toSlateRange(editor, staleDomRange, {
+      exactMatch: false,
+      suppressThrow: true,
+    })
+
+    expect(slateRange).toBeNull()
   })
 
   test('toSlatePoint finds the next selectable leaf when selection lands inside a non-editable node', async () => {

--- a/packages/core/__tests__/text-area/event-handlers/before-input.test.ts
+++ b/packages/core/__tests__/text-area/event-handlers/before-input.test.ts
@@ -345,6 +345,114 @@ describe('handleBeforeInput', () => {
     expect(Editor.insertText).toHaveBeenCalledWith(editor, 'hello')
   })
 
+  it('restores previous selection when insert target range is stale and selection is null', () => {
+    const restoredRange = createSelection(false)
+    const editor = {
+      selection: null,
+      getConfig: () => ({ readOnly: false }),
+      restoreSelection() {
+        this.selection = restoredRange
+      },
+      insertData: vi.fn(),
+    } as any
+    const targetRange = { startContainer: document.createTextNode('x') }
+    const event = {
+      inputType: 'insertText',
+      data: 'hello',
+      dataTransfer: null,
+      target: {},
+      preventDefault: vi.fn(),
+      getTargetRanges: () => [targetRange],
+    } as any
+
+    vi.spyOn(helpers, 'hasEditableTarget').mockReturnValue(true)
+    vi.spyOn(DomEditor, 'toSlateRange').mockReturnValue(null as any)
+    vi.spyOn(DomEditor, 'findDocumentOrShadowRoot').mockReturnValue({
+      getSelection: () => null,
+    } as any)
+    vi.spyOn(Editor, 'insertText').mockImplementation(() => {})
+
+    expect(() => handleBeforeInput(event, {} as any, editor)).not.toThrow()
+    expect(editor.selection).toEqual(restoredRange)
+    expect(Editor.insertText).toHaveBeenCalledWith(editor, 'hello')
+  })
+
+  it('falls back to document end when insert target range is stale and selection cannot be restored', () => {
+    const fallbackPoint = { path: [0, 0], offset: 0 }
+    const editor = {
+      selection: null,
+      getConfig: () => ({ readOnly: false }),
+      restoreSelection: vi.fn(),
+      insertData: vi.fn(),
+    } as any
+    const targetRange = { startContainer: document.createTextNode('x') }
+    const event = {
+      inputType: 'insertText',
+      data: 'hello',
+      dataTransfer: null,
+      target: {},
+      preventDefault: vi.fn(),
+      getTargetRanges: () => [targetRange],
+    } as any
+
+    vi.spyOn(helpers, 'hasEditableTarget').mockReturnValue(true)
+    vi.spyOn(DomEditor, 'toSlateRange').mockReturnValue(null as any)
+    vi.spyOn(DomEditor, 'findDocumentOrShadowRoot').mockReturnValue({
+      getSelection: () => null,
+    } as any)
+    vi.spyOn(Editor, 'end').mockReturnValue(fallbackPoint as any)
+    vi.spyOn(Transforms, 'select').mockImplementation((_editor: any, range: any) => {
+      _editor.selection = range
+    })
+    vi.spyOn(Editor, 'insertText').mockImplementation(() => {})
+
+    expect(() => handleBeforeInput(event, {} as any, editor)).not.toThrow()
+    expect(Transforms.select).toHaveBeenCalledWith(editor, {
+      anchor: fallbackPoint,
+      focus: fallbackPoint,
+    })
+    expect(Editor.insertText).toHaveBeenCalledWith(editor, 'hello')
+  })
+
+  it('falls back to document end when restoreSelection throws on stale path', () => {
+    const fallbackPoint = { path: [0, 0], offset: 0 }
+    const editor = {
+      selection: null,
+      getConfig: () => ({ readOnly: false }),
+      restoreSelection: vi.fn(() => {
+        throw new Error('Cannot find a descendant at path [0,0,0]')
+      }),
+      insertData: vi.fn(),
+    } as any
+    const targetRange = { startContainer: document.createTextNode('x') }
+    const event = {
+      inputType: 'insertText',
+      data: 'hello',
+      dataTransfer: null,
+      target: {},
+      preventDefault: vi.fn(),
+      getTargetRanges: () => [targetRange],
+    } as any
+
+    vi.spyOn(helpers, 'hasEditableTarget').mockReturnValue(true)
+    vi.spyOn(DomEditor, 'toSlateRange').mockReturnValue(null as any)
+    vi.spyOn(DomEditor, 'findDocumentOrShadowRoot').mockReturnValue({
+      getSelection: () => null,
+    } as any)
+    vi.spyOn(Editor, 'end').mockReturnValue(fallbackPoint as any)
+    vi.spyOn(Transforms, 'select').mockImplementation((_editor: any, range: any) => {
+      _editor.selection = range
+    })
+    vi.spyOn(Editor, 'insertText').mockImplementation(() => {})
+
+    expect(() => handleBeforeInput(event, {} as any, editor)).not.toThrow()
+    expect(Transforms.select).toHaveBeenCalledWith(editor, {
+      anchor: fallbackPoint,
+      focus: fallbackPoint,
+    })
+    expect(Editor.insertText).toHaveBeenCalledWith(editor, 'hello')
+  })
+
   it('does not delete when selection partially covers a table', () => {
     const editor = {
       selection: createSelection(true),

--- a/packages/core/src/editor/dom-editor.ts
+++ b/packages/core/src/editor/dom-editor.ts
@@ -502,6 +502,9 @@ export const DomEditor = {
     }
 
     if (anchorNode == null || focusNode == null || anchorOffset == null || focusOffset == null) {
+      if (suppressThrow) {
+        return null as T extends true ? Range | null : Range
+      }
       throw new Error(`Cannot resolve a Slate range from DOM range: ${domRange}`)
     }
 
@@ -734,10 +737,14 @@ export const DomEditor = {
     // COMPAT: If someone is clicking from one Slate editor into another,
     // the select event fires twice, once for the old editor's `element`
     // first, and then afterwards for the correct `element`. (2017/03/03)
-    const slateNode = DomEditor.toSlateNode(editor, textNode!)
     let path: Path
 
     try {
+      // During undo/redo around void blocks, target ranges can briefly point
+      // to stale leaf wrappers that are no longer mapped in KEY_TO_ELEMENT.
+      // Respect suppressThrow and let callers skip reselection for this tick.
+      const slateNode = DomEditor.toSlateNode(editor, textNode!)
+
       path = DomEditor.findPath(editor, slateNode)
     } catch (e) {
       if (suppressThrow) {

--- a/packages/core/src/text-area/event-handlers/beforeInput.ts
+++ b/packages/core/src/text-area/event-handlers/beforeInput.ts
@@ -36,7 +36,7 @@ function handleBeforeInput(e: Event, textarea: TextArea, editor: IDomEditor) {
   // 一些输入法和浏览器扩展会先改 DOM 选区，再触发 beforeinput
   textarea.flushDOMSelectionChange?.()
 
-  const { selection } = editor
+  let { selection } = editor
   const { inputType: type } = event
   const data = event.dataTransfer || event.data || undefined
 
@@ -71,6 +71,7 @@ function handleBeforeInput(e: Event, textarea: TextArea, editor: IDomEditor) {
 
       if (range && (!selection || !Range.equals(selection, range))) {
         Transforms.select(editor, range)
+        selection = range
       }
     }
   }
@@ -92,6 +93,41 @@ function handleBeforeInput(e: Event, textarea: TextArea, editor: IDomEditor) {
 
       Editor.deleteFragment(editor, { direction })
       return
+    }
+  }
+
+  if (selection == null && type.startsWith('insert')) {
+    const root = DomEditor.findDocumentOrShadowRoot(editor)
+    const domSelection = root.getSelection()
+
+    if (domSelection) {
+      const domRange = DomEditor.toSlateRange(editor, domSelection, {
+        exactMatch: false,
+        suppressThrow: true,
+      })
+
+      if (domRange) {
+        Transforms.select(editor, domRange)
+        selection = domRange
+      }
+    }
+
+    if (selection == null) {
+      try {
+        editor.restoreSelection?.()
+      } catch {
+        // Undo/redo across void blocks can keep a stale cached selection path.
+        // Fall through to the explicit end-of-document fallback below.
+      }
+      selection = editor.selection
+    }
+
+    if (selection == null) {
+      const fallbackPoint = Editor.end(editor, [])
+      const fallbackRange = { anchor: fallbackPoint, focus: fallbackPoint }
+
+      Transforms.select(editor, fallbackRange)
+      selection = fallbackRange
     }
   }
 


### PR DESCRIPTION
## 背景
- 线上 demo 在空编辑器场景中，执行「toolbar 插入 void 节点（`divider` / `codeBlock`） -> 撤销 -> 再输入」会报错，且输入被吞。
- 报错表现为：`Cannot resolve a Slate node from DOM node: [object HTMLSpanElement]`。

## 根因
- `DomEditor.toSlatePoint` 在 `suppressThrow: true` 下，内部 `toSlateNode`/`findPath` 仍可能抛错，导致 stale DOM 映射没有被真正吞掉。
- `beforeInput` 在撤销后 `editor.selection` 为空时缺少统一恢复链路，导致即使不抛错也可能“无选区可写入”。

## 变更
- `packages/core/src/editor/dom-editor.ts`
  - `toSlateRange` 在 anchor/focus 无法解析且 `suppressThrow: true` 时返回 `null`。
  - `toSlatePoint` 将 `toSlateNode + findPath` 一并纳入容错，在 `suppressThrow: true` 时返回 `null`。
- `packages/core/src/text-area/event-handlers/beforeInput.ts`
  - 将本地 `selection` 改为可更新引用（在 `Transforms.select` 后同步）。
  - 对 `insert*` 输入增加选区恢复链路：
    1. 优先从当前 DOM selection 反推 Slate range；
    2. 失败则尝试 `restoreSelection`；
    3. 再失败则兜底选到文档末尾。
  - `restoreSelection` stale path 抛错时改为容错并继续兜底。
- 新增 changeset：
  - `@wangeditor-next/core` patch
  - `@wangeditor-next/editor` patch

## 测试与验证
- 单测：`pnpm --filter @wangeditor-next/core test`（41 files / 299 tests 通过）
- 新增回归测试覆盖：
  - stale DOM mapping 下 `toSlatePoint` / `toSlateRange` 的 `suppressThrow` 行为
  - `beforeInput` 在 selection 为空时的恢复与兜底路径
- demo 场景自动化回归（拦截 demo 页面 `@latest` 脚本为本分支本地 `dist/index.js`）：
  - `divider -> undo -> type`：`errors=0`，结果 `<p>x</p>`
  - `codeBlock -> undo -> type`：`errors=0`，结果 `<p>x</p>`

## 风险与回滚
- 风险：选区恢复逻辑增加了 insert 路径下的兜底选区行为，理论上可能影响极端边界输入位置。
- 缓解：仅在 `selection == null` 且 `insert*` 时触发，优先保留 DOM/历史选区，末尾兜底为最后手段。
- 回滚：可直接回滚本 PR 单提交。



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved selection recovery after undo operations, particularly for void blocks (dividers, code blocks).
  * Enhanced stale DOM range handling to prevent input dropping and related crashes during editing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->