### PR TITLE
test(e2e): add regression coverage for toolbar undo + IME composition

### DIFF
--- a/tests/e2e/editor.smoke.spec.ts
+++ b/tests/e2e/editor.smoke.spec.ts
@@ -46,6 +46,85 @@ const setEditorHtml = async (page: Page, html: string) => {
   }, html)
 }
 
+const runDividerUndoImeScenario = async (page: Page) => {
+  const pageErrors: string[] = []
+
+  page.on('pageerror', err => {
+    pageErrors.push(err?.stack || err?.message || String(err))
+  })
+
+  await focusEditor(page)
+  await waitForMenuEnabled(page, 'divider')
+  await getToolbarMenu(page, 'divider').click()
+
+  await waitForMenuEnabled(page, 'undo')
+  await getToolbarMenu(page, 'undo').click()
+
+  await page.evaluate(() => {
+    const el = document.querySelector('[data-testid="editor-textarea"] [contenteditable="true"]') as HTMLElement | null
+
+    if (!el) {
+      throw new Error('editable not found')
+    }
+
+    el.focus()
+    const selection = window.getSelection()
+
+    if (!selection) {
+      throw new Error('selection not found')
+    }
+
+    const range = document.createRange()
+
+    range.selectNodeContents(el)
+    range.collapse(false)
+    selection.removeAllRanges()
+    selection.addRange(range)
+
+    const fire = (event: Event) => el.dispatchEvent(event)
+
+    fire(new CompositionEvent('compositionstart', { data: '' }))
+    fire(new InputEvent('beforeinput', {
+      inputType: 'insertCompositionText',
+      data: 'ni',
+      bubbles: true,
+      cancelable: true,
+    }))
+    fire(new InputEvent('input', {
+      inputType: 'insertCompositionText',
+      data: 'ni',
+      bubbles: true,
+    }))
+    fire(new CompositionEvent('compositionupdate', { data: 'ni' }))
+    fire(new CompositionEvent('compositionend', { data: '你' }))
+  })
+
+  await page.waitForTimeout(320)
+  await selectAll(page)
+
+  const selectionSnapshot = await page.evaluate(() => {
+    const selection = window.getSelection()
+
+    return {
+      text: selection?.toString() || '',
+      rangeCount: selection?.rangeCount || 0,
+    }
+  })
+
+  await expect(page.getByTestId('editor-html')).toContainText('你')
+  await expect(page.locator('.w-e-text-placeholder')).toBeHidden()
+  expect(selectionSnapshot.rangeCount).toBeGreaterThan(0)
+  expect(selectionSnapshot.text).toContain('你')
+
+  const fatalErrors = pageErrors.filter(msg => {
+    if (msg.includes('Cannot resolve a Slate node from DOM node')) { return true }
+    if (msg.includes('Cannot resolve a DOM point from Slate point')) { return true }
+    return false
+  })
+
+  expect(fatalErrors).toEqual([])
+}
+
 test.describe('Cross Browser Smoke', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/examples/default-mode.html')
@@ -105,5 +184,9 @@ test.describe('Cross Browser Smoke', () => {
     await waitForMenuEnabled(page, 'redo')
     await getToolbarMenu(page, 'redo').click()
     await expect(page.getByTestId('editor-html')).toContainText('undo text')
+  })
+
+  test('regression #892: divider -> undo -> composition should stay stable', async ({ page }) => {
+    await runDividerUndoImeScenario(page)
   })
 })

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -76,6 +76,94 @@ const dropImage = async (page: Page) => {
   )
 }
 
+const runToolbarUndoImeCompositionScenario = async (
+  page: Page,
+  menuKey: 'divider' | 'codeBlock',
+) => {
+  const pageErrors: string[] = []
+
+  page.on('pageerror', err => {
+    pageErrors.push(err?.stack || err?.message || String(err))
+  })
+
+  await focusEditor(page)
+
+  if (menuKey === 'codeBlock') {
+    await typeInEditor(page, 'code line')
+    await selectAll(page)
+  }
+
+  await waitForMenuEnabled(page, menuKey)
+  await getToolbarMenu(page, menuKey).click()
+
+  await waitForMenuEnabled(page, 'undo')
+  await getToolbarMenu(page, 'undo').click()
+
+  await page.evaluate(() => {
+    const el = document.querySelector('[data-testid="editor-textarea"] [contenteditable="true"]') as HTMLElement | null
+
+    if (!el) {
+      throw new Error('editable not found')
+    }
+
+    el.focus()
+    const selection = window.getSelection()
+
+    if (!selection) {
+      throw new Error('selection not found')
+    }
+
+    const range = document.createRange()
+
+    range.selectNodeContents(el)
+    range.collapse(false)
+    selection.removeAllRanges()
+    selection.addRange(range)
+
+    const fire = (event: Event) => el.dispatchEvent(event)
+
+    fire(new CompositionEvent('compositionstart', { data: '' }))
+    fire(new InputEvent('beforeinput', {
+      inputType: 'insertCompositionText',
+      data: 'ni',
+      bubbles: true,
+      cancelable: true,
+    }))
+    fire(new InputEvent('input', {
+      inputType: 'insertCompositionText',
+      data: 'ni',
+      bubbles: true,
+    }))
+    fire(new CompositionEvent('compositionupdate', { data: 'ni' }))
+    fire(new CompositionEvent('compositionend', { data: '你' }))
+  })
+
+  await page.waitForTimeout(320)
+  await selectAll(page)
+
+  const selectionSnapshot = await page.evaluate(() => {
+    const selection = window.getSelection()
+
+    return {
+      text: selection?.toString() || '',
+      rangeCount: selection?.rangeCount || 0,
+    }
+  })
+
+  await expect(page.getByTestId('editor-html')).toContainText('你')
+  await expect(page.locator('.w-e-text-placeholder')).toBeHidden()
+  expect(selectionSnapshot.rangeCount).toBeGreaterThan(0)
+  expect(selectionSnapshot.text).toContain('你')
+
+  const fatalErrors = pageErrors.filter(msg => {
+    if (msg.includes('Cannot resolve a Slate node from DOM node')) { return true }
+    if (msg.includes('Cannot resolve a DOM point from Slate point')) { return true }
+    return false
+  })
+
+  expect(fatalErrors).toEqual([])
+}
+
 test.describe('Basic Editor', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/examples/default-mode.html')
@@ -266,6 +354,14 @@ test.describe('Basic Editor', () => {
     await expect(page.getByTestId('editor-html')).not.toContainText('中文中文')
     await expect(getEditable(page)).toContainText('中文')
     expect(pageErrors).toEqual([])
+  })
+
+  test('regression #892: divider -> undo -> composition -> select-all should not throw', async ({ page }) => {
+    await runToolbarUndoImeCompositionScenario(page, 'divider')
+  })
+
+  test('regression #892: codeBlock -> undo -> composition -> select-all should not throw', async ({ page }) => {
+    await runToolbarUndoImeCompositionScenario(page, 'codeBlock')
   })
 
   test('regression #282: first-line superscript with large font should not be clipped', async ({ page }) => {


### PR DESCRIPTION
## 背景
#898 修复了撤销后 IME 提交时 selection 丢失问题，但缺少覆盖 `toolbar -> undo -> composition -> select-all` 的端到端回归用例。

## 改动
在 `tests/e2e/editor.spec.ts` 新增两条回归用例：
- regression #892: divider -> undo -> composition -> select-all should not throw
- regression #892: codeBlock -> undo -> composition -> select-all should not throw

复用一个场景 helper，统一断言：
- 不出现 `Cannot resolve a Slate node from DOM node`
- 不出现 `Cannot resolve a DOM point from Slate point`
- placeholder 隐藏
- 全选后 selection 有效且包含已提交中文

## 验证
- PLAYWRIGHT_SKIP_BUILD=1 pnpm playwright test tests/e2e/editor.spec.ts --grep 'regression #892|regression #813|regression #793|regression #861'
- 5 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression and smoke tests covering undo → IME composition flows for divider and code block toolbar actions.
  * Verifies composed characters are preserved, the editor placeholder hides, and selection state remains correct after composition.
  * Captures page errors during scenarios and filters known non-fatal editor-related errors to assert no unexpected failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->