### PR TITLE
fix(table): improve property modal ui

### DIFF
--- a/.changeset/polite-tables-dress.md
+++ b/.changeset/polite-tables-dress.md
@@ -1,0 +1,5 @@
+---
+"@wangeditor-next/table-module": patch
+---
+
+Improve table and cell property modal controls.

--- a/packages/table-module/__tests__/menu/property-menu.test.ts
+++ b/packages/table-module/__tests__/menu/property-menu.test.ts
@@ -43,15 +43,17 @@ function setSelectionInsideFirstCell(editor) {
 }
 
 function createContextSelection(editor, rows: number[][][]): NodeEntryWithContext[][] {
-  return rows.map(row => row.map(path => [
-    [Node.get(editor, path as any) as any, path as any],
-    {
-      rtl: 0,
-      ltr: 1,
-      ttb: 1,
-      btt: 0,
-    },
-  ]))
+  return rows.map(row =>
+    row.map(path => [
+      [Node.get(editor, path as any) as any, path as any],
+      {
+        rtl: 0,
+        ltr: 1,
+        ttb: 1,
+        btt: 0,
+      },
+    ])
+  )
 }
 
 describe('table property menus', () => {
@@ -73,14 +75,20 @@ describe('table property menus', () => {
     const borderColor = elem.querySelector('[name="borderColor"]') as HTMLInputElement
     const borderWidth = elem.querySelector('[name="borderWidth"]') as HTMLInputElement
     const backgroundColor = elem.querySelector('[name="backgroundColor"]') as HTMLInputElement
-    const textAlign = elem.querySelector('[name="textAlign"]') as HTMLSelectElement
-    const button = elem.querySelector('button') as HTMLButtonElement
+    const textAlign = elem.querySelector('[name="textAlign"]') as HTMLInputElement
+    const centerAlignButton = elem.querySelector(
+      '.w-e-table-property-align-button[data-value="center"]'
+    ) as HTMLButtonElement
+    const button = elem.querySelector('.button-container button') as HTMLButtonElement
 
     borderStyle.value = 'dashed'
     borderColor.value = '#ff0000'
     borderWidth.value = '2'
     backgroundColor.value = '#00ff00'
-    textAlign.value = 'center'
+    centerAlignButton.click()
+
+    expect(textAlign.value).toBe('center')
+    expect(centerAlignButton.classList.contains('active')).toBe(true)
 
     button.click()
     vi.runAllTimers()
@@ -105,20 +113,32 @@ describe('table property menus', () => {
     EDITOR_TO_SELECTION.set(
       editor,
       createContextSelection(editor, [
-        [[0, 0, 0], [0, 0, 1]],
-        [[0, 1, 0], [0, 1, 1]],
-      ]),
+        [
+          [0, 0, 0],
+          [0, 0, 1],
+        ],
+        [
+          [0, 1, 0],
+          [0, 1, 1],
+        ],
+      ])
     )
 
     const elem = menu.getModalContentElem(editor) as HTMLDivElement
     const borderStyle = elem.querySelector('[name="borderStyle"]') as HTMLSelectElement
-    const textAlign = elem.querySelector('[name="textAlign"]') as HTMLSelectElement
+    const textAlign = elem.querySelector('[name="textAlign"]') as HTMLInputElement
+    const rightAlignButton = elem.querySelector(
+      '.w-e-table-property-align-button[data-value="right"]'
+    ) as HTMLButtonElement
     const backgroundColor = elem.querySelector('[name="backgroundColor"]') as HTMLInputElement
-    const button = elem.querySelector('button') as HTMLButtonElement
+    const button = elem.querySelector('.button-container button') as HTMLButtonElement
 
     borderStyle.value = 'solid'
-    textAlign.value = 'right'
+    rightAlignButton.click()
     backgroundColor.value = '#cccccc'
+
+    expect(textAlign.value).toBe('right')
+    expect(rightAlignButton.classList.contains('active')).toBe(true)
 
     button.click()
     vi.runAllTimers()
@@ -138,8 +158,12 @@ describe('table property menus', () => {
 
     setSelectionInsideFirstCell(editor)
     vi.spyOn(editor, 'getMenuConfig').mockImplementation((mark: string) => {
-      if (mark === 'color') { return { colors: ['#ff0000', '#00ff00'] } as any }
-      if (mark === 'bgColor') { return { colors: ['#cccccc'] } as any }
+      if (mark === 'color') {
+        return { colors: ['#ff0000', '#00ff00'] } as any
+      }
+      if (mark === 'bgColor') {
+        return { colors: ['#cccccc'] } as any
+      }
       return {} as any
     })
 
@@ -156,8 +180,9 @@ describe('table property menus', () => {
     colorOption.click()
 
     expect(borderColorInput.value).toBe('#00ff00')
-    expect((borderColorTrigger.querySelector('.color-group-block') as HTMLElement).style.backgroundColor)
-      .toContain('0, 255, 0')
+    expect(
+      (borderColorTrigger.querySelector('.color-group-block') as HTMLElement).style.backgroundColor
+    ).toContain('0, 255, 0')
 
     const clearPanel = menu.getPanelContentElem(editor, {
       mark: 'bgColor',
@@ -167,5 +192,32 @@ describe('table property menus', () => {
 
     expect(clearPanel.text()).toContain('清除')
     expect(clearPanel.find('li.active').attr('data-value')).toBe('#cccccc')
+  })
+
+  test('TableProperty marks the current text alignment button as active', () => {
+    const editor = createEditor({
+      content: [
+        {
+          ...createTableContent()[0],
+          textAlign: 'right',
+        },
+      ],
+    })
+    const menu = new TableProperty()
+
+    setSelectionInsideFirstCell(editor)
+
+    const elem = menu.getModalContentElem(editor) as HTMLDivElement
+    const rightAlignButton = elem.querySelector(
+      '.w-e-table-property-align-button[data-value="right"]'
+    ) as HTMLButtonElement
+    const leftAlignButton = elem.querySelector(
+      '.w-e-table-property-align-button[data-value="left"]'
+    ) as HTMLButtonElement
+
+    expect(rightAlignButton.classList.contains('active')).toBe(true)
+    expect(rightAlignButton.getAttribute('aria-pressed')).toBe('true')
+    expect(leftAlignButton.classList.contains('active')).toBe(false)
+    expect(leftAlignButton.getAttribute('aria-pressed')).toBe('false')
   })
 })

--- a/packages/table-module/src/assets/index.less
+++ b/packages/table-module/src/assets/index.less
@@ -160,52 +160,128 @@
 }
 
 .w-e-modal {
-  .babel-container {
-    span.babel-container-border {
+  .w-e-table-property-modal {
+    .babel-container {
       display: flex;
+      align-items: flex-start;
+      margin-bottom: 14px;
 
-      &> * {
-        height: 28px;
+      > span {
+        margin-bottom: 0;
+      }
+    }
+
+    .w-e-table-property-label {
+      flex: 0 0 72px;
+      min-height: 32px;
+      padding-top: 6px;
+      color: @toolbar-color;
+      line-height: 20px;
+    }
+
+    .w-e-table-property-controls {
+      flex: 1;
+      min-width: 0;
+    }
+
+    span.babel-container-border {
+      display: grid;
+      grid-template-columns: minmax(108px, 1fr) 32px 86px;
+      column-gap: 8px;
+
+      & > * {
+        min-height: 32px;
         border: 1px solid var(--w-e-modal-button-border-color);
-        border-radius: 2px;
+        border-radius: 4px;
       }
 
       select {
-        width: 114px;
-      }
-
-      > :nth-child(n+2) {
-        margin-left: 8px;
-      }
-
-      input:nth-child(3) {
-        width: 100px;
+        width: 100%;
+        height: 32px;
+        padding: 4px 8px;
+        color: @toolbar-color;
+        background-color: @toolbar-bg-color;
       }
     }
 
-    span.babel-container-background input {
-      height: 28px;
-      border: 1px solid var(--w-e-modal-button-border-color);
-      border-radius: 2px;
-      width: 60px;
+    .w-e-table-property-number {
+      position: relative;
+      display: block;
+
+      input[type='number'] {
+        width: 100%;
+        height: 30px;
+        padding-right: 28px;
+        border: 0;
+      }
     }
 
-    span.babel-container-algin select {
-      height: 28px;
+    .w-e-table-property-unit {
+      position: absolute;
+      top: 50%;
+      right: 8px;
+      display: inline;
+      margin-bottom: 0;
+      color: @toolbar-disabled-color;
+      line-height: 1;
+      transform: translateY(-50%);
+    }
+
+    span.babel-container-background {
+      display: flex;
+      min-height: 32px;
+    }
+
+    span.babel-container-align {
+      display: flex;
+    }
+
+    .w-e-table-property-align {
+      display: inline-flex;
+      overflow: hidden;
       border: 1px solid var(--w-e-modal-button-border-color);
-      border-radius: 2px;
+      border-radius: 4px;
+    }
+
+    .w-e-table-property-align-button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 36px;
+      height: 32px;
+      padding: 0;
+      border: 0;
+      border-right: 1px solid var(--w-e-modal-button-border-color);
+      border-radius: 0;
+      background-color: @toolbar-bg-color;
+
+      &:last-child {
+        border-right: 0;
+      }
+
+      &.active {
+        color: @toolbar-active-color;
+        background-color: @toolbar-active-bg-color;
+      }
+
+      svg {
+        width: 15px;
+        height: 15px;
+        fill: currentColor;
+      }
     }
 
     .color-group {
       position: relative;
-      width: 28px;
-      height: 28px;
+      width: 32px;
+      height: 32px;
+      margin-bottom: 0;
       border: 1px solid var(--w-e-modal-button-border-color);
-      border-radius: 2px;
+      border-radius: 4px;
       cursor: pointer;
 
       .w-e-drop-panel {
-        margin-top: 28px;
+        margin-top: 32px;
       }
     }
 
@@ -218,7 +294,7 @@
       svg {
         width: 20px;
         height: 20px;
-        margin: 1px 0px;
+        margin: 2px 1px;
       }
     }
   }

--- a/packages/table-module/src/locale/en.ts
+++ b/packages/table-module/src/locale/en.ts
@@ -7,6 +7,7 @@ export default {
   tableModule: {
     modal: {
       border: 'Border',
+      borderColor: 'Border color',
       borderWidth: 'Width',
       bgColor: 'Back color',
       align: 'Text Align',

--- a/packages/table-module/src/locale/zh-CN.ts
+++ b/packages/table-module/src/locale/zh-CN.ts
@@ -7,6 +7,7 @@ export default {
   tableModule: {
     modal: {
       border: '边框',
+      borderColor: '边框颜色',
       borderWidth: '宽度',
       bgColor: '背景色',
       align: '对齐方式',

--- a/packages/table-module/src/module/menu/CellProperty.ts
+++ b/packages/table-module/src/module/menu/CellProperty.ts
@@ -14,7 +14,7 @@ class CellProperty extends TableProperty implements IButtonMenu {
 
   readonly showModal = true
 
-  readonly modalWidth = 300
+  readonly modalWidth = 360
 
   readonly menu = 'cell'
 

--- a/packages/table-module/src/module/menu/TableProperty.ts
+++ b/packages/table-module/src/module/menu/TableProperty.ts
@@ -3,9 +3,7 @@
  * @author hsuna
  */
 
-import {
-  DomEditor, IButtonMenu, IDomEditor, t,
-} from '@wangeditor-next/core'
+import { DomEditor, IButtonMenu, IDomEditor, t } from '@wangeditor-next/core'
 import { Editor, Transforms } from 'slate'
 
 import {
@@ -29,7 +27,7 @@ class TableProperty implements IButtonMenu {
 
   readonly showModal = true
 
-  readonly modalWidth = 300
+  readonly modalWidth = 360
 
   readonly menu: string = 'table'
 
@@ -88,46 +86,62 @@ class TableProperty implements IButtonMenu {
   getModalContentElem(editor: IDomEditor) {
     const node = this.getModalContentNode(editor)
 
-    if (!node) { return null }
+    if (!node) {
+      return null
+    }
 
     const [data, path] = node
-    const $content = $(`<div>
-      <label class="babel-container">
-        <span>${t('tableModule.modal.border')}</span>
-        <span class="babel-container-border">
-          <select name="borderStyle">
+    const $content = $(`<div class="w-e-table-property-modal">
+      <label class="babel-container w-e-table-property-row">
+        <span class="w-e-table-property-label">${t('tableModule.modal.border')}</span>
+        <span class="babel-container-border w-e-table-property-controls">
+          <select name="borderStyle" aria-label="${t('tableModule.modal.border')}">
             ${this.borderStyle
-    .map(item => `<option value="${item.value}">${item.label}</option>`)
-    .join('')}
+              .map(item => `<option value="${item.value}">${item.label}</option>`)
+              .join('')}
           </select>
-          <span class="color-group" data-mark="color">
+          <span class="color-group" data-mark="color" title="${t('tableModule.modal.borderColor')}">
             <span class="color-group-block"></span>
             <input name="borderColor" type="hidden">
           </span>
-          <input name="borderWidth" type="number" placeholder="${t(
-    'tableModule.modal.borderWidth',
-  )}">
+          <span class="w-e-table-property-number">
+            <input name="borderWidth" type="number" min="0" placeholder="${t(
+              'tableModule.modal.borderWidth'
+            )}" aria-label="${t('tableModule.modal.borderWidth')}">
+            <span class="w-e-table-property-unit">px</span>
+          </span>
         </span>
       </label>
-      <div class="babel-container">
-        <span>${t('tableModule.modal.bgColor')}</span>
-        <span class="babel-container-background">
-          <span class="color-group" data-mark="bgColor">
+      <div class="babel-container w-e-table-property-row">
+        <span class="w-e-table-property-label">${t('tableModule.modal.bgColor')}</span>
+        <span class="babel-container-background w-e-table-property-controls">
+          <span class="color-group" data-mark="bgColor" title="${t('tableModule.modal.bgColor')}">
             <span class="color-group-block"></span>
             <input name="backgroundColor" type="hidden">
           </span>
         </span>
       </div>
-      <label class="babel-container">
-        <span>${t('tableModule.modal.align')}</span>
-        <span class="babel-container-align">
-          <select name="textAlign">
+      <div class="babel-container w-e-table-property-row">
+        <span class="w-e-table-property-label">${t('tableModule.modal.align')}</span>
+        <span class="babel-container-align w-e-table-property-controls">
+          <input name="textAlign" type="hidden">
+          <span class="w-e-table-property-align">
             ${this.textAlignOptions
-    .map(item => `<option value="${item.value}">${item.label}</option>`)
-    .join('')}
-          </select>
+              .map(
+                item => `
+              <button
+                type="button"
+                class="w-e-table-property-align-button"
+                data-value="${item.value}"
+                title="${item.label}"
+                aria-label="${item.label}"
+              >${item.svg}</button>
+            `
+              )
+              .join('')}
+          </span>
         </span>
-      </label>
+      </div>
       <div class="button-container">
         <button type="button">${t('tableModule.modal.ok')}</button>
       </div>
@@ -136,6 +150,37 @@ class TableProperty implements IButtonMenu {
     // 初始化所有表单的值
     $content.find('[name]').each(elem => {
       $(elem).val(data[$(elem).attr('name')])
+    })
+
+    const updateTextAlignButton = value => {
+      $content.find('.w-e-table-property-align-button').each(button => {
+        const $buttonElem = $(button)
+        const isActive = $buttonElem.attr('data-value') === value
+
+        if (isActive) {
+          $buttonElem.addClass('active')
+          $buttonElem.attr('aria-pressed', 'true')
+        } else {
+          $buttonElem.removeClass('active')
+          $buttonElem.attr('aria-pressed', 'false')
+        }
+      })
+    }
+
+    updateTextAlignButton($content.find('[name="textAlign"]').val() || '')
+
+    $content.find('.w-e-table-property-align-button').on('click', e => {
+      const button = e.currentTarget
+
+      if (button == null) {
+        return
+      }
+
+      const $buttonElem = $(button)
+      const value = $buttonElem.attr('data-value') || ''
+
+      $content.find('[name="textAlign"]').val(value)
+      updateTextAlignButton(value)
     })
 
     const setSelectedColor = (elem, color) => {
@@ -175,7 +220,7 @@ class TableProperty implements IButtonMenu {
       })
     })
 
-    const $button = $content.find('button')
+    const $button = $content.find('.button-container button')
 
     $button.on('click', () => {
       const props = Array.from($content.find('[name]')).reduce((obj, elem) => {
@@ -209,7 +254,9 @@ class TableProperty implements IButtonMenu {
     $colorPanel.on('click', 'li', e => {
       const { target } = e
 
-      if (!target) { return }
+      if (!target) {
+        return
+      }
       e.preventDefault()
       e.stopPropagation()
 
@@ -239,8 +286,12 @@ class TableProperty implements IButtonMenu {
 
     let clearText = ''
 
-    if (mark === 'color') { clearText = t('tableModule.color.default') }
-    if (mark === 'bgColor') { clearText = t('tableModule.color.clear') }
+    if (mark === 'color') {
+      clearText = t('tableModule.color.default')
+    }
+    if (mark === 'bgColor') {
+      clearText = t('tableModule.color.clear')
+    }
     const $clearLi = $(`
       <li data-value="" class="clear">
         ${CLEAN_SVG}


### PR DESCRIPTION
## Summary

- Refine the table/cell property modal layout for border, background, and alignment controls.
- Replace the text alignment select with icon segmented buttons while keeping the existing `textAlign` data field.
- Add tests for the new alignment button interaction and active state.
- Add a patch changeset for `@wangeditor-next/table-module`.

## Verification

- `pnpm --filter @wangeditor-next/table-module test`
- `pnpm --filter @wangeditor-next/table-module build`
- `pnpm eslint --quiet --no-error-on-unmatched-pattern packages/table-module/src/module/menu/TableProperty.ts packages/table-module/src/module/menu/CellProperty.ts packages/table-module/__tests__/menu/property-menu.test.ts`
- `git diff --check`
- `pnpm build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added border color option to table property modals.

* **Improvements**
  * Expanded table and cell property modal widths for better control visibility.
  * Enhanced modal styling with refined spacing, borders, and color token consistency.
  * Improved table alignment controls with clearer button states and accessibility support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->