### PR TITLE
fix(core): 修复撤销后 IME 提交时 selection 丢失导致输入异常

### DIFF
--- a/.changeset/green-pillows-smoke.md
+++ b/.changeset/green-pillows-smoke.md
@@ -1,0 +1,6 @@
+---
+'@wangeditor-next/core': patch
+'@wangeditor-next/editor': patch
+---
+
+fix IME composition commit after undo by recovering selection when editor selection is null to avoid placeholder overlap and dropped CJK input in demo flows

--- a/packages/core/__tests__/text-area/event-handlers/composition.test.ts
+++ b/packages/core/__tests__/text-area/event-handlers/composition.test.ts
@@ -99,6 +99,77 @@ describe('composition handlers', () => {
     expect(Editor.insertText).not.toHaveBeenCalled()
   })
 
+  it('recovers selection before composition commit when selection is null', () => {
+    const paragraph = { type: 'paragraph', children: [{ text: 'x' }] }
+    const recoveredSelection = createSelection(false)
+    const editor = {
+      selection: null,
+      getConfig: () => ({ maxLength: 0 }),
+      restoreSelection() {
+        this.selection = recoveredSelection
+      },
+    } as any
+    const textarea = { changeViewState: vi.fn() } as any
+    const event = { target: {}, data: '拼' } as any
+
+    vi.spyOn(helpers, 'hasEditableTarget').mockReturnValue(true)
+    vi.spyOn(DomEditor, 'findDocumentOrShadowRoot').mockReturnValue({
+      getSelection: () => null,
+    } as any)
+    vi.spyOn(DomEditor, 'cleanExposedTexNodeInSelectionBlock').mockImplementation(() => {})
+    vi.spyOn(Editor, 'node').mockImplementation((_ed, path) => {
+      if (path.length === 1) {
+        return [paragraph, path] as any
+      }
+
+      return [{ text: 'x' }, path] as any
+    })
+    vi.spyOn(Editor, 'insertText').mockImplementation(() => {})
+
+    expect(() => handleCompositionEnd(event, textarea, editor)).not.toThrow()
+    expect(editor.selection).toEqual(recoveredSelection)
+    expect(Editor.insertText).toHaveBeenCalledWith(editor, '拼')
+  })
+
+  it('falls back to document end when selection recovery fails before composition commit', () => {
+    const fallbackPoint = { path: [0, 0], offset: 0 }
+    const paragraph = { type: 'paragraph', children: [{ text: 'x' }] }
+    const editor = {
+      selection: null,
+      getConfig: () => ({ maxLength: 0 }),
+      restoreSelection: vi.fn(() => {
+        throw new Error('stale selection path')
+      }),
+    } as any
+    const textarea = { changeViewState: vi.fn() } as any
+    const event = { target: {}, data: '拼' } as any
+
+    vi.spyOn(helpers, 'hasEditableTarget').mockReturnValue(true)
+    vi.spyOn(DomEditor, 'findDocumentOrShadowRoot').mockReturnValue({
+      getSelection: () => null,
+    } as any)
+    vi.spyOn(DomEditor, 'cleanExposedTexNodeInSelectionBlock').mockImplementation(() => {})
+    vi.spyOn(Editor, 'end').mockReturnValue(fallbackPoint as any)
+    vi.spyOn(Transforms, 'select').mockImplementation((_editor: any, range: any) => {
+      _editor.selection = range
+    })
+    vi.spyOn(Editor, 'node').mockImplementation((_ed, path) => {
+      if (path.length === 1) {
+        return [paragraph, path] as any
+      }
+
+      return [{ text: 'x' }, path] as any
+    })
+    vi.spyOn(Editor, 'insertText').mockImplementation(() => {})
+
+    expect(() => handleCompositionEnd(event, textarea, editor)).not.toThrow()
+    expect(Transforms.select).toHaveBeenCalledWith(editor, {
+      anchor: fallbackPoint,
+      focus: fallbackPoint,
+    })
+    expect(Editor.insertText).toHaveBeenCalledWith(editor, '拼')
+  })
+
   it('handles composition end with maxLength', () => {
     const paragraph = { type: 'paragraph', children: [{ text: 'x' }] }
     const codeNode = { type: 'code', children: [{ text: 'y' }] }

--- a/packages/core/src/text-area/event-handlers/composition.ts
+++ b/packages/core/src/text-area/event-handlers/composition.ts
@@ -4,7 +4,7 @@
  */
 
 import {
-  Editor, Element, Range, Text,
+  Editor, Element, Range, Text, Transforms,
 } from 'slate'
 
 import { DomEditor } from '../../editor/dom-editor'
@@ -68,6 +68,53 @@ function areBothTextNodes(editor, selection) {
       }
     }
   }
+}
+
+function recoverSelectionForCompositionEnd(editor: IDomEditor): Range | null {
+  let { selection } = editor
+
+  if (selection) {
+    return selection
+  }
+
+  try {
+    const root = DomEditor.findDocumentOrShadowRoot(editor)
+    const domSelection = root.getSelection()
+
+    if (domSelection) {
+      const domRange = DomEditor.toSlateRange(editor, domSelection, {
+        exactMatch: false,
+        suppressThrow: true,
+      })
+
+      if (domRange) {
+        Transforms.select(editor, domRange)
+        selection = domRange
+      }
+    }
+  } catch (error) {
+    // Ignore transient DOM/selection mismatches and continue with fallbacks.
+  }
+
+  if (!selection) {
+    try {
+      editor.restoreSelection?.()
+    } catch {
+      // Undo/redo around void blocks can make cached selection paths stale.
+      // Continue to the explicit end-of-document fallback.
+    }
+    selection = editor.selection
+  }
+
+  if (!selection) {
+    const fallbackPoint = Editor.end(editor, [])
+    const fallbackRange = { anchor: fallbackPoint, focus: fallbackPoint }
+
+    Transforms.select(editor, fallbackRange)
+    selection = fallbackRange
+  }
+
+  return selection
 }
 
 /**
@@ -146,7 +193,7 @@ export function handleCompositionEnd(e: Event, textarea: TextArea, editor: IDomE
     EDITOR_TO_PENDING_SELECTION.delete(editor)
   }
 
-  const { selection } = editor
+  const selection = recoverSelectionForCompositionEnd(editor)
 
   if (selection == null) { return }
 


### PR DESCRIPTION
## 背景
在 #896 之后仍存在 IME 场景下的后续问题：撤销后进入中文输入法组合输入，compositionend 时若 editor.selection 为空，提交阶段会提前返回，导致模型与 DOM 脱节，表现为 placeholder 与中文重叠、全选失效等。

## 改动
- 在 compositionend 路径补齐 selection 恢复兜底：
  - 优先使用 DOM selection
  - 其次尝试 restoreSelection()
  - 最后兜底到文档末尾
- 当恢复成功后再继续执行组合输入提交逻辑，避免直接 return。
- 补充 composition 相关单测覆盖 null selection 与 stale restore 场景。

## 验证
- pnpm --filter @wangeditor-next/core test 通过（301/301）。

## 发布
- 新增 changeset：@wangeditor-next/core、@wangeditor-next/editor 均为 patch。

Ref: #892


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed IME composition input issues following undo operations
  * Improved selection handling to prevent placeholder overlap and lost CJK text input in certain scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->