### PR TITLE
fix(table): refine property modal behavior

### DIFF
--- a/.changeset/sharp-tables-rest.md
+++ b/.changeset/sharp-tables-rest.md
@@ -1,0 +1,5 @@
+---
+"@wangeditor-next/table-module": patch
+---
+
+Improve table and cell property modal behavior.

--- a/packages/table-module/__tests__/menu/property-menu.test.ts
+++ b/packages/table-module/__tests__/menu/property-menu.test.ts
@@ -42,6 +42,11 @@ function setSelectionInsideFirstCell(editor) {
   }
 }
 
+function changeInputValue(input: HTMLInputElement | HTMLSelectElement, value: string) {
+  input.value = value
+  input.dispatchEvent(new Event('change', { bubbles: true }))
+}
+
 function createContextSelection(editor, rows: number[][][]): NodeEntryWithContext[][] {
   return rows.map(row =>
     row.map(path => [
@@ -72,34 +77,44 @@ describe('table property menus', () => {
 
     const elem = menu.getModalContentElem(editor) as HTMLDivElement
     const borderStyle = elem.querySelector('[name="borderStyle"]') as HTMLSelectElement
-    const borderColor = elem.querySelector('[name="borderColor"]') as HTMLInputElement
     const borderWidth = elem.querySelector('[name="borderWidth"]') as HTMLInputElement
-    const backgroundColor = elem.querySelector('[name="backgroundColor"]') as HTMLInputElement
-    const textAlign = elem.querySelector('[name="textAlign"]') as HTMLInputElement
-    const centerAlignButton = elem.querySelector(
-      '.w-e-table-property-align-button[data-value="center"]'
-    ) as HTMLButtonElement
+    const borderColorTrigger = elem.querySelector('[data-mark="color"]') as HTMLElement
+    const backgroundColorTrigger = elem.querySelector('[data-mark="bgColor"]') as HTMLElement
+    const width = elem.querySelector('[name="width"]') as HTMLSelectElement
+    const textAlign = elem.querySelector('[name="textAlign"]') as HTMLInputElement | null
     const button = elem.querySelector('.button-container button') as HTMLButtonElement
 
-    borderStyle.value = 'dashed'
-    borderColor.value = '#ff0000'
-    borderWidth.value = '2'
-    backgroundColor.value = '#00ff00'
-    centerAlignButton.click()
+    vi.spyOn(editor, 'getMenuConfig').mockImplementation((mark: string) => {
+      if (mark === 'color') {
+        return { colors: ['#ff0000'] } as any
+      }
+      if (mark === 'bgColor') {
+        return { colors: ['#00ff00'] } as any
+      }
+      return {} as any
+    })
 
-    expect(textAlign.value).toBe('center')
-    expect(centerAlignButton.classList.contains('active')).toBe(true)
+    changeInputValue(width, '100%')
+    changeInputValue(borderStyle, 'dashed')
+    changeInputValue(borderWidth, '2')
+    borderColorTrigger.click()
+    ;(borderColorTrigger.querySelector('li[data-value="#ff0000"]') as HTMLElement).click()
+    backgroundColorTrigger.click()
+    ;(backgroundColorTrigger.querySelector('li[data-value="#00ff00"]') as HTMLElement).click()
+
+    expect(textAlign).toBeNull()
 
     button.click()
     vi.runAllTimers()
 
     const table = editor.children[0] as TableElement & Record<string, string>
 
+    expect(table.width).toBe('100%')
     expect(table.borderStyle).toBe('dashed')
     expect(table.borderColor).toBe('#ff0000')
     expect(table.borderWidth).toBe('2')
     expect(table.backgroundColor).toBe('#00ff00')
-    expect(table.textAlign).toBe('center')
+    expect(table.textAlign).toBeUndefined()
     expect(focusSpy).toHaveBeenCalled()
   })
 
@@ -130,15 +145,30 @@ describe('table property menus', () => {
     const rightAlignButton = elem.querySelector(
       '.w-e-table-property-align-button[data-value="right"]'
     ) as HTMLButtonElement
-    const backgroundColor = elem.querySelector('[name="backgroundColor"]') as HTMLInputElement
+    const middleVerticalAlignButton = elem.querySelector(
+      '.w-e-table-property-segment-button[data-value="middle"]'
+    ) as HTMLButtonElement
+    const verticalAlign = elem.querySelector('[name="verticalAlign"]') as HTMLInputElement
+    const backgroundColorTrigger = elem.querySelector('[data-mark="bgColor"]') as HTMLElement
     const button = elem.querySelector('.button-container button') as HTMLButtonElement
 
-    borderStyle.value = 'solid'
+    vi.spyOn(editor, 'getMenuConfig').mockImplementation((mark: string) => {
+      if (mark === 'bgColor') {
+        return { colors: ['#cccccc'] } as any
+      }
+      return {} as any
+    })
+
+    changeInputValue(borderStyle, 'solid')
     rightAlignButton.click()
-    backgroundColor.value = '#cccccc'
+    middleVerticalAlignButton.click()
+    backgroundColorTrigger.click()
+    ;(backgroundColorTrigger.querySelector('li[data-value="#cccccc"]') as HTMLElement).click()
 
     expect(textAlign.value).toBe('right')
     expect(rightAlignButton.classList.contains('active')).toBe(true)
+    expect(verticalAlign.value).toBe('middle')
+    expect(middleVerticalAlignButton.classList.contains('active')).toBe(true)
 
     button.click()
     vi.runAllTimers()
@@ -148,8 +178,80 @@ describe('table property menus', () => {
 
     expect(allCells.every(cell => cell.borderStyle === 'solid')).toBe(true)
     expect(allCells.every(cell => cell.textAlign === 'right')).toBe(true)
+    expect(allCells.every(cell => cell.verticalAlign === 'middle')).toBe(true)
     expect(allCells.every(cell => cell.backgroundColor === '#cccccc')).toBe(true)
     expect(focusSpy).toHaveBeenCalled()
+  })
+
+  test('CellProperty only applies changed properties in batch selection', () => {
+    vi.useFakeTimers()
+    const editor = createEditor({
+      content: [
+        {
+          type: 'table',
+          width: 'auto',
+          children: [
+            {
+              type: 'table-row',
+              children: [
+                {
+                  type: 'table-cell',
+                  borderStyle: 'dashed',
+                  backgroundColor: '#ffffff',
+                  children: [{ text: 'A' }],
+                },
+                {
+                  type: 'table-cell',
+                  borderStyle: 'solid',
+                  backgroundColor: '#eeeeee',
+                  children: [{ text: 'B' }],
+                },
+              ],
+            },
+          ],
+          columnWidths: [60, 60],
+          scrollWidth: 120,
+          height: 31,
+        },
+      ],
+    })
+    const menu = new CellProperty()
+
+    setSelectionInsideFirstCell(editor)
+    EDITOR_TO_SELECTION.set(
+      editor,
+      createContextSelection(editor, [
+        [
+          [0, 0, 0],
+          [0, 0, 1],
+        ],
+      ])
+    )
+
+    const elem = menu.getModalContentElem(editor) as HTMLDivElement
+    const backgroundColor = elem.querySelector('[name="backgroundColor"]') as HTMLInputElement
+    const borderStyle = elem.querySelector('[name="borderStyle"]') as HTMLSelectElement
+    const rightAlignButton = elem.querySelector(
+      '.w-e-table-property-align-button[data-value="right"]'
+    ) as HTMLButtonElement
+    const button = elem.querySelector('.button-container button') as HTMLButtonElement
+
+    expect(borderStyle.getAttribute('data-mixed')).toBe('true')
+    expect(backgroundColor.getAttribute('data-mixed')).toBe('true')
+
+    rightAlignButton.click()
+    button.click()
+    vi.runAllTimers()
+
+    const table = editor.children[0] as TableElement
+    const [firstCell, secondCell] = table.children[0].children
+
+    expect(firstCell.borderStyle).toBe('dashed')
+    expect(secondCell.borderStyle).toBe('solid')
+    expect(firstCell.backgroundColor).toBe('#ffffff')
+    expect(secondCell.backgroundColor).toBe('#eeeeee')
+    expect(firstCell.textAlign).toBe('right')
+    expect(secondCell.textAlign).toBe('right')
   })
 
   test('TableProperty renders color panels and updates hidden values through the color picker', () => {
@@ -194,16 +296,32 @@ describe('table property menus', () => {
     expect(clearPanel.find('li.active').attr('data-value')).toBe('#cccccc')
   })
 
-  test('TableProperty marks the current text alignment button as active', () => {
+  test('CellProperty marks the current text alignment button as active', () => {
     const editor = createEditor({
       content: [
         {
-          ...createTableContent()[0],
-          textAlign: 'right',
+          type: 'table',
+          width: 'auto',
+          children: [
+            {
+              type: 'table-row',
+              children: [
+                {
+                  type: 'table-cell',
+                  textAlign: 'right',
+                  verticalAlign: 'bottom',
+                  children: [{ text: 'A' }],
+                },
+              ],
+            },
+          ],
+          columnWidths: [60],
+          scrollWidth: 60,
+          height: 31,
         },
       ],
     })
-    const menu = new TableProperty()
+    const menu = new CellProperty()
 
     setSelectionInsideFirstCell(editor)
 
@@ -214,10 +332,15 @@ describe('table property menus', () => {
     const leftAlignButton = elem.querySelector(
       '.w-e-table-property-align-button[data-value="left"]'
     ) as HTMLButtonElement
+    const bottomVerticalAlignButton = elem.querySelector(
+      '.w-e-table-property-segment-button[data-value="bottom"]'
+    ) as HTMLButtonElement
 
     expect(rightAlignButton.classList.contains('active')).toBe(true)
     expect(rightAlignButton.getAttribute('aria-pressed')).toBe('true')
     expect(leftAlignButton.classList.contains('active')).toBe(false)
     expect(leftAlignButton.getAttribute('aria-pressed')).toBe('false')
+    expect(bottomVerticalAlignButton.classList.contains('active')).toBe(true)
+    expect(bottomVerticalAlignButton.getAttribute('aria-pressed')).toBe('true')
   })
 })

--- a/packages/table-module/__tests__/menu/property-menu.test.ts
+++ b/packages/table-module/__tests__/menu/property-menu.test.ts
@@ -346,6 +346,37 @@ describe('table property menus', () => {
     expect(clearPanel.find('li.active').attr('data-value')).toBe('#cccccc')
   })
 
+  test('TableProperty supports keyboard activation for custom controls', () => {
+    const editor = createEditor({ content: createTableContent() })
+    const menu = new TableProperty()
+
+    setSelectionInsideFirstCell(editor)
+    vi.spyOn(editor, 'getMenuConfig').mockImplementation((mark: string) => {
+      if (mark === 'color') {
+        return { colors: ['#ff0000'] } as any
+      }
+      return {} as any
+    })
+
+    const elem = menu.getModalContentElem(editor) as HTMLDivElement
+    const trigger = elem.querySelector('.w-e-table-property-select-trigger') as HTMLButtonElement
+    const borderStyle = elem.querySelector('[name="borderStyle"]') as HTMLInputElement
+    const option = elem.querySelector(
+      '.w-e-table-property-select-option[data-value="dashed"]'
+    ) as HTMLButtonElement
+    const borderColorTrigger = elem.querySelector('[data-mark="color"]') as HTMLElement
+
+    trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    expect(trigger.getAttribute('aria-expanded')).toBe('true')
+
+    option.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }))
+    expect(borderStyle.value).toBe('dashed')
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
+
+    borderColorTrigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    expect(borderColorTrigger.querySelector('.w-e-drop-panel')).not.toBeNull()
+  })
+
   test('CellProperty marks the current text alignment button as active', () => {
     const editor = createEditor({
       content: [

--- a/packages/table-module/__tests__/menu/property-menu.test.ts
+++ b/packages/table-module/__tests__/menu/property-menu.test.ts
@@ -80,7 +80,10 @@ describe('table property menus', () => {
     const borderWidth = elem.querySelector('[name="borderWidth"]') as HTMLInputElement
     const borderColorTrigger = elem.querySelector('[data-mark="color"]') as HTMLElement
     const backgroundColorTrigger = elem.querySelector('[data-mark="bgColor"]') as HTMLElement
-    const width = elem.querySelector('[name="width"]') as HTMLSelectElement
+    const width = elem.querySelector('[name="width"]') as HTMLInputElement
+    const fullWidthButton = elem.querySelector(
+      '.w-e-table-property-segment-button[data-value="100%"]'
+    ) as HTMLButtonElement
     const textAlign = elem.querySelector('[name="textAlign"]') as HTMLInputElement | null
     const button = elem.querySelector('.button-container button') as HTMLButtonElement
 
@@ -94,7 +97,7 @@ describe('table property menus', () => {
       return {} as any
     })
 
-    changeInputValue(width, '100%')
+    fullWidthButton.click()
     changeInputValue(borderStyle, 'dashed')
     changeInputValue(borderWidth, '2')
     borderColorTrigger.click()
@@ -103,6 +106,8 @@ describe('table property menus', () => {
     ;(backgroundColorTrigger.querySelector('li[data-value="#00ff00"]') as HTMLElement).click()
 
     expect(textAlign).toBeNull()
+    expect(width.value).toBe('100%')
+    expect(fullWidthButton.classList.contains('active')).toBe(true)
 
     button.click()
     vi.runAllTimers()

--- a/packages/table-module/__tests__/menu/property-menu.test.ts
+++ b/packages/table-module/__tests__/menu/property-menu.test.ts
@@ -47,6 +47,16 @@ function changeInputValue(input: HTMLInputElement | HTMLSelectElement, value: st
   input.dispatchEvent(new Event('change', { bubbles: true }))
 }
 
+function selectBorderStyle(elem: HTMLElement, value: string) {
+  const trigger = elem.querySelector('.w-e-table-property-select-trigger') as HTMLButtonElement
+  const option = elem.querySelector(
+    `.w-e-table-property-select-option[data-value="${value}"]`
+  ) as HTMLButtonElement
+
+  trigger.click()
+  option.click()
+}
+
 function createContextSelection(editor, rows: number[][][]): NodeEntryWithContext[][] {
   return rows.map(row =>
     row.map(path => [
@@ -76,15 +86,12 @@ describe('table property menus', () => {
     setSelectionInsideFirstCell(editor)
 
     const elem = menu.getModalContentElem(editor) as HTMLDivElement
-    const borderStyle = elem.querySelector('[name="borderStyle"]') as HTMLSelectElement
+    const borderStyle = elem.querySelector('[name="borderStyle"]') as HTMLInputElement
     const borderWidth = elem.querySelector('[name="borderWidth"]') as HTMLInputElement
     const borderColorTrigger = elem.querySelector('[data-mark="color"]') as HTMLElement
     const backgroundColorTrigger = elem.querySelector('[data-mark="bgColor"]') as HTMLElement
-    const width = elem.querySelector('[name="width"]') as HTMLInputElement
-    const fullWidthButton = elem.querySelector(
-      '.w-e-table-property-segment-button[data-value="100%"]'
-    ) as HTMLButtonElement
     const textAlign = elem.querySelector('[name="textAlign"]') as HTMLInputElement | null
+    const width = elem.querySelector('[name="width"]') as HTMLInputElement | null
     const button = elem.querySelector('.button-container button') as HTMLButtonElement
 
     vi.spyOn(editor, 'getMenuConfig').mockImplementation((mark: string) => {
@@ -97,8 +104,7 @@ describe('table property menus', () => {
       return {} as any
     })
 
-    fullWidthButton.click()
-    changeInputValue(borderStyle, 'dashed')
+    selectBorderStyle(elem, 'dashed')
     changeInputValue(borderWidth, '2')
     borderColorTrigger.click()
     ;(borderColorTrigger.querySelector('li[data-value="#ff0000"]') as HTMLElement).click()
@@ -106,21 +112,59 @@ describe('table property menus', () => {
     ;(backgroundColorTrigger.querySelector('li[data-value="#00ff00"]') as HTMLElement).click()
 
     expect(textAlign).toBeNull()
-    expect(width.value).toBe('100%')
-    expect(fullWidthButton.classList.contains('active')).toBe(true)
+    expect(width).toBeNull()
+    expect(borderStyle.value).toBe('dashed')
 
     button.click()
     vi.runAllTimers()
 
     const table = editor.children[0] as TableElement & Record<string, string>
 
-    expect(table.width).toBe('100%')
+    expect(table.width).toBe('auto')
     expect(table.borderStyle).toBe('dashed')
     expect(table.borderColor).toBe('#ff0000')
     expect(table.borderWidth).toBe('2')
     expect(table.backgroundColor).toBe('#00ff00')
     expect(table.textAlign).toBeUndefined()
     expect(focusSpy).toHaveBeenCalled()
+  })
+
+  test('TableProperty shows default border style and makes selected border color visible', () => {
+    vi.useFakeTimers()
+    const editor = createEditor({ content: createTableContent() })
+    const menu = new TableProperty()
+
+    setSelectionInsideFirstCell(editor)
+    vi.spyOn(editor, 'getMenuConfig').mockImplementation((mark: string) => {
+      if (mark === 'color') {
+        return { colors: ['#ff0000'] } as any
+      }
+      return {} as any
+    })
+
+    const elem = menu.getModalContentElem(editor) as HTMLDivElement
+    const borderStyle = elem.querySelector('[name="borderStyle"]') as HTMLInputElement
+    const borderWidth = elem.querySelector('[name="borderWidth"]') as HTMLInputElement
+    const borderColorTrigger = elem.querySelector('[data-mark="color"]') as HTMLElement
+    const button = elem.querySelector('.button-container button') as HTMLButtonElement
+
+    expect(borderStyle.value).toBe('none')
+    expect(borderWidth.placeholder).toBe('默认 1')
+
+    borderColorTrigger.click()
+    ;(borderColorTrigger.querySelector('li[data-value="#ff0000"]') as HTMLElement).click()
+
+    expect(borderStyle.value).toBe('solid')
+    expect(borderWidth.value).toBe('1')
+
+    button.click()
+    vi.runAllTimers()
+
+    const table = editor.children[0] as TableElement & Record<string, string>
+
+    expect(table.borderColor).toBe('#ff0000')
+    expect(table.borderStyle).toBe('solid')
+    expect(table.borderWidth).toBe('1')
   })
 
   test('CellProperty applies properties to every selected cell in the batch selection', () => {
@@ -145,7 +189,6 @@ describe('table property menus', () => {
     )
 
     const elem = menu.getModalContentElem(editor) as HTMLDivElement
-    const borderStyle = elem.querySelector('[name="borderStyle"]') as HTMLSelectElement
     const textAlign = elem.querySelector('[name="textAlign"]') as HTMLInputElement
     const rightAlignButton = elem.querySelector(
       '.w-e-table-property-align-button[data-value="right"]'
@@ -164,7 +207,7 @@ describe('table property menus', () => {
       return {} as any
     })
 
-    changeInputValue(borderStyle, 'solid')
+    selectBorderStyle(elem, 'solid')
     rightAlignButton.click()
     middleVerticalAlignButton.click()
     backgroundColorTrigger.click()
@@ -235,7 +278,7 @@ describe('table property menus', () => {
 
     const elem = menu.getModalContentElem(editor) as HTMLDivElement
     const backgroundColor = elem.querySelector('[name="backgroundColor"]') as HTMLInputElement
-    const borderStyle = elem.querySelector('[name="borderStyle"]') as HTMLSelectElement
+    const borderStyle = elem.querySelector('[name="borderStyle"]') as HTMLInputElement
     const rightAlignButton = elem.querySelector(
       '.w-e-table-property-align-button[data-value="right"]'
     ) as HTMLButtonElement
@@ -287,6 +330,8 @@ describe('table property menus', () => {
     colorOption.click()
 
     expect(borderColorInput.value).toBe('#00ff00')
+    expect((elem.querySelector('[name="borderStyle"]') as HTMLInputElement).value).toBe('solid')
+    expect((elem.querySelector('[name="borderWidth"]') as HTMLInputElement).value).toBe('1')
     expect(
       (borderColorTrigger.querySelector('.color-group-block') as HTMLElement).style.backgroundColor
     ).toContain('0, 255, 0')

--- a/packages/table-module/__tests__/parse-html.test.ts
+++ b/packages/table-module/__tests__/parse-html.test.ts
@@ -60,13 +60,13 @@ describe('table - pre parse html', () => {
 
   it('should preserve cells that use display:none but still contain imported content', () => {
     const $table = $(
-      '<table><tbody><tr><td>A1</td><td style="display:none">B1</td><td style="display: none">C1</td></tr></tbody></table>',
+      '<table><tbody><tr><td>A1</td><td style="display:none">B1</td><td style="display: none">C1</td></tr></tbody></table>'
     )
 
     const res = preParseTableHtmlConf.preParseHtml($table[0])
 
     expect(res.outerHTML).toBe(
-      '<table><tr><td width="auto">A1</td><td style="display:none" width="auto">B1</td><td style="display: none" width="auto">C1</td></tr></table>',
+      '<table><tr><td width="auto">A1</td><td style="display:none" width="auto">B1</td><td style="display: none" width="auto">C1</td></tr></table>'
     )
   })
 
@@ -77,7 +77,7 @@ describe('table - pre parse html', () => {
         '<p><span style="color: rgb(255, 0, 0); background-color: rgb(255, 255, 0);">line 1</span></p>',
         '<p><span style="color: rgb(255, 0, 0); background-color: rgb(255, 255, 0);">line 2</span></p>',
         '</td></tr></tbody></table>',
-      ].join(''),
+      ].join('')
     )
 
     const res = preParseTableHtmlConf.preParseHtml($table[0])
@@ -89,7 +89,7 @@ describe('table - pre parse html', () => {
         '<br>',
         '<span style="color: rgb(255, 0, 0); background-color: rgb(255, 255, 0);">line 2</span>',
         '</td></tr></table>',
-      ].join(''),
+      ].join('')
     )
   })
 
@@ -108,7 +108,7 @@ describe('table - pre parse html', () => {
         '</tr>',
         '</tbody>',
         '</table>',
-      ].join(''),
+      ].join('')
     )
 
     const boundingClientRectSpy = vi
@@ -159,7 +159,7 @@ describe('table - pre parse html', () => {
         '<tr><td data-measure-width="999">A</td><td data-measure-width="999">B</td></tr>',
         '</tbody>',
         '</table>',
-      ].join(''),
+      ].join('')
     )
 
     const boundingClientRectSpy = vi
@@ -253,7 +253,7 @@ describe('table - parse html', () => {
 
   it('table cell should keep line breaks imported from word-like paragraphs', () => {
     const $cell = $(
-      '<td><span style="color: rgb(255, 0, 0); background-color: rgb(255, 255, 0);">line 1<br>line 2</span></td>',
+      '<td><span style="color: rgb(255, 0, 0); background-color: rgb(255, 255, 0);">line 1<br>line 2</span></td>'
     )
     const [cell] = parseElemHtmlFromCore($($cell[0]), editor) as any[]
 
@@ -307,12 +307,13 @@ describe('table - parse html', () => {
     const stubEditor = {
       isInline: () => false,
     } as any
-    const rows = Array.from($table.find('tr'))
-      .map(row => {
-        const cells = Array.from(row.children).map(cell => parseCellHtmlConf.parseElemHtml(cell as HTMLTableCellElement, [], stubEditor))
+    const rows = Array.from($table.find('tr')).map(row => {
+      const cells = Array.from(row.children).map(cell =>
+        parseCellHtmlConf.parseElemHtml(cell as HTMLTableCellElement, [], stubEditor)
+      )
 
-        return parseRowHtmlConf.parseElemHtml(row as HTMLTableRowElement, cells, stubEditor)
-      })
+      return parseRowHtmlConf.parseElemHtml(row as HTMLTableRowElement, cells, stubEditor)
+    })
     const table = parseTableHtmlConf.parseElemHtml($table[0], rows as any, stubEditor)
 
     expect(table).toMatchObject({
@@ -363,12 +364,13 @@ describe('table - parse html', () => {
     const stubEditor = {
       isInline: () => false,
     } as any
-    const rows = Array.from($table.find('tr'))
-      .map(row => {
-        const cells = Array.from(row.children).map(cell => parseCellHtmlConf.parseElemHtml(cell as HTMLTableCellElement, [], stubEditor))
+    const rows = Array.from($table.find('tr')).map(row => {
+      const cells = Array.from(row.children).map(cell =>
+        parseCellHtmlConf.parseElemHtml(cell as HTMLTableCellElement, [], stubEditor)
+      )
 
-        return parseRowHtmlConf.parseElemHtml(row as HTMLTableRowElement, cells, stubEditor)
-      })
+      return parseRowHtmlConf.parseElemHtml(row as HTMLTableRowElement, cells, stubEditor)
+    })
     const table = parseTableHtmlConf.parseElemHtml($table[0], rows as any, stubEditor)
 
     expect(table).toMatchObject({
@@ -417,7 +419,7 @@ describe('table - parse html', () => {
 
   it('table cell with explicit float border-width (1.5em)', () => {
     const $cell = $(
-      '<td style="border-width: 1.5em; border-style: dotted; border-color: orange;">Cell C</td>',
+      '<td style="border-width: 1.5em; border-style: dotted; border-color: orange;">Cell C</td>'
     )
     const children = [{ text: 'Cell C' }]
 
@@ -434,7 +436,7 @@ describe('table - parse html', () => {
 
   it('table cell with keyword border-width (thin) should be retained', () => {
     const $cell = $(
-      '<td style="border-width: thin; border-style: dotted; border-color: blue;">Cell D</td>',
+      '<td style="border-width: thin; border-style: dotted; border-color: blue;">Cell D</td>'
     )
     const children = [{ text: 'Cell D' }]
 
@@ -451,7 +453,7 @@ describe('table - parse html', () => {
 
   it('table cell with multi-value should be retained', () => {
     const $cell = $(
-      '<td style="border-width: 2px 1em; border-style: dotted solid dashed; border-color: #ff0000 #00ff00 #0000ff rgb(250,0,255)">Cell E</td>',
+      '<td style="border-width: 2px 1em; border-style: dotted solid dashed; border-color: #ff0000 #00ff00 #0000ff rgb(250,0,255)">Cell E</td>'
     )
     const children = [{ text: 'Cell E' }]
 
@@ -486,7 +488,7 @@ describe('table - parse html', () => {
   it('table cell with multi-value border-width mixing keywords, pt, and px should convert correctly', () => {
     const multiPtWidth = 'medium 1pt 0.5pt 2px'
     const $cell = $(
-      `<td style="border-width: ${multiPtWidth}; border-style: dashed; border-color: red;">Cell H</td>`,
+      `<td style="border-width: ${multiPtWidth}; border-style: dashed; border-color: red;">Cell H</td>`
     )
     const children = [{ text: 'Cell H' }]
 
@@ -524,7 +526,7 @@ describe('table - parse html', () => {
 
   it('should use specific border-width/style/color over border shorthand', () => {
     const $cell = $(
-      '<td style="border: 1px solid red; border-width: 5px; border-style: dashed; border-color: blue;">Cell I</td>',
+      '<td style="border: 1px solid red; border-width: 5px; border-style: dashed; border-color: blue;">Cell I</td>'
     )
     const children = [{ text: 'Cell I' }]
 
@@ -541,7 +543,7 @@ describe('table - parse html', () => {
 
   it('should use specific border-width/color over border shorthand', () => {
     const $cell = $(
-      '<td style="border: 1px dashed red; border-width: 5px; border-color: blue;">Cell I</td>',
+      '<td style="border: 1px dashed red; border-width: 5px; border-color: blue;">Cell I</td>'
     )
     const children = [{ text: 'Cell I' }]
 
@@ -695,7 +697,7 @@ describe('table - parse html', () => {
           <td colSpan="1" rowSpan="1" width="auto">数学</td>
           <td colSpan="1" rowSpan="1" width="auto">92</td>
         </tr>
-      </table>`,
+      </table>`
     )
     const children = [
       {
@@ -742,14 +744,12 @@ describe('table - parse html', () => {
 
   it('table should fallback auto height to 0 instead of NaN', () => {
     const $table = $(
-      '<table style="width: auto;table-layout: fixed;height:auto"><tr><td width="auto">A</td></tr></table>',
+      '<table style="width: auto;table-layout: fixed;height:auto"><tr><td width="auto">A</td></tr></table>'
     )
     const children = [
       {
         type: 'table-row',
-        children: [
-          { ...TABLE_CELL_BASE_PROPS, children: [{ text: 'A' }] },
-        ],
+        children: [{ ...TABLE_CELL_BASE_PROPS, children: [{ text: 'A' }] }],
       },
     ]
 
@@ -764,7 +764,7 @@ describe('table - parse html', () => {
 
   it('table should keep columns from excel-like hidden-style cells when they contain text', () => {
     const $table = $(
-      '<table><tr><td width="auto">A1</td><td style="display:none" width="auto">B1</td><td style="display: none" width="auto">C1</td></tr></table>',
+      '<table><tr><td width="auto">A1</td><td style="display:none" width="auto">B1</td><td style="display: none" width="auto">C1</td></tr></table>'
     )
     const children = [
       {
@@ -788,7 +788,7 @@ describe('table - parse html', () => {
 
   it('table - class mode attrs', () => {
     const $table = $(
-      '<table class="w-e-table-layout-fixed" width="320px" height="124" data-w-e-table-height="124"><tr><td width="auto">A</td></tr></table>',
+      '<table class="w-e-table-layout-fixed" width="320px" height="124" data-w-e-table-height="124"><tr><td width="auto">A</td></tr></table>'
     )
     const children = [
       {
@@ -813,7 +813,7 @@ describe('table - parse html', () => {
         '<colgroup><col width="120"></col><col width="180"></col></colgroup>',
         '<tr><td width="auto">A</td><td width="auto">B</td></tr>',
         '</table>',
-      ].join(''),
+      ].join('')
     )
     const children = [
       {
@@ -841,7 +841,7 @@ describe('table - parse html', () => {
         '<colgroup><col width="120"></col><col width="180"></col></colgroup>',
         '<tr><td width="auto">A</td><td width="auto">B</td></tr>',
         '</table>',
-      ].join(''),
+      ].join('')
     )
     const children = [
       {
@@ -860,7 +860,7 @@ describe('table - parse html', () => {
         getConfig() {
           return { textStyleMode: 'class' }
         },
-      } as any,
+      } as any
     )
 
     expect(parsedTable.width).toBe('100%')
@@ -885,17 +885,17 @@ describe('table - parse html', () => {
         },
       ],
     }
-    const exported = tableToHtmlConf.elemToHtml(
-      tableNode as any,
-      '<tr><td>A</td><td>B</td></tr>',
-      {
-        getConfig() {
-          return { textStyleMode: 'class' }
-        },
-      } as any,
-    )
+    const exported = tableToHtmlConf.elemToHtml(tableNode as any, '<tr><td>A</td><td>B</td></tr>', {
+      getConfig() {
+        return { textStyleMode: 'class' }
+      },
+    } as any)
     const $table = $(exported)
-    const parsedBack = parseTableHtmlConf.parseElemHtml($table[0], tableNode.children as any, editor)
+    const parsedBack = parseTableHtmlConf.parseElemHtml(
+      $table[0],
+      tableNode.children as any,
+      editor
+    )
 
     expect(exported).toContain('width="100%"')
     expect(parsedBack).toMatchObject({
@@ -907,7 +907,7 @@ describe('table - parse html', () => {
 
   it('table cell style - class mode attrs', () => {
     const $cell = $(
-      '<td bgcolor="#fff" border="2" bordercolor="#000" align="center" class="w-e-table-border-style-dashed" data-w-e-border-line="dashed">Cell Z</td>',
+      '<td bgcolor="#fff" border="2" bordercolor="#000" align="center" valign="middle" class="w-e-table-border-style-dashed" data-w-e-border-line="dashed">Cell Z</td>'
     )
     const children = [{ text: 'Cell Z' }]
 
@@ -920,6 +920,23 @@ describe('table - parse html', () => {
         borderStyle: 'dashed',
         borderColor: '#000',
         textAlign: 'center',
+        verticalAlign: 'middle',
+      },
+    ])
+  })
+
+  it('table cell style - data vertical align should parse', () => {
+    const $cell = $('<td data-w-e-vertical-align="bottom">Cell Z</td>')
+    const children = [{ text: 'Cell Z' }]
+
+    expect(parseElemHtmlFromCore($($cell[0]), editor)).toEqual([
+      {
+        ...TABLE_CELL_BASE_PROPS,
+        children,
+        borderWidth: '1px',
+        borderStyle: 'solid',
+        borderColor: undefined,
+        verticalAlign: 'bottom',
       },
     ])
   })

--- a/packages/table-module/__tests__/render-style.test.ts
+++ b/packages/table-module/__tests__/render-style.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'vitest'
+
+import { renderStyle } from '../src/module/render-style'
+
+describe('table renderStyle', () => {
+  test('applies vertical align to table cell vnode', () => {
+    const vnode = { data: {} } as any
+    const styled = renderStyle(
+      {
+        type: 'table-cell',
+        verticalAlign: 'middle',
+        children: [{ text: 'A' }],
+      } as any,
+      vnode
+    ) as any
+
+    expect(styled.data.style.verticalAlign).toBe('middle')
+  })
+})

--- a/packages/table-module/__tests__/style-to-html.test.ts
+++ b/packages/table-module/__tests__/style-to-html.test.ts
@@ -35,14 +35,16 @@ describe('table styleToHtml', () => {
         borderStyle: 'none',
         borderColor: '#000',
         textAlign: 'center',
+        verticalAlign: 'middle',
       },
-      html,
+      html
     )
 
     expect(styled).toContain('background-color: rgb(255, 255, 255);')
     expect(styled).toContain('border-width: 2px;')
     expect(styled).toContain('border-color: #000;')
     expect(styled).toContain('text-align: center;')
+    expect(styled).toContain('vertical-align: middle;')
     expect(styled).not.toContain('border-style:')
   })
 
@@ -61,20 +63,23 @@ describe('table styleToHtml', () => {
         borderStyle: 'dashed',
         borderColor: '#000',
         textAlign: 'center',
+        verticalAlign: 'bottom',
       },
       html,
-      mockEditor,
+      mockEditor
     )
 
     expect(styled).toContain('bgcolor="#fff"')
     expect(styled).toContain('border="2"')
     expect(styled).toContain('bordercolor="#000"')
     expect(styled).toContain('align="center"')
+    expect(styled).toContain('valign="bottom"')
     expect(styled).toContain('data-w-e-background-color="#fff"')
     expect(styled).toContain('data-w-e-border-width="2"')
     expect(styled).toContain('data-w-e-border-line="dashed"')
     expect(styled).toContain('data-w-e-border-color="#000"')
     expect(styled).toContain('data-w-e-text-align="center"')
+    expect(styled).toContain('data-w-e-vertical-align="bottom"')
     expect(styled).toContain('class="w-e-table-border-style-dashed"')
     expect(styled).not.toMatch(/\sstyle=/)
   })
@@ -92,7 +97,7 @@ describe('table styleToHtml', () => {
         borderStyle: 'dotted solid dashed',
       },
       html,
-      mockEditor,
+      mockEditor
     )
 
     expect(styled).toContain('data-w-e-border-line="dotted solid dashed"')
@@ -116,7 +121,7 @@ describe('table styleToHtml', () => {
         borderStyle: 'dotted solid dashed',
       },
       html,
-      mockEditor,
+      mockEditor
     )
 
     expect(styled).toContain('data-w-e-border-line="dotted solid dashed"')
@@ -134,11 +139,17 @@ describe('table styleToHtml', () => {
       },
     } as any
 
-    expect(() => styleToHtml({
-      type: 'table-cell',
-      borderStyle: 'dotted solid dashed',
-    }, html, mockEditor)).toThrow(
-      '[wangeditor] Unsupported table border-style token "dotted solid dashed" in class mode. policy=strict',
+    expect(() =>
+      styleToHtml(
+        {
+          type: 'table-cell',
+          borderStyle: 'dotted solid dashed',
+        },
+        html,
+        mockEditor
+      )
+    ).toThrow(
+      '[wangeditor] Unsupported table border-style token "dotted solid dashed" in class mode. policy=strict'
     )
   })
 })

--- a/packages/table-module/src/assets/index.less
+++ b/packages/table-module/src/assets/index.less
@@ -161,10 +161,12 @@
 
 .w-e-modal {
   .w-e-table-property-modal {
+    min-width: 310px;
+
     .babel-container {
       display: flex;
-      align-items: flex-start;
-      margin-bottom: 14px;
+      align-items: center;
+      margin-bottom: 10px;
 
       > span {
         margin-bottom: 0;
@@ -172,11 +174,11 @@
     }
 
     .w-e-table-property-label {
-      flex: 0 0 72px;
+      flex: 0 0 82px;
       min-height: 32px;
-      padding-top: 6px;
       color: @toolbar-color;
       line-height: 20px;
+      white-space: nowrap;
     }
 
     .w-e-table-property-controls {
@@ -185,42 +187,39 @@
     }
 
     span.babel-container-width,
-    span.babel-container-border {
-      display: grid;
-      column-gap: 8px;
-
-      & > * {
-        min-height: 32px;
-        border: 1px solid var(--w-e-modal-button-border-color);
-        border-radius: 4px;
-      }
-
-      select {
-        width: 100%;
-        height: 32px;
-        padding: 4px 8px;
-        color: @toolbar-color;
-        background-color: @toolbar-bg-color;
-      }
+    span.babel-container-select,
+    span.babel-container-number {
+      display: block;
     }
 
     span.babel-container-width {
-      grid-template-columns: minmax(108px, 1fr);
+      width: 100%;
     }
 
-    span.babel-container-border {
-      grid-template-columns: minmax(108px, 1fr) 32px 86px;
+    span.babel-container-select select {
+      width: 100%;
+      height: 32px;
+      padding: 4px 8px;
+      color: @toolbar-color;
+      background-color: @toolbar-bg-color;
+      border: 1px solid @modal-button-border-color;
+      border-radius: 4px;
     }
 
     .w-e-table-property-number {
       position: relative;
       display: block;
+      width: 128px;
+      height: 32px;
+      border: 1px solid @modal-button-border-color;
+      border-radius: 4px;
 
       input[type='number'] {
         width: 100%;
         height: 30px;
         padding-right: 28px;
         border: 0;
+        background-color: transparent;
       }
     }
 
@@ -235,7 +234,7 @@
       transform: translateY(-50%);
     }
 
-    span.babel-container-background {
+    span.babel-container-color {
       display: flex;
       min-height: 32px;
     }
@@ -252,8 +251,19 @@
     .w-e-table-property-segment {
       display: inline-flex;
       overflow: hidden;
-      border: 1px solid var(--w-e-modal-button-border-color);
+      width: fit-content;
+      border: 1px solid @modal-button-border-color;
       border-radius: 4px;
+    }
+
+    .w-e-table-property-segment-fill {
+      display: grid;
+      width: 100%;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+
+      .w-e-table-property-segment-button {
+        min-width: 0;
+      }
     }
 
     .w-e-table-property-align-button,
@@ -264,17 +274,24 @@
       height: 32px;
       padding: 0;
       border: 0;
-      border-right: 1px solid var(--w-e-modal-button-border-color);
+      border-right: 1px solid @modal-button-border-color;
       border-radius: 0;
-      background-color: @toolbar-bg-color;
+      color: @toolbar-color;
+      background-color: @modal-button-bg-color;
+      transition: background-color .2s ease, color .2s ease;
 
       &:last-child {
         border-right: 0;
       }
 
+      &:hover {
+        background-color: @toolbar-active-bg-color;
+      }
+
       &.active {
         color: @toolbar-active-color;
         background-color: @toolbar-active-bg-color;
+        box-shadow: inset 0 -2px 0 @toolbar-active-color;
       }
 
       svg {
@@ -289,34 +306,98 @@
     }
 
     .w-e-table-property-segment-button {
-      min-width: 44px;
+      min-width: 48px;
       padding: 0 10px;
     }
 
     .color-group {
       position: relative;
-      width: 32px;
+      display: inline-flex;
+      align-items: center;
+      width: 100%;
+      max-width: 168px;
       height: 32px;
       margin-bottom: 0;
-      border: 1px solid var(--w-e-modal-button-border-color);
+      padding: 4px 22px 4px 6px;
+      border: 1px solid @modal-button-border-color;
       border-radius: 4px;
+      background-color: @modal-button-bg-color;
       cursor: pointer;
 
+      &::after {
+        position: absolute;
+        right: 8px;
+        top: 50%;
+        width: 0;
+        height: 0;
+        border-top: 4px solid @toolbar-disabled-color;
+        border-right: 4px solid transparent;
+        border-left: 4px solid transparent;
+        content: '';
+        transform: translateY(-50%);
+      }
+
+      &[data-mixed='true'] {
+        .color-group-block {
+          opacity: .28;
+        }
+
+        .color-group-label {
+          color: @toolbar-disabled-color;
+        }
+      }
+
+      &:hover {
+        background-color: @toolbar-active-bg-color;
+      }
+
       .w-e-drop-panel {
-        margin-top: 32px;
+        margin-top: 30px;
       }
     }
 
+    .color-group-wide {
+      width: 100%;
+    }
+
     .color-group-block {
-      display: block;
-      width: 80%;
-      height: 80%;
-      margin: 10%;
+      display: inline-flex;
+      flex: 0 0 18px;
+      width: 18px;
+      height: 18px;
+      min-height: 18px;
+      margin-right: 8px;
+      border: 1px solid @textarea-slight-border-color;
+      border-radius: 3px;
+      background-clip: padding-box;
 
       svg {
-        width: 20px;
-        height: 20px;
-        margin: 2px 1px;
+        width: 14px;
+        height: 14px;
+        margin: 1px;
+      }
+    }
+
+    .color-group-label {
+      overflow: hidden;
+      color: @toolbar-color;
+      line-height: 20px;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .button-container {
+      display: flex;
+      justify-content: flex-end;
+      margin-top: 2px;
+      margin-bottom: 0;
+      padding-top: 10px;
+      border-top: 1px solid @textarea-slight-border-color;
+
+      button {
+        min-width: 72px;
+        color: @toolbar-active-color;
+        background-color: @toolbar-active-bg-color;
       }
     }
   }

--- a/packages/table-module/src/assets/index.less
+++ b/packages/table-module/src/assets/index.less
@@ -186,24 +186,80 @@
       min-width: 0;
     }
 
-    span.babel-container-width,
     span.babel-container-select,
     span.babel-container-number {
       display: block;
     }
 
-    span.babel-container-width {
+    .w-e-table-property-select {
+      position: relative;
+      display: block;
       width: 100%;
     }
 
-    span.babel-container-select select {
+    .w-e-table-property-select-trigger {
+      position: relative;
       width: 100%;
       height: 32px;
-      padding: 4px 8px;
+      padding: 4px 24px 4px 8px;
       color: @toolbar-color;
       background-color: @toolbar-bg-color;
+      text-align: left;
       border: 1px solid @modal-button-border-color;
       border-radius: 4px;
+
+      &::after {
+        position: absolute;
+        top: 50%;
+        right: 8px;
+        width: 0;
+        height: 0;
+        border-top: 4px solid @toolbar-disabled-color;
+        border-right: 4px solid transparent;
+        border-left: 4px solid transparent;
+        content: '';
+        transform: translateY(-50%);
+      }
+    }
+
+    .w-e-table-property-select-value {
+      display: block;
+      overflow: hidden;
+      line-height: 20px;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .w-e-table-property-select-panel {
+      position: absolute;
+      z-index: 1;
+      top: 34px;
+      left: 0;
+      display: none;
+      width: 100%;
+      max-height: 184px;
+      overflow-y: auto;
+      padding: 4px;
+      border: 1px solid @modal-button-border-color;
+      border-radius: 4px;
+      background-color: @toolbar-bg-color;
+      box-shadow: 0 2px 8px #0000001f;
+    }
+
+    .w-e-table-property-select-option {
+      display: block;
+      width: 100%;
+      height: 28px;
+      padding: 4px 8px;
+      text-align: left;
+      border: 0;
+      border-radius: 3px;
+      background-color: transparent;
+
+      &:hover,
+      &.active {
+        background-color: @toolbar-active-bg-color;
+      }
     }
 
     .w-e-table-property-number {
@@ -240,10 +296,6 @@
     }
 
     span.babel-container-align {
-      display: flex;
-    }
-
-    span.babel-container-vertical-align {
       display: flex;
     }
 

--- a/packages/table-module/src/assets/index.less
+++ b/packages/table-module/src/assets/index.less
@@ -184,9 +184,9 @@
       min-width: 0;
     }
 
+    span.babel-container-width,
     span.babel-container-border {
       display: grid;
-      grid-template-columns: minmax(108px, 1fr) 32px 86px;
       column-gap: 8px;
 
       & > * {
@@ -202,6 +202,14 @@
         color: @toolbar-color;
         background-color: @toolbar-bg-color;
       }
+    }
+
+    span.babel-container-width {
+      grid-template-columns: minmax(108px, 1fr);
+    }
+
+    span.babel-container-border {
+      grid-template-columns: minmax(108px, 1fr) 32px 86px;
     }
 
     .w-e-table-property-number {
@@ -236,18 +244,23 @@
       display: flex;
     }
 
-    .w-e-table-property-align {
+    span.babel-container-vertical-align {
+      display: flex;
+    }
+
+    .w-e-table-property-align,
+    .w-e-table-property-segment {
       display: inline-flex;
       overflow: hidden;
       border: 1px solid var(--w-e-modal-button-border-color);
       border-radius: 4px;
     }
 
-    .w-e-table-property-align-button {
+    .w-e-table-property-align-button,
+    .w-e-table-property-segment-button {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      width: 36px;
       height: 32px;
       padding: 0;
       border: 0;
@@ -269,6 +282,15 @@
         height: 15px;
         fill: currentColor;
       }
+    }
+
+    .w-e-table-property-align-button {
+      width: 36px;
+    }
+
+    .w-e-table-property-segment-button {
+      min-width: 44px;
+      padding: 0 10px;
     }
 
     .color-group {

--- a/packages/table-module/src/locale/en.ts
+++ b/packages/table-module/src/locale/en.ts
@@ -11,6 +11,11 @@ export default {
       borderWidth: 'Width',
       bgColor: 'Back color',
       align: 'Text Align',
+      verticalAlign: 'Vertical Align',
+      width: 'Width mode',
+      widthAuto: 'Auto',
+      widthFull: 'Full',
+      mixed: 'Mixed',
       ok: 'OK',
     },
     color: {
@@ -27,6 +32,11 @@ export default {
       ridge: 'Ridge',
       inset: 'Inset',
       outset: 'Outset',
+    },
+    verticalAlign: {
+      top: 'Top',
+      middle: 'Middle',
+      bottom: 'Bottom',
     },
     deleteCol: 'Delete column',
     deleteRow: 'Delete row',

--- a/packages/table-module/src/locale/en.ts
+++ b/packages/table-module/src/locale/en.ts
@@ -10,6 +10,7 @@ export default {
       borderColor: 'Border color',
       borderStyle: 'Border style',
       borderWidth: 'Border width',
+      borderWidthDefault: 'Default 1',
       bgColor: 'Back color',
       align: 'Text Align',
       verticalAlign: 'Vertical Align',

--- a/packages/table-module/src/locale/en.ts
+++ b/packages/table-module/src/locale/en.ts
@@ -8,7 +8,8 @@ export default {
     modal: {
       border: 'Border',
       borderColor: 'Border color',
-      borderWidth: 'Width',
+      borderStyle: 'Border style',
+      borderWidth: 'Border width',
       bgColor: 'Back color',
       align: 'Text Align',
       verticalAlign: 'Vertical Align',

--- a/packages/table-module/src/locale/zh-CN.ts
+++ b/packages/table-module/src/locale/zh-CN.ts
@@ -8,7 +8,8 @@ export default {
     modal: {
       border: '边框',
       borderColor: '边框颜色',
-      borderWidth: '宽度',
+      borderStyle: '边框样式',
+      borderWidth: '边框粗细',
       bgColor: '背景色',
       align: '对齐方式',
       verticalAlign: '垂直对齐',

--- a/packages/table-module/src/locale/zh-CN.ts
+++ b/packages/table-module/src/locale/zh-CN.ts
@@ -10,6 +10,7 @@ export default {
       borderColor: '边框颜色',
       borderStyle: '边框样式',
       borderWidth: '边框粗细',
+      borderWidthDefault: '默认 1',
       bgColor: '背景色',
       align: '对齐方式',
       verticalAlign: '垂直对齐',

--- a/packages/table-module/src/locale/zh-CN.ts
+++ b/packages/table-module/src/locale/zh-CN.ts
@@ -11,6 +11,11 @@ export default {
       borderWidth: '宽度',
       bgColor: '背景色',
       align: '对齐方式',
+      verticalAlign: '垂直对齐',
+      width: '宽度模式',
+      widthAuto: '自适应',
+      widthFull: '撑满',
+      mixed: '混合',
       ok: '确定',
     },
     color: {
@@ -27,6 +32,11 @@ export default {
       ridge: '菱形边框',
       inset: '凹边框',
       outset: '凸边框',
+    },
+    verticalAlign: {
+      top: '上',
+      middle: '中',
+      bottom: '下',
     },
     deleteCol: '删除列',
     deleteRow: '删除行',

--- a/packages/table-module/src/module/custom-types.ts
+++ b/packages/table-module/src/module/custom-types.ts
@@ -13,6 +13,7 @@ export type TableCellProperty = {
   borderStyle?: string // 边框样式
   borderColor?: string // 边框颜色
   textAlign?: string // 对齐方式
+  verticalAlign?: string // 垂直对齐方式
 }
 
 export type TableCellElement = {

--- a/packages/table-module/src/module/menu/CellProperty.ts
+++ b/packages/table-module/src/module/menu/CellProperty.ts
@@ -3,7 +3,7 @@ import { Editor } from 'slate'
 
 import { CELL_PROPERTY_SVG } from '../../constants/svg'
 import { isOfType } from '../../utils'
-import TableProperty from './TableProperty'
+import TableProperty, { FieldName } from './TableProperty'
 
 class CellProperty extends TableProperty implements IButtonMenu {
   readonly title = t('tableModule.cellProperty')
@@ -17,6 +17,15 @@ class CellProperty extends TableProperty implements IButtonMenu {
   readonly modalWidth = 360
 
   readonly menu = 'cell'
+
+  readonly propertyFields: FieldName[] = [
+    'borderStyle',
+    'borderColor',
+    'borderWidth',
+    'backgroundColor',
+    'textAlign',
+    'verticalAlign',
+  ]
 
   getModalContentNode(editor: IDomEditor) {
     const [node] = Editor.nodes(editor, {

--- a/packages/table-module/src/module/menu/DeleteRow.ts
+++ b/packages/table-module/src/module/menu/DeleteRow.ts
@@ -3,12 +3,8 @@
  * @author wangfupeng
  */
 
-import {
-  DomEditor, IButtonMenu, IDomEditor, t,
-} from '@wangeditor-next/core'
-import {
-  Editor, Path, Range, Transforms,
-} from 'slate'
+import { DomEditor, IButtonMenu, IDomEditor, t } from '@wangeditor-next/core'
+import { Editor, Path, Range, Transforms } from 'slate'
 
 import { DEL_ROW_SVG } from '../../constants/svg'
 import { filledMatrix } from '../../utils'
@@ -34,8 +30,12 @@ class DeleteRow implements IButtonMenu {
   isDisabled(editor: IDomEditor): boolean {
     const { selection } = editor
 
-    if (selection == null) { return true }
-    if (!Range.isCollapsed(selection)) { return true }
+    if (selection == null) {
+      return true
+    }
+    if (!Range.isCollapsed(selection)) {
+      return true
+    }
 
     const rowNode = DomEditor.getSelectedNodeByType(editor, 'table-row')
 
@@ -47,7 +47,9 @@ class DeleteRow implements IButtonMenu {
   }
 
   exec(editor: IDomEditor, _value: string | boolean) {
-    if (this.isDisabled(editor)) { return }
+    if (this.isDisabled(editor)) {
+      return
+    }
 
     const [rowEntry] = Editor.nodes(editor, {
       match: n => DomEditor.checkNodeType(n, 'table-row'),
@@ -103,7 +105,12 @@ class DeleteRow implements IButtonMenu {
           const originalRowIndex = trIndex - (ttb - 1)
 
           // 安全检查：确保目标行和列都存在
-          if (originalRowIndex < 0 || originalRowIndex >= matrix.length || !matrix[originalRowIndex] || !matrix[originalRowIndex][y]) {
+          if (
+            originalRowIndex < 0 ||
+            originalRowIndex >= matrix.length ||
+            !matrix[originalRowIndex] ||
+            !matrix[originalRowIndex][y]
+          ) {
             continue
           }
 
@@ -119,7 +126,7 @@ class DeleteRow implements IButtonMenu {
                 rowSpan: Math.max(rowSpan - 1, 1),
                 colSpan,
               },
-              { at: path },
+              { at: path }
             )
           } else if (ttb === 1 && rtl === 1) {
             // 只处理合并单元格的真正位置（左上角）：ttb=1且rtl=1
@@ -137,13 +144,30 @@ class DeleteRow implements IButtonMenu {
               }
 
               // 继承原单元格的其他属性
-              if (typedOriginalCell.isHeader) { newCell.isHeader = typedOriginalCell.isHeader }
-              if (typedOriginalCell.width) { newCell.width = typedOriginalCell.width }
-              if (typedOriginalCell.backgroundColor) { newCell.backgroundColor = typedOriginalCell.backgroundColor }
-              if (typedOriginalCell.borderWidth) { newCell.borderWidth = typedOriginalCell.borderWidth }
-              if (typedOriginalCell.borderStyle) { newCell.borderStyle = typedOriginalCell.borderStyle }
-              if (typedOriginalCell.borderColor) { newCell.borderColor = typedOriginalCell.borderColor }
-              if (typedOriginalCell.textAlign) { newCell.textAlign = typedOriginalCell.textAlign }
+              if (typedOriginalCell.isHeader) {
+                newCell.isHeader = typedOriginalCell.isHeader
+              }
+              if (typedOriginalCell.width) {
+                newCell.width = typedOriginalCell.width
+              }
+              if (typedOriginalCell.backgroundColor) {
+                newCell.backgroundColor = typedOriginalCell.backgroundColor
+              }
+              if (typedOriginalCell.borderWidth) {
+                newCell.borderWidth = typedOriginalCell.borderWidth
+              }
+              if (typedOriginalCell.borderStyle) {
+                newCell.borderStyle = typedOriginalCell.borderStyle
+              }
+              if (typedOriginalCell.borderColor) {
+                newCell.borderColor = typedOriginalCell.borderColor
+              }
+              if (typedOriginalCell.textAlign) {
+                newCell.textAlign = typedOriginalCell.textAlign
+              }
+              if (typedOriginalCell.verticalAlign) {
+                newCell.verticalAlign = typedOriginalCell.verticalAlign
+              }
 
               // 记录需要插入的单元格信息
               cellsToInsert.push({
@@ -158,7 +182,7 @@ class DeleteRow implements IButtonMenu {
                   rowSpan: Math.max(rowSpan - 1, 1),
                   colSpan,
                 },
-                { at: path },
+                { at: path }
               )
             }
           } else {
@@ -170,7 +194,7 @@ class DeleteRow implements IButtonMenu {
                 rowSpan: Math.max(rowSpan - 1, 1),
                 colSpan,
               },
-              { at: path },
+              { at: path }
             )
           }
         }

--- a/packages/table-module/src/module/menu/TableProperty.ts
+++ b/packages/table-module/src/module/menu/TableProperty.ts
@@ -66,6 +66,10 @@ function createElem<K extends keyof HTMLElementTagNameMap>(
   return elem
 }
 
+function getKeyboardEvent(event: Event): KeyboardEvent | null {
+  return event instanceof KeyboardEvent ? event : null
+}
+
 function isActionKey(event: KeyboardEvent) {
   return event.key === 'Enter' || event.key === ' '
 }
@@ -572,20 +576,21 @@ class TableProperty implements IButtonMenu {
     })
 
     $content.find('.w-e-table-property-select-trigger').on('keydown', e => {
+      const keyboardEvent = getKeyboardEvent(e)
       const trigger = e.currentTarget
 
-      if (trigger == null) {
+      if (keyboardEvent == null || !(trigger instanceof HTMLElement)) {
         return
       }
 
-      if (isActionKey(e)) {
-        e.preventDefault()
+      if (isActionKey(keyboardEvent)) {
+        keyboardEvent.preventDefault()
         trigger.click()
         return
       }
 
-      if (e.key === 'Escape') {
-        e.preventDefault()
+      if (keyboardEvent.key === 'Escape') {
+        keyboardEvent.preventDefault()
         closeSelectPanels()
       }
     })
@@ -609,20 +614,21 @@ class TableProperty implements IButtonMenu {
     })
 
     $content.find('.w-e-table-property-select-option').on('keydown', e => {
+      const keyboardEvent = getKeyboardEvent(e)
       const option = e.currentTarget
 
-      if (option == null) {
+      if (keyboardEvent == null || !(option instanceof HTMLElement)) {
         return
       }
 
-      if (isActionKey(e)) {
-        e.preventDefault()
+      if (isActionKey(keyboardEvent)) {
+        keyboardEvent.preventDefault()
         option.click()
         return
       }
 
-      if (e.key === 'Escape') {
-        e.preventDefault()
+      if (keyboardEvent.key === 'Escape') {
+        keyboardEvent.preventDefault()
         closeSelectPanels()
       }
     })
@@ -694,11 +700,13 @@ class TableProperty implements IButtonMenu {
       })
 
       $elem.on('keydown', e => {
-        if (!isActionKey(e)) {
+        const keyboardEvent = getKeyboardEvent(e)
+
+        if (keyboardEvent == null || !isActionKey(keyboardEvent)) {
           return
         }
 
-        e.preventDefault()
+        keyboardEvent.preventDefault()
         openColorPanel()
       })
     })

--- a/packages/table-module/src/module/menu/TableProperty.ts
+++ b/packages/table-module/src/module/menu/TableProperty.ts
@@ -19,7 +19,6 @@ import $ from '../../utils/dom'
 import { EDITOR_TO_SELECTION } from '../weak-maps'
 
 export type FieldName =
-  | 'width'
   | 'borderStyle'
   | 'borderColor'
   | 'borderWidth'
@@ -28,6 +27,8 @@ export type FieldName =
   | 'verticalAlign'
 
 type FieldValue = string | undefined
+type SelectOption = { value: string; label: string }
+type SegmentOption = SelectOption & { svg?: string }
 
 class TableProperty implements IButtonMenu {
   readonly title = t('tableModule.tableProperty')
@@ -43,7 +44,6 @@ class TableProperty implements IButtonMenu {
   readonly menu: string = 'table'
 
   readonly propertyFields: FieldName[] = [
-    'width',
     'borderStyle',
     'borderColor',
     'borderWidth',
@@ -62,23 +62,130 @@ class TableProperty implements IButtonMenu {
     { value: 'outset', label: t('tableModule.borderStyle.outset') },
   ]
 
-  readonly textAlignOptions = [
+  readonly textAlignOptions: SegmentOption[] = [
     { value: 'left', label: t('justify.left'), svg: JUSTIFY_LEFT_SVG },
     { value: 'center', label: t('justify.center'), svg: JUSTIFY_CENTER_SVG },
     { value: 'right', label: t('justify.right'), svg: JUSTIFY_RIGHT_SVG },
     { value: 'justify', label: t('justify.justify'), svg: JUSTIFY_JUSTIFY_SVG },
   ]
 
-  readonly widthOptions = [
-    { value: 'auto', label: t('tableModule.modal.widthAuto') },
-    { value: '100%', label: t('tableModule.modal.widthFull') },
-  ]
-
-  readonly verticalAlignOptions = [
+  readonly verticalAlignOptions: SegmentOption[] = [
     { value: 'top', label: t('tableModule.verticalAlign.top') },
     { value: 'middle', label: t('tableModule.verticalAlign.middle') },
     { value: 'bottom', label: t('tableModule.verticalAlign.bottom') },
   ]
+
+  private renderRow(label: string, controlsHtml: string, tag = 'div') {
+    return `
+      <${tag} class="babel-container w-e-table-property-row">
+        <span class="w-e-table-property-label">${label}</span>
+        ${controlsHtml}
+      </${tag}>
+    `
+  }
+
+  private renderSelect(field: FieldName, label: string, options: SelectOption[]) {
+    return this.renderRow(
+      label,
+      `
+        <span class="babel-container-select w-e-table-property-controls">
+          <input name="${field}" type="hidden">
+          <span class="w-e-table-property-select" data-select-field="${field}">
+            <button
+              type="button"
+              class="w-e-table-property-select-trigger"
+              aria-label="${label}"
+              aria-haspopup="listbox"
+              aria-expanded="false"
+            >
+              <span class="w-e-table-property-select-value"></span>
+            </button>
+            <span class="w-e-table-property-select-panel" role="listbox">
+              ${options
+                .map(
+                  item => `
+                <button
+                  type="button"
+                  class="w-e-table-property-select-option"
+                  data-select-option-field="${field}"
+                  data-value="${item.value}"
+                  role="option"
+                >${item.label}</button>
+              `
+                )
+                .join('')}
+            </span>
+          </span>
+        </span>
+      `,
+      'div'
+    )
+  }
+
+  private renderNumber(field: FieldName, label: string) {
+    return this.renderRow(
+      label,
+      `
+        <span class="babel-container-number w-e-table-property-controls">
+          <span class="w-e-table-property-number">
+            <input name="${field}" type="number" min="0" placeholder="${t(
+        'tableModule.modal.borderWidthDefault'
+      )}" aria-label="${label}">
+            <span class="w-e-table-property-unit">px</span>
+          </span>
+        </span>
+      `,
+      'label'
+    )
+  }
+
+  private renderColor(field: FieldName, mark: string, label: string, emptyLabel: string) {
+    return this.renderRow(
+      label,
+      `
+        <span class="babel-container-color w-e-table-property-controls">
+          <span
+            class="color-group color-group-wide"
+            data-mark="${mark}"
+            title="${label}"
+            role="button"
+            tabindex="0"
+          >
+            <span class="color-group-block"></span>
+            <span class="color-group-label">${emptyLabel}</span>
+            <input name="${field}" type="hidden">
+          </span>
+        </span>
+      `
+    )
+  }
+
+  private renderSegment(field: FieldName, label: string, options: SegmentOption[], fill = false) {
+    return this.renderRow(
+      label,
+      `
+        <span class="babel-container-align w-e-table-property-controls">
+          <input name="${field}" type="hidden">
+          <span class="w-e-table-property-segment${fill ? ' w-e-table-property-segment-fill' : ''}">
+            ${options
+              .map(
+                item => `
+              <button
+                type="button"
+                class="w-e-table-property-segment-button${item.svg ? ' w-e-table-property-align-button' : ''}"
+                data-field="${field}"
+                data-value="${item.value}"
+                title="${item.label}"
+                aria-label="${item.label}"
+              >${item.svg || item.label}</button>
+            `
+              )
+              .join('')}
+          </span>
+        </span>
+      `
+    )
+  }
 
   getValue(_editor: IDomEditor): string | boolean {
     return ''
@@ -120,141 +227,32 @@ class TableProperty implements IButtonMenu {
     const hasField = (field: FieldName) => fields.includes(field)
     const isCellMenu = this.menu === 'cell'
     const $content = $(`<div class="w-e-table-property-modal">
-      ${
-        hasField('width')
-          ? `
-        <div class="babel-container w-e-table-property-row">
-          <span class="w-e-table-property-label">${t('tableModule.modal.width')}</span>
-          <span class="babel-container-width w-e-table-property-controls">
-            <input name="width" type="hidden">
-            <span class="w-e-table-property-segment w-e-table-property-segment-fill">
-              ${this.widthOptions
-                .map(
-                  item => `
-                <button
-                  type="button"
-                  class="w-e-table-property-segment-button"
-                  data-field="width"
-                  data-value="${item.value}"
-                  title="${item.label}"
-                  aria-label="${item.label}"
-                >${item.label}</button>
-              `
-                )
-                .join('')}
-            </span>
-          </span>
-        </div>
-      `
-          : ''
-      }
-      <label class="babel-container w-e-table-property-row">
-        <span class="w-e-table-property-label">${t('tableModule.modal.borderStyle')}</span>
-        <span class="babel-container-select w-e-table-property-controls">
-          <select name="borderStyle" aria-label="${t('tableModule.modal.borderStyle')}">
-            ${this.borderStyle
-              .map(item => `<option value="${item.value}">${item.label}</option>`)
-              .join('')}
-          </select>
-        </span>
-      </label>
-      <div class="babel-container w-e-table-property-row">
-        <span class="w-e-table-property-label">${t('tableModule.modal.borderColor')}</span>
-        <span class="babel-container-color w-e-table-property-controls">
-          <span
-            class="color-group color-group-wide"
-            data-mark="color"
-            title="${t('tableModule.modal.borderColor')}"
-            role="button"
-            tabindex="0"
-          >
-            <span class="color-group-block"></span>
-            <span class="color-group-label">${t('tableModule.color.default')}</span>
-            <input name="borderColor" type="hidden">
-          </span>
-        </span>
-      </div>
-      <label class="babel-container w-e-table-property-row">
-        <span class="w-e-table-property-label">${t('tableModule.modal.borderWidth')}</span>
-        <span class="babel-container-number w-e-table-property-controls">
-          <span class="w-e-table-property-number">
-            <input name="borderWidth" type="number" min="0" placeholder="${t(
-              'tableModule.modal.borderWidth'
-            )}" aria-label="${t('tableModule.modal.borderWidth')}">
-            <span class="w-e-table-property-unit">px</span>
-          </span>
-        </span>
-      </label>
-      <div class="babel-container w-e-table-property-row">
-        <span class="w-e-table-property-label">${t('tableModule.modal.bgColor')}</span>
-        <span class="babel-container-color w-e-table-property-controls">
-          <span
-            class="color-group color-group-wide"
-            data-mark="bgColor"
-            title="${t('tableModule.modal.bgColor')}"
-            role="button"
-            tabindex="0"
-          >
-            <span class="color-group-block"></span>
-            <span class="color-group-label">${t('tableModule.color.clear')}</span>
-            <input name="backgroundColor" type="hidden">
-          </span>
-        </span>
-      </div>
+      ${this.renderSelect('borderStyle', t('tableModule.modal.borderStyle'), this.borderStyle)}
+      ${this.renderColor(
+        'borderColor',
+        'color',
+        t('tableModule.modal.borderColor'),
+        t('tableModule.color.default')
+      )}
+      ${this.renderNumber('borderWidth', t('tableModule.modal.borderWidth'))}
+      ${this.renderColor(
+        'backgroundColor',
+        'bgColor',
+        t('tableModule.modal.bgColor'),
+        t('tableModule.color.clear')
+      )}
       ${
         hasField('textAlign')
-          ? `
-        <div class="babel-container w-e-table-property-row">
-          <span class="w-e-table-property-label">${t('tableModule.modal.align')}</span>
-          <span class="babel-container-align w-e-table-property-controls">
-            <input name="textAlign" type="hidden">
-            <span class="w-e-table-property-align">
-              ${this.textAlignOptions
-                .map(
-                  item => `
-                <button
-                  type="button"
-                  class="w-e-table-property-align-button"
-                  data-field="textAlign"
-                  data-value="${item.value}"
-                  title="${item.label}"
-                  aria-label="${item.label}"
-                >${item.svg}</button>
-              `
-                )
-                .join('')}
-            </span>
-          </span>
-        </div>
-      `
+          ? this.renderSegment('textAlign', t('tableModule.modal.align'), this.textAlignOptions)
           : ''
       }
       ${
         hasField('verticalAlign')
-          ? `
-        <div class="babel-container w-e-table-property-row">
-          <span class="w-e-table-property-label">${t('tableModule.modal.verticalAlign')}</span>
-          <span class="babel-container-vertical-align w-e-table-property-controls">
-            <input name="verticalAlign" type="hidden">
-            <span class="w-e-table-property-segment">
-              ${this.verticalAlignOptions
-                .map(
-                  item => `
-                <button
-                  type="button"
-                  class="w-e-table-property-segment-button"
-                  data-field="verticalAlign"
-                  data-value="${item.value}"
-                  title="${item.label}"
-                  aria-label="${item.label}"
-                >${item.label}</button>
-              `
-                )
-                .join('')}
-            </span>
-          </span>
-        </div>
-      `
+          ? this.renderSegment(
+              'verticalAlign',
+              t('tableModule.modal.verticalAlign'),
+              this.verticalAlignOptions
+            )
           : ''
       }
       <div class="button-container">
@@ -263,6 +261,23 @@ class TableProperty implements IButtonMenu {
     </div>`)
 
     const changedFields = new Set<FieldName>()
+
+    const closeSelectPanels = () => {
+      $content.find('.w-e-table-property-select-panel').hide()
+      $content.find('.w-e-table-property-select-trigger').attr('aria-expanded', 'false')
+    }
+
+    $content.on('mousedown', e => {
+      const target = e.target
+
+      if (!(target instanceof Element)) {
+        return
+      }
+      if (target.closest('.w-e-table-property-select')) {
+        return
+      }
+      closeSelectPanels()
+    })
 
     const markChanged = (field: string | undefined) => {
       if (field == null) {
@@ -309,10 +324,18 @@ class TableProperty implements IButtonMenu {
       return isMixed ? undefined : commonValue
     }
 
+    const getDisplayFieldValue = (field: FieldName, value: FieldValue): FieldValue => {
+      if (field === 'borderStyle' && !value) {
+        return 'none'
+      }
+      return value
+    }
+
     // 初始化所有表单的值
     $content.find('[name]').each(elem => {
       const name = $(elem).attr('name') as FieldName
       const value = getCommonFieldValue(name)
+      const displayValue = getDisplayFieldValue(name, value)
 
       if (value == null) {
         $(elem).val('')
@@ -330,10 +353,10 @@ class TableProperty implements IButtonMenu {
         return
       }
 
-      $(elem).val(value)
+      $(elem).val(displayValue)
     })
 
-    $content.find('select,input[name="borderWidth"]').on('change', e => {
+    $content.find('input[name="borderWidth"]').on('change', e => {
       const target = e.currentTarget
 
       if (target == null) {
@@ -341,6 +364,80 @@ class TableProperty implements IButtonMenu {
       }
       markChanged($(target).attr('name'))
       $(target).attr('data-mixed', 'false')
+    })
+
+    const updateSelectControl = (field: FieldName, value: FieldValue) => {
+      const $select = $content.find(`[data-select-field="${field}"]`)
+      const $input = $content.find(`[name="${field}"]`)
+      const displayValue = getDisplayFieldValue(field, value)
+      const isMixed = value == null
+
+      $input.val(displayValue || '')
+      $input.attr('data-mixed', isMixed ? 'true' : 'false')
+      $select.attr('data-mixed', isMixed ? 'true' : 'false')
+
+      const selectedOption = this.borderStyle.find(item => item.value === displayValue)
+      const label = isMixed ? t('tableModule.modal.mixed') : selectedOption?.label || ''
+
+      $select.find('.w-e-table-property-select-value').text(label)
+      $select.find('.w-e-table-property-select-option').each(option => {
+        const $option = $(option)
+        const isActive = !isMixed && $option.attr('data-value') === displayValue
+
+        if (isActive) {
+          $option.addClass('active')
+          $option.attr('aria-selected', 'true')
+        } else {
+          $option.removeClass('active')
+          $option.attr('aria-selected', 'false')
+        }
+      })
+    }
+
+    updateSelectControl('borderStyle', getCommonFieldValue('borderStyle'))
+
+    $content.find('.w-e-table-property-select-trigger').on('click', e => {
+      e.preventDefault()
+      e.stopPropagation()
+
+      const trigger = e.currentTarget
+
+      if (trigger == null) {
+        return
+      }
+      const $trigger = $(trigger)
+      const $select = $trigger.parents('.w-e-table-property-select')
+      const $panel = $select.find('.w-e-table-property-select-panel')
+      const isOpen = $trigger.attr('aria-expanded') === 'true'
+
+      $content.find('.color-group .w-e-drop-panel').hide()
+      closeSelectPanels()
+
+      if (!isOpen) {
+        $panel.show()
+        $trigger.attr('aria-expanded', 'true')
+      }
+    })
+
+    $content.find('.w-e-table-property-select-option').on('click', e => {
+      e.preventDefault()
+      e.stopPropagation()
+
+      const option = e.currentTarget
+
+      if (option == null) {
+        return
+      }
+      const $option = $(option)
+      const field = $option.attr('data-select-option-field') as FieldName
+      const value = $option.attr('data-value') || ''
+      const $input = $content.find(`[name="${field}"]`)
+
+      $input.val(value)
+      $input.attr('data-mixed', 'false')
+      markChanged(field)
+      updateSelectControl(field, value)
+      closeSelectPanels()
     })
 
     const updateButtonGroup = (field: FieldName, value: FieldValue) => {
@@ -358,7 +455,6 @@ class TableProperty implements IButtonMenu {
       })
     }
 
-    updateButtonGroup('width', getCommonFieldValue('width') || '')
     updateButtonGroup('textAlign', getCommonFieldValue('textAlign') || '')
     updateButtonGroup('verticalAlign', getCommonFieldValue('verticalAlign') || '')
 
@@ -399,6 +495,26 @@ class TableProperty implements IButtonMenu {
       $elem.attr('data-empty', color ? 'false' : 'true')
     }
 
+    const applyBorderVisibilityDefaults = () => {
+      const $borderStyle = $content.find('[name="borderStyle"]')
+      const $borderWidth = $content.find('[name="borderWidth"]')
+      const currentBorderStyle = $borderStyle.val()
+      const currentBorderWidth = $borderWidth.val()
+
+      if (!currentBorderStyle || currentBorderStyle === 'none') {
+        $borderStyle.val('solid')
+        $borderStyle.attr('data-mixed', 'false')
+        updateSelectControl('borderStyle', 'solid')
+        markChanged('borderStyle')
+      }
+
+      if (!currentBorderWidth || currentBorderWidth === '0') {
+        $borderWidth.val('1')
+        $borderWidth.attr('data-mixed', 'false')
+        markChanged('borderWidth')
+      }
+    }
+
     $content.find('.color-group').each(elem => {
       const selectedColor = $('[type="hidden"]', elem).val() || ''
 
@@ -407,6 +523,7 @@ class TableProperty implements IButtonMenu {
       const $elem = $(elem)
 
       $elem.on('click', () => {
+        closeSelectPanels()
         $content.find('.color-group .w-e-drop-panel').hide()
         let $panel = $elem.data('panel')
 
@@ -423,6 +540,9 @@ class TableProperty implements IButtonMenu {
               $('[type="hidden"]', elem).attr('data-mixed', 'false')
               $(elem).attr('data-mixed', 'false')
               markChanged(fieldName)
+              if (fieldName === 'borderColor' && color) {
+                applyBorderVisibilityDefaults()
+              }
               setSelectedColor(elem, color)
               $panel.hide()
             },

--- a/packages/table-module/src/module/menu/TableProperty.ts
+++ b/packages/table-module/src/module/menu/TableProperty.ts
@@ -29,6 +29,46 @@ export type FieldName =
 type FieldValue = string | undefined
 type SelectOption = { value: string; label: string }
 type SegmentOption = SelectOption & { svg?: string }
+type AttrValue = string | boolean | undefined
+type FieldControl = {
+  field: FieldName
+  root: HTMLElement
+  input: HTMLInputElement
+  setValue: (value: FieldValue, mixed?: boolean) => void
+  getValue: () => string
+  setMixed: (mixed: boolean) => void
+}
+
+function createElem<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  attrs: Record<string, AttrValue> = {},
+  children: Array<Node | string> = []
+): HTMLElementTagNameMap[K] {
+  const elem = document.createElement(tag)
+
+  Object.entries(attrs).forEach(([key, value]) => {
+    if (value == null || value === false) {
+      return
+    }
+
+    if (value === true) {
+      elem.setAttribute(key, '')
+      return
+    }
+
+    elem.setAttribute(key, value)
+  })
+
+  children.forEach(child => {
+    elem.append(typeof child === 'string' ? document.createTextNode(child) : child)
+  })
+
+  return elem
+}
+
+function isActionKey(event: KeyboardEvent) {
+  return event.key === 'Enter' || event.key === ' '
+}
 
 class TableProperty implements IButtonMenu {
   readonly title = t('tableModule.tableProperty')
@@ -75,116 +115,235 @@ class TableProperty implements IButtonMenu {
     { value: 'bottom', label: t('tableModule.verticalAlign.bottom') },
   ]
 
-  private renderRow(label: string, controlsHtml: string, tag = 'div') {
-    return `
-      <${tag} class="babel-container w-e-table-property-row">
-        <span class="w-e-table-property-label">${label}</span>
-        ${controlsHtml}
-      </${tag}>
-    `
+  private renderRow(label: string, controls: HTMLElement, tag: 'div' | 'label' = 'div') {
+    const row = createElem(tag, { class: 'babel-container w-e-table-property-row' })
+    const labelElem = createElem('span', { class: 'w-e-table-property-label' }, [label])
+
+    row.append(labelElem, controls)
+    return row
   }
 
-  private renderSelect(field: FieldName, label: string, options: SelectOption[]) {
-    return this.renderRow(
-      label,
-      `
-        <span class="babel-container-select w-e-table-property-controls">
-          <input name="${field}" type="hidden">
-          <span class="w-e-table-property-select" data-select-field="${field}">
-            <button
-              type="button"
-              class="w-e-table-property-select-trigger"
-              aria-label="${label}"
-              aria-haspopup="listbox"
-              aria-expanded="false"
-            >
-              <span class="w-e-table-property-select-value"></span>
-            </button>
-            <span class="w-e-table-property-select-panel" role="listbox">
-              ${options
-                .map(
-                  item => `
-                <button
-                  type="button"
-                  class="w-e-table-property-select-option"
-                  data-select-option-field="${field}"
-                  data-value="${item.value}"
-                  role="option"
-                >${item.label}</button>
-              `
-                )
-                .join('')}
-            </span>
-          </span>
-        </span>
-      `,
-      'div'
-    )
+  private createFieldControl(
+    field: FieldName,
+    root: HTMLElement,
+    input: HTMLInputElement
+  ): FieldControl {
+    return {
+      field,
+      root,
+      input,
+      setValue: (value, mixed = false) => {
+        input.value = value || ''
+        input.setAttribute('data-mixed', mixed ? 'true' : 'false')
+      },
+      getValue: () => input.value,
+      setMixed: mixed => {
+        input.setAttribute('data-mixed', mixed ? 'true' : 'false')
+      },
+    }
   }
 
-  private renderNumber(field: FieldName, label: string) {
-    return this.renderRow(
-      label,
-      `
-        <span class="babel-container-number w-e-table-property-controls">
-          <span class="w-e-table-property-number">
-            <input name="${field}" type="number" min="0" placeholder="${t(
-        'tableModule.modal.borderWidthDefault'
-      )}" aria-label="${label}">
-            <span class="w-e-table-property-unit">px</span>
-          </span>
-        </span>
-      `,
-      'label'
+  private renderSelect(field: FieldName, label: string, options: SelectOption[]): FieldControl {
+    const input = createElem('input', { name: field, type: 'hidden' })
+    const valueElem = createElem('span', { class: 'w-e-table-property-select-value' })
+    const trigger = createElem(
+      'button',
+      {
+        type: 'button',
+        class: 'w-e-table-property-select-trigger',
+        'aria-label': label,
+        'aria-haspopup': 'listbox',
+        'aria-expanded': 'false',
+      },
+      [valueElem]
     )
+    const panel = createElem('span', { class: 'w-e-table-property-select-panel', role: 'listbox' })
+
+    options.forEach(item => {
+      panel.append(
+        createElem(
+          'button',
+          {
+            type: 'button',
+            class: 'w-e-table-property-select-option',
+            'data-select-option-field': field,
+            'data-value': item.value,
+            role: 'option',
+          },
+          [item.label]
+        )
+      )
+    })
+
+    const select = createElem(
+      'span',
+      { class: 'w-e-table-property-select', 'data-select-field': field },
+      [trigger, panel]
+    )
+    const controls = createElem(
+      'span',
+      { class: 'babel-container-select w-e-table-property-controls' },
+      [input, select]
+    )
+    const root = this.renderRow(label, controls)
+    const control = this.createFieldControl(field, root, input)
+
+    control.setValue = (value, mixed = false) => {
+      const displayValue = field === 'borderStyle' && !value ? 'none' : value
+      const selectedOption = options.find(item => item.value === displayValue)
+      const displayLabel = mixed ? t('tableModule.modal.mixed') : selectedOption?.label || ''
+
+      input.value = displayValue || ''
+      input.setAttribute('data-mixed', mixed ? 'true' : 'false')
+      select.setAttribute('data-mixed', mixed ? 'true' : 'false')
+      valueElem.textContent = displayLabel
+
+      Array.from(panel.querySelectorAll<HTMLElement>('.w-e-table-property-select-option')).forEach(
+        option => {
+          const isActive = !mixed && option.dataset.value === displayValue
+
+          option.classList.toggle('active', isActive)
+          option.setAttribute('aria-selected', isActive ? 'true' : 'false')
+        }
+      )
+    }
+    control.setMixed = mixed => {
+      input.setAttribute('data-mixed', mixed ? 'true' : 'false')
+      select.setAttribute('data-mixed', mixed ? 'true' : 'false')
+      if (mixed) {
+        valueElem.textContent = t('tableModule.modal.mixed')
+      }
+    }
+
+    return control
   }
 
-  private renderColor(field: FieldName, mark: string, label: string, emptyLabel: string) {
-    return this.renderRow(
-      label,
-      `
-        <span class="babel-container-color w-e-table-property-controls">
-          <span
-            class="color-group color-group-wide"
-            data-mark="${mark}"
-            title="${label}"
-            role="button"
-            tabindex="0"
-          >
-            <span class="color-group-block"></span>
-            <span class="color-group-label">${emptyLabel}</span>
-            <input name="${field}" type="hidden">
-          </span>
-        </span>
-      `
+  private renderNumber(field: FieldName, label: string): FieldControl {
+    const input = createElem('input', {
+      name: field,
+      type: 'number',
+      min: '0',
+      placeholder: t('tableModule.modal.borderWidthDefault'),
+      'aria-label': label,
+    })
+    const number = createElem('span', { class: 'w-e-table-property-number' }, [
+      input,
+      createElem('span', { class: 'w-e-table-property-unit' }, ['px']),
+    ])
+    const controls = createElem(
+      'span',
+      { class: 'babel-container-number w-e-table-property-controls' },
+      [number]
     )
+
+    return this.createFieldControl(field, this.renderRow(label, controls, 'label'), input)
   }
 
-  private renderSegment(field: FieldName, label: string, options: SegmentOption[], fill = false) {
-    return this.renderRow(
-      label,
-      `
-        <span class="babel-container-align w-e-table-property-controls">
-          <input name="${field}" type="hidden">
-          <span class="w-e-table-property-segment${fill ? ' w-e-table-property-segment-fill' : ''}">
-            ${options
-              .map(
-                item => `
-              <button
-                type="button"
-                class="w-e-table-property-segment-button${item.svg ? ' w-e-table-property-align-button' : ''}"
-                data-field="${field}"
-                data-value="${item.value}"
-                title="${item.label}"
-                aria-label="${item.label}"
-              >${item.svg || item.label}</button>
-            `
-              )
-              .join('')}
-          </span>
-        </span>
-      `
+  private renderColor(
+    field: FieldName,
+    mark: string,
+    label: string,
+    emptyLabel: string
+  ): FieldControl {
+    const block = createElem('span', { class: 'color-group-block' })
+    const labelElem = createElem('span', { class: 'color-group-label' }, [emptyLabel])
+    const input = createElem('input', { name: field, type: 'hidden' })
+    const colorGroup = createElem(
+      'span',
+      {
+        class: 'color-group color-group-wide',
+        'data-mark': mark,
+        title: label,
+        role: 'button',
+        tabindex: '0',
+      },
+      [block, labelElem, input]
     )
+    const controls = createElem(
+      'span',
+      { class: 'babel-container-color w-e-table-property-controls' },
+      [colorGroup]
+    )
+    const root = this.renderRow(label, controls)
+    const control = this.createFieldControl(field, root, input)
+
+    control.setValue = (value, mixed = false) => {
+      input.value = value || ''
+      input.setAttribute('data-mixed', mixed ? 'true' : 'false')
+      colorGroup.setAttribute('data-mixed', mixed ? 'true' : 'false')
+
+      if (value) {
+        block.style.backgroundColor = value
+        block.innerHTML = ''
+        labelElem.textContent = value
+        colorGroup.classList.remove('is-empty')
+      } else {
+        block.style.backgroundColor = ''
+        block.innerHTML = CLEAN_SVG
+        labelElem.textContent = emptyLabel
+        colorGroup.classList.add('is-empty')
+      }
+      colorGroup.setAttribute('data-empty', value ? 'false' : 'true')
+    }
+    control.setMixed = mixed => {
+      input.setAttribute('data-mixed', mixed ? 'true' : 'false')
+      colorGroup.setAttribute('data-mixed', mixed ? 'true' : 'false')
+    }
+
+    return control
+  }
+
+  private renderSegment(
+    field: FieldName,
+    label: string,
+    options: SegmentOption[],
+    fill = false
+  ): FieldControl {
+    const input = createElem('input', { name: field, type: 'hidden' })
+    const segment = createElem('span', {
+      class: `w-e-table-property-segment${fill ? ' w-e-table-property-segment-fill' : ''}`,
+    })
+
+    options.forEach(item => {
+      const button = createElem('button', {
+        type: 'button',
+        class: `w-e-table-property-segment-button${
+          item.svg ? ' w-e-table-property-align-button' : ''
+        }`,
+        'data-field': field,
+        'data-value': item.value,
+        title: item.label,
+        'aria-label': item.label,
+      })
+
+      if (item.svg) {
+        button.innerHTML = item.svg
+      } else {
+        button.textContent = item.label
+      }
+      segment.append(button)
+    })
+
+    const controls = createElem(
+      'span',
+      { class: 'babel-container-align w-e-table-property-controls' },
+      [input, segment]
+    )
+    const root = this.renderRow(label, controls)
+    const control = this.createFieldControl(field, root, input)
+
+    control.setValue = (value, mixed = false) => {
+      input.value = value || ''
+      input.setAttribute('data-mixed', mixed ? 'true' : 'false')
+      Array.from(segment.querySelectorAll<HTMLElement>('[data-field]')).forEach(button => {
+        const isActive = !mixed && button.dataset.value === value
+
+        button.classList.toggle('active', isActive)
+        button.setAttribute('aria-pressed', isActive ? 'true' : 'false')
+      })
+    }
+
+    return control
   }
 
   getValue(_editor: IDomEditor): string | boolean {
@@ -226,39 +385,61 @@ class TableProperty implements IButtonMenu {
     const fields = this.propertyFields
     const hasField = (field: FieldName) => fields.includes(field)
     const isCellMenu = this.menu === 'cell'
-    const $content = $(`<div class="w-e-table-property-modal">
-      ${this.renderSelect('borderStyle', t('tableModule.modal.borderStyle'), this.borderStyle)}
-      ${this.renderColor(
+    const fieldControls = [
+      this.renderSelect('borderStyle', t('tableModule.modal.borderStyle'), this.borderStyle),
+      this.renderColor(
         'borderColor',
         'color',
         t('tableModule.modal.borderColor'),
         t('tableModule.color.default')
-      )}
-      ${this.renderNumber('borderWidth', t('tableModule.modal.borderWidth'))}
-      ${this.renderColor(
+      ),
+      this.renderNumber('borderWidth', t('tableModule.modal.borderWidth')),
+      this.renderColor(
         'backgroundColor',
         'bgColor',
         t('tableModule.modal.bgColor'),
         t('tableModule.color.clear')
-      )}
-      ${
-        hasField('textAlign')
-          ? this.renderSegment('textAlign', t('tableModule.modal.align'), this.textAlignOptions)
-          : ''
-      }
-      ${
-        hasField('verticalAlign')
-          ? this.renderSegment(
-              'verticalAlign',
-              t('tableModule.modal.verticalAlign'),
-              this.verticalAlignOptions
-            )
-          : ''
-      }
-      <div class="button-container">
-        <button type="button">${t('tableModule.modal.ok')}</button>
-      </div>
-    </div>`)
+      ),
+    ]
+    const content = createElem(
+      'div',
+      { class: 'w-e-table-property-modal' },
+      fieldControls.map(control => control.root)
+    )
+
+    if (hasField('textAlign')) {
+      const control = this.renderSegment(
+        'textAlign',
+        t('tableModule.modal.align'),
+        this.textAlignOptions
+      )
+
+      fieldControls.push(control)
+      content.append(control.root)
+    }
+    if (hasField('verticalAlign')) {
+      const control = this.renderSegment(
+        'verticalAlign',
+        t('tableModule.modal.verticalAlign'),
+        this.verticalAlignOptions
+      )
+
+      fieldControls.push(control)
+      content.append(control.root)
+    }
+
+    content.append(
+      createElem('div', { class: 'button-container' }, [
+        createElem('button', { type: 'button' }, [t('tableModule.modal.ok')]),
+      ])
+    )
+
+    const $content = $(content)
+    const controls = new Map<FieldName, FieldControl>()
+
+    fieldControls.forEach(control => {
+      controls.set(control.field, control)
+    })
 
     const changedFields = new Set<FieldName>()
 
@@ -288,6 +469,12 @@ class TableProperty implements IButtonMenu {
       }
       changedFields.add(field as FieldName)
     }
+
+    const setFieldValue = (field: FieldName, value: FieldValue, mixed = false) => {
+      controls.get(field)?.setValue(value, mixed)
+    }
+
+    const getFieldValue = (field: FieldName) => controls.get(field)?.getValue() || ''
 
     const getCommonFieldValue = (field: FieldName): FieldValue => {
       if (!isCellMenu) {
@@ -332,69 +519,34 @@ class TableProperty implements IButtonMenu {
     }
 
     // 初始化所有表单的值
-    $content.find('[name]').each(elem => {
-      const name = $(elem).attr('name') as FieldName
+    controls.forEach((control, name) => {
       const value = getCommonFieldValue(name)
       const displayValue = getDisplayFieldValue(name, value)
 
       if (value == null) {
-        $(elem).val('')
-        $(elem).attr('data-mixed', 'true')
-        if (elem instanceof HTMLInputElement && elem.type === 'hidden') {
-          const colorGroup = elem.closest('.color-group')
+        setFieldValue(name, '', true)
+        if (control.input.type === 'hidden') {
+          const colorGroup = control.input.closest('.color-group')
 
           if (colorGroup) {
             $(colorGroup).attr('data-mixed', 'true')
           }
         }
-        if (elem instanceof HTMLInputElement && elem.type !== 'hidden') {
-          elem.placeholder = t('tableModule.modal.mixed')
+        if (control.input.type !== 'hidden') {
+          control.input.placeholder = t('tableModule.modal.mixed')
         }
         return
       }
 
-      $(elem).val(displayValue)
+      setFieldValue(name, displayValue)
     })
 
-    $content.find('input[name="borderWidth"]').on('change', e => {
-      const target = e.currentTarget
+    controls.get('borderWidth')?.input.addEventListener('change', e => {
+      const target = e.currentTarget as HTMLInputElement
 
-      if (target == null) {
-        return
-      }
-      markChanged($(target).attr('name'))
-      $(target).attr('data-mixed', 'false')
+      markChanged(target.name)
+      target.setAttribute('data-mixed', 'false')
     })
-
-    const updateSelectControl = (field: FieldName, value: FieldValue) => {
-      const $select = $content.find(`[data-select-field="${field}"]`)
-      const $input = $content.find(`[name="${field}"]`)
-      const displayValue = getDisplayFieldValue(field, value)
-      const isMixed = value == null
-
-      $input.val(displayValue || '')
-      $input.attr('data-mixed', isMixed ? 'true' : 'false')
-      $select.attr('data-mixed', isMixed ? 'true' : 'false')
-
-      const selectedOption = this.borderStyle.find(item => item.value === displayValue)
-      const label = isMixed ? t('tableModule.modal.mixed') : selectedOption?.label || ''
-
-      $select.find('.w-e-table-property-select-value').text(label)
-      $select.find('.w-e-table-property-select-option').each(option => {
-        const $option = $(option)
-        const isActive = !isMixed && $option.attr('data-value') === displayValue
-
-        if (isActive) {
-          $option.addClass('active')
-          $option.attr('aria-selected', 'true')
-        } else {
-          $option.removeClass('active')
-          $option.attr('aria-selected', 'false')
-        }
-      })
-    }
-
-    updateSelectControl('borderStyle', getCommonFieldValue('borderStyle'))
 
     $content.find('.w-e-table-property-select-trigger').on('click', e => {
       e.preventDefault()
@@ -419,6 +571,25 @@ class TableProperty implements IButtonMenu {
       }
     })
 
+    $content.find('.w-e-table-property-select-trigger').on('keydown', e => {
+      const trigger = e.currentTarget
+
+      if (trigger == null) {
+        return
+      }
+
+      if (isActionKey(e)) {
+        e.preventDefault()
+        trigger.click()
+        return
+      }
+
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        closeSelectPanels()
+      }
+    })
+
     $content.find('.w-e-table-property-select-option').on('click', e => {
       e.preventDefault()
       e.stopPropagation()
@@ -431,32 +602,30 @@ class TableProperty implements IButtonMenu {
       const $option = $(option)
       const field = $option.attr('data-select-option-field') as FieldName
       const value = $option.attr('data-value') || ''
-      const $input = $content.find(`[name="${field}"]`)
 
-      $input.val(value)
-      $input.attr('data-mixed', 'false')
+      setFieldValue(field, value)
       markChanged(field)
-      updateSelectControl(field, value)
       closeSelectPanels()
     })
 
-    const updateButtonGroup = (field: FieldName, value: FieldValue) => {
-      $content.find(`[data-field="${field}"]`).each(button => {
-        const $buttonElem = $(button)
-        const isActive = $buttonElem.attr('data-value') === value
+    $content.find('.w-e-table-property-select-option').on('keydown', e => {
+      const option = e.currentTarget
 
-        if (isActive) {
-          $buttonElem.addClass('active')
-          $buttonElem.attr('aria-pressed', 'true')
-        } else {
-          $buttonElem.removeClass('active')
-          $buttonElem.attr('aria-pressed', 'false')
-        }
-      })
-    }
+      if (option == null) {
+        return
+      }
 
-    updateButtonGroup('textAlign', getCommonFieldValue('textAlign') || '')
-    updateButtonGroup('verticalAlign', getCommonFieldValue('verticalAlign') || '')
+      if (isActionKey(e)) {
+        e.preventDefault()
+        option.click()
+        return
+      }
+
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        closeSelectPanels()
+      }
+    })
 
     $content.find('[data-field]').on('click', e => {
       const button = e.currentTarget
@@ -469,103 +638,80 @@ class TableProperty implements IButtonMenu {
       const value = $buttonElem.attr('data-value') || ''
       const field = $buttonElem.attr('data-field') as FieldName
 
-      const $input = $content.find(`[name="${field}"]`)
-
-      $input.val(value)
-      $input.attr('data-mixed', 'false')
-      updateButtonGroup(field, value)
+      setFieldValue(field, value)
       markChanged(field)
     })
 
-    const setSelectedColor = (elem, color) => {
-      const $elem = $(elem)
-      const $label = $('.color-group-label', elem)
-
-      if (color) {
-        $('.color-group-block', elem).css('background-color', color).empty()
-        $label.text(color)
-        $elem.removeClass('is-empty')
-      } else {
-        $('.color-group-block', elem).css('background-color', '').html(CLEAN_SVG)
-        $label.text(
-          $elem.data('mark') === 'color' ? t('tableModule.color.default') : t('tableModule.color.clear')
-        )
-        $elem.addClass('is-empty')
-      }
-      $elem.attr('data-empty', color ? 'false' : 'true')
-    }
-
     const applyBorderVisibilityDefaults = () => {
-      const $borderStyle = $content.find('[name="borderStyle"]')
-      const $borderWidth = $content.find('[name="borderWidth"]')
-      const currentBorderStyle = $borderStyle.val()
-      const currentBorderWidth = $borderWidth.val()
+      const currentBorderStyle = getFieldValue('borderStyle')
+      const currentBorderWidth = getFieldValue('borderWidth')
 
       if (!currentBorderStyle || currentBorderStyle === 'none') {
-        $borderStyle.val('solid')
-        $borderStyle.attr('data-mixed', 'false')
-        updateSelectControl('borderStyle', 'solid')
+        setFieldValue('borderStyle', 'solid')
         markChanged('borderStyle')
       }
 
       if (!currentBorderWidth || currentBorderWidth === '0') {
-        $borderWidth.val('1')
-        $borderWidth.attr('data-mixed', 'false')
+        setFieldValue('borderWidth', '1')
         markChanged('borderWidth')
       }
     }
 
     $content.find('.color-group').each(elem => {
-      const selectedColor = $('[type="hidden"]', elem).val() || ''
-
-      setSelectedColor(elem, selectedColor)
-
       const $elem = $(elem)
 
-      $elem.on('click', () => {
+      const openColorPanel = () => {
         closeSelectPanels()
         $content.find('.color-group .w-e-drop-panel').hide()
         let $panel = $elem.data('panel')
+        const colorMark = $elem.data('mark')
+        const fieldName = colorMark === 'color' ? 'borderColor' : 'backgroundColor'
 
         if (!$panel) {
-          const colorMark = $elem.data('mark')
-
           $panel = this.getPanelContentElem(editor, {
             mark: colorMark,
-            selectedColor,
+            selectedColor: getFieldValue(fieldName),
             callback: color => {
-              const fieldName = colorMark === 'color' ? 'borderColor' : 'backgroundColor'
-
-              $('[type="hidden"]', elem).val(color || '')
-              $('[type="hidden"]', elem).attr('data-mixed', 'false')
+              setFieldValue(fieldName, color || '')
               $(elem).attr('data-mixed', 'false')
               markChanged(fieldName)
               if (fieldName === 'borderColor' && color) {
                 applyBorderVisibilityDefaults()
               }
-              setSelectedColor(elem, color)
               $panel.hide()
             },
           })
           $elem.append($panel)
           $elem.data('panel', $panel)
         } else {
+          this.updateColorPanelActive($panel, getFieldValue(fieldName))
           $panel.show()
         }
+      }
+
+      $elem.on('click', () => {
+        openColorPanel()
+      })
+
+      $elem.on('keydown', e => {
+        if (!isActionKey(e)) {
+          return
+        }
+
+        e.preventDefault()
+        openColorPanel()
       })
     })
 
     const $button = $content.find('.button-container button')
 
     $button.on('click', () => {
-      const props = Array.from($content.find('[name]')).reduce((obj, elem) => {
-        const field = $(elem).attr('name') as FieldName
-
+      const props = Array.from(controls).reduce((obj, [field, control]) => {
         if (!changedFields.has(field)) {
           return obj
         }
 
-        obj[field] = $(elem).val()
+        obj[field] = control.getValue()
         return obj
       }, {})
 
@@ -595,7 +741,8 @@ class TableProperty implements IButtonMenu {
   }
 
   getPanelContentElem(editor, { mark, selectedColor, callback }) {
-    const $colorPanel = $('<ul class="w-e-panel-content-color"></ul>')
+    const colorPanel = createElem('ul', { class: 'w-e-panel-content-color' })
+    const $colorPanel = $(colorPanel)
 
     $colorPanel.on('click', 'li', e => {
       const { target } = e
@@ -616,11 +763,11 @@ class TableProperty implements IButtonMenu {
     const { colors = [] } = colorConf
 
     colors.forEach(color => {
-      const $block = $(`<div class="color-block" data-value="${color}"></div>`)
+      const $block = $(createElem('div', { class: 'color-block', 'data-value': color }))
 
       $block.css('background-color', color)
 
-      const $li = $(`<li data-value="${color}"></li>`)
+      const $li = $(createElem('li', { 'data-value': color }))
 
       if (selectedColor === color) {
         $li.addClass('active')
@@ -638,19 +785,31 @@ class TableProperty implements IButtonMenu {
     if (mark === 'bgColor') {
       clearText = t('tableModule.color.clear')
     }
-    const $clearLi = $(`
-      <li data-value="" class="clear">
-        ${CLEAN_SVG}
-        ${clearText}
-      </li>
-    `)
+    const clearLi = createElem('li', { 'data-value': '', class: 'clear' })
+
+    clearLi.innerHTML = CLEAN_SVG
+    clearLi.append(document.createTextNode(clearText))
+    const $clearLi = $(clearLi)
 
     $colorPanel.prepend($clearLi)
 
-    const $panel = $('<div class="w-e-drop-panel"></div>')
+    const $panel = $(createElem('div', { class: 'w-e-drop-panel' }))
 
     $panel.append($colorPanel)
     return $panel
+  }
+
+  updateColorPanelActive($panel, selectedColor: string) {
+    $panel.find('li').each(li => {
+      const $li = $(li)
+      const isActive = $li.attr('data-value') === selectedColor
+
+      if (isActive) {
+        $li.addClass('active')
+      } else {
+        $li.removeClass('active')
+      }
+    })
   }
 }
 

--- a/packages/table-module/src/module/menu/TableProperty.ts
+++ b/packages/table-module/src/module/menu/TableProperty.ts
@@ -38,7 +38,7 @@ class TableProperty implements IButtonMenu {
 
   readonly showModal = true
 
-  readonly modalWidth = 360
+  readonly modalWidth: number = 340
 
   readonly menu: string = 'table'
 
@@ -123,31 +123,60 @@ class TableProperty implements IButtonMenu {
       ${
         hasField('width')
           ? `
-        <label class="babel-container w-e-table-property-row">
+        <div class="babel-container w-e-table-property-row">
           <span class="w-e-table-property-label">${t('tableModule.modal.width')}</span>
           <span class="babel-container-width w-e-table-property-controls">
-            <select name="width" aria-label="${t('tableModule.modal.width')}">
+            <input name="width" type="hidden">
+            <span class="w-e-table-property-segment w-e-table-property-segment-fill">
               ${this.widthOptions
-                .map(item => `<option value="${item.value}">${item.label}</option>`)
+                .map(
+                  item => `
+                <button
+                  type="button"
+                  class="w-e-table-property-segment-button"
+                  data-field="width"
+                  data-value="${item.value}"
+                  title="${item.label}"
+                  aria-label="${item.label}"
+                >${item.label}</button>
+              `
+                )
                 .join('')}
-            </select>
+            </span>
           </span>
-        </label>
+        </div>
       `
           : ''
       }
       <label class="babel-container w-e-table-property-row">
-        <span class="w-e-table-property-label">${t('tableModule.modal.border')}</span>
-        <span class="babel-container-border w-e-table-property-controls">
-          <select name="borderStyle" aria-label="${t('tableModule.modal.border')}">
+        <span class="w-e-table-property-label">${t('tableModule.modal.borderStyle')}</span>
+        <span class="babel-container-select w-e-table-property-controls">
+          <select name="borderStyle" aria-label="${t('tableModule.modal.borderStyle')}">
             ${this.borderStyle
               .map(item => `<option value="${item.value}">${item.label}</option>`)
               .join('')}
           </select>
-          <span class="color-group" data-mark="color" title="${t('tableModule.modal.borderColor')}">
+        </span>
+      </label>
+      <div class="babel-container w-e-table-property-row">
+        <span class="w-e-table-property-label">${t('tableModule.modal.borderColor')}</span>
+        <span class="babel-container-color w-e-table-property-controls">
+          <span
+            class="color-group color-group-wide"
+            data-mark="color"
+            title="${t('tableModule.modal.borderColor')}"
+            role="button"
+            tabindex="0"
+          >
             <span class="color-group-block"></span>
+            <span class="color-group-label">${t('tableModule.color.default')}</span>
             <input name="borderColor" type="hidden">
           </span>
+        </span>
+      </div>
+      <label class="babel-container w-e-table-property-row">
+        <span class="w-e-table-property-label">${t('tableModule.modal.borderWidth')}</span>
+        <span class="babel-container-number w-e-table-property-controls">
           <span class="w-e-table-property-number">
             <input name="borderWidth" type="number" min="0" placeholder="${t(
               'tableModule.modal.borderWidth'
@@ -158,9 +187,16 @@ class TableProperty implements IButtonMenu {
       </label>
       <div class="babel-container w-e-table-property-row">
         <span class="w-e-table-property-label">${t('tableModule.modal.bgColor')}</span>
-        <span class="babel-container-background w-e-table-property-controls">
-          <span class="color-group" data-mark="bgColor" title="${t('tableModule.modal.bgColor')}">
+        <span class="babel-container-color w-e-table-property-controls">
+          <span
+            class="color-group color-group-wide"
+            data-mark="bgColor"
+            title="${t('tableModule.modal.bgColor')}"
+            role="button"
+            tabindex="0"
+          >
             <span class="color-group-block"></span>
+            <span class="color-group-label">${t('tableModule.color.clear')}</span>
             <input name="backgroundColor" type="hidden">
           </span>
         </span>
@@ -240,13 +276,13 @@ class TableProperty implements IButtonMenu {
 
     const getCommonFieldValue = (field: FieldName): FieldValue => {
       if (!isCellMenu) {
-        return data[field]
+        return data[field] || ''
       }
 
       const selection = EDITOR_TO_SELECTION.get(editor)
 
       if (!selection?.length) {
-        return data[field]
+        return data[field] || ''
       }
 
       let commonValue: FieldValue
@@ -281,6 +317,13 @@ class TableProperty implements IButtonMenu {
       if (value == null) {
         $(elem).val('')
         $(elem).attr('data-mixed', 'true')
+        if (elem instanceof HTMLInputElement && elem.type === 'hidden') {
+          const colorGroup = elem.closest('.color-group')
+
+          if (colorGroup) {
+            $(colorGroup).attr('data-mixed', 'true')
+          }
+        }
         if (elem instanceof HTMLInputElement && elem.type !== 'hidden') {
           elem.placeholder = t('tableModule.modal.mixed')
         }
@@ -315,6 +358,7 @@ class TableProperty implements IButtonMenu {
       })
     }
 
+    updateButtonGroup('width', getCommonFieldValue('width') || '')
     updateButtonGroup('textAlign', getCommonFieldValue('textAlign') || '')
     updateButtonGroup('verticalAlign', getCommonFieldValue('verticalAlign') || '')
 
@@ -329,17 +373,30 @@ class TableProperty implements IButtonMenu {
       const value = $buttonElem.attr('data-value') || ''
       const field = $buttonElem.attr('data-field') as FieldName
 
-      $content.find(`[name="${field}"]`).val(value)
+      const $input = $content.find(`[name="${field}"]`)
+
+      $input.val(value)
+      $input.attr('data-mixed', 'false')
       updateButtonGroup(field, value)
       markChanged(field)
     })
 
     const setSelectedColor = (elem, color) => {
+      const $elem = $(elem)
+      const $label = $('.color-group-label', elem)
+
       if (color) {
         $('.color-group-block', elem).css('background-color', color).empty()
+        $label.text(color)
+        $elem.removeClass('is-empty')
       } else {
         $('.color-group-block', elem).css('background-color', '').html(CLEAN_SVG)
+        $label.text(
+          $elem.data('mark') === 'color' ? t('tableModule.color.default') : t('tableModule.color.clear')
+        )
+        $elem.addClass('is-empty')
       }
+      $elem.attr('data-empty', color ? 'false' : 'true')
     }
 
     $content.find('.color-group').each(elem => {
@@ -363,6 +420,8 @@ class TableProperty implements IButtonMenu {
               const fieldName = colorMark === 'color' ? 'borderColor' : 'backgroundColor'
 
               $('[type="hidden"]', elem).val(color || '')
+              $('[type="hidden"]', elem).attr('data-mixed', 'false')
+              $(elem).attr('data-mixed', 'false')
               markChanged(fieldName)
               setSelectedColor(elem, color)
               $panel.hide()

--- a/packages/table-module/src/module/menu/TableProperty.ts
+++ b/packages/table-module/src/module/menu/TableProperty.ts
@@ -3,7 +3,7 @@
  * @author hsuna
  */
 
-import { DomEditor, IButtonMenu, IDomEditor, t } from '@wangeditor-next/core'
+import { IButtonMenu, IDomEditor, t } from '@wangeditor-next/core'
 import { Editor, Transforms } from 'slate'
 
 import {
@@ -18,6 +18,17 @@ import { isOfType } from '../../utils'
 import $ from '../../utils/dom'
 import { EDITOR_TO_SELECTION } from '../weak-maps'
 
+export type FieldName =
+  | 'width'
+  | 'borderStyle'
+  | 'borderColor'
+  | 'borderWidth'
+  | 'backgroundColor'
+  | 'textAlign'
+  | 'verticalAlign'
+
+type FieldValue = string | undefined
+
 class TableProperty implements IButtonMenu {
   readonly title = t('tableModule.tableProperty')
 
@@ -30,6 +41,14 @@ class TableProperty implements IButtonMenu {
   readonly modalWidth = 360
 
   readonly menu: string = 'table'
+
+  readonly propertyFields: FieldName[] = [
+    'width',
+    'borderStyle',
+    'borderColor',
+    'borderWidth',
+    'backgroundColor',
+  ]
 
   readonly borderStyle = [
     { value: 'none', label: t('tableModule.borderStyle.none') },
@@ -50,6 +69,17 @@ class TableProperty implements IButtonMenu {
     { value: 'justify', label: t('justify.justify'), svg: JUSTIFY_JUSTIFY_SVG },
   ]
 
+  readonly widthOptions = [
+    { value: 'auto', label: t('tableModule.modal.widthAuto') },
+    { value: '100%', label: t('tableModule.modal.widthFull') },
+  ]
+
+  readonly verticalAlignOptions = [
+    { value: 'top', label: t('tableModule.verticalAlign.top') },
+    { value: 'middle', label: t('tableModule.verticalAlign.middle') },
+    { value: 'bottom', label: t('tableModule.verticalAlign.bottom') },
+  ]
+
   getValue(_editor: IDomEditor): string | boolean {
     return ''
   }
@@ -59,12 +89,7 @@ class TableProperty implements IButtonMenu {
   }
 
   isDisabled(editor: IDomEditor): boolean {
-    const tableNode = DomEditor.getSelectedNodeByType(editor, 'table')
-
-    if (tableNode == null) {
-      return true
-    }
-    return false
+    return this.getModalContentNode(editor) == null
   }
 
   exec(_editor: IDomEditor, _value: string | boolean) {
@@ -91,7 +116,26 @@ class TableProperty implements IButtonMenu {
     }
 
     const [data, path] = node
+    const fields = this.propertyFields
+    const hasField = (field: FieldName) => fields.includes(field)
+    const isCellMenu = this.menu === 'cell'
     const $content = $(`<div class="w-e-table-property-modal">
+      ${
+        hasField('width')
+          ? `
+        <label class="babel-container w-e-table-property-row">
+          <span class="w-e-table-property-label">${t('tableModule.modal.width')}</span>
+          <span class="babel-container-width w-e-table-property-controls">
+            <select name="width" aria-label="${t('tableModule.modal.width')}">
+              ${this.widthOptions
+                .map(item => `<option value="${item.value}">${item.label}</option>`)
+                .join('')}
+            </select>
+          </span>
+        </label>
+      `
+          : ''
+      }
       <label class="babel-container w-e-table-property-row">
         <span class="w-e-table-property-label">${t('tableModule.modal.border')}</span>
         <span class="babel-container-border w-e-table-property-controls">
@@ -121,39 +165,143 @@ class TableProperty implements IButtonMenu {
           </span>
         </span>
       </div>
-      <div class="babel-container w-e-table-property-row">
-        <span class="w-e-table-property-label">${t('tableModule.modal.align')}</span>
-        <span class="babel-container-align w-e-table-property-controls">
-          <input name="textAlign" type="hidden">
-          <span class="w-e-table-property-align">
-            ${this.textAlignOptions
-              .map(
-                item => `
-              <button
-                type="button"
-                class="w-e-table-property-align-button"
-                data-value="${item.value}"
-                title="${item.label}"
-                aria-label="${item.label}"
-              >${item.svg}</button>
-            `
-              )
-              .join('')}
+      ${
+        hasField('textAlign')
+          ? `
+        <div class="babel-container w-e-table-property-row">
+          <span class="w-e-table-property-label">${t('tableModule.modal.align')}</span>
+          <span class="babel-container-align w-e-table-property-controls">
+            <input name="textAlign" type="hidden">
+            <span class="w-e-table-property-align">
+              ${this.textAlignOptions
+                .map(
+                  item => `
+                <button
+                  type="button"
+                  class="w-e-table-property-align-button"
+                  data-field="textAlign"
+                  data-value="${item.value}"
+                  title="${item.label}"
+                  aria-label="${item.label}"
+                >${item.svg}</button>
+              `
+                )
+                .join('')}
+            </span>
           </span>
-        </span>
-      </div>
+        </div>
+      `
+          : ''
+      }
+      ${
+        hasField('verticalAlign')
+          ? `
+        <div class="babel-container w-e-table-property-row">
+          <span class="w-e-table-property-label">${t('tableModule.modal.verticalAlign')}</span>
+          <span class="babel-container-vertical-align w-e-table-property-controls">
+            <input name="verticalAlign" type="hidden">
+            <span class="w-e-table-property-segment">
+              ${this.verticalAlignOptions
+                .map(
+                  item => `
+                <button
+                  type="button"
+                  class="w-e-table-property-segment-button"
+                  data-field="verticalAlign"
+                  data-value="${item.value}"
+                  title="${item.label}"
+                  aria-label="${item.label}"
+                >${item.label}</button>
+              `
+                )
+                .join('')}
+            </span>
+          </span>
+        </div>
+      `
+          : ''
+      }
       <div class="button-container">
         <button type="button">${t('tableModule.modal.ok')}</button>
       </div>
     </div>`)
 
+    const changedFields = new Set<FieldName>()
+
+    const markChanged = (field: string | undefined) => {
+      if (field == null) {
+        return
+      }
+      if (!fields.includes(field as FieldName)) {
+        return
+      }
+      changedFields.add(field as FieldName)
+    }
+
+    const getCommonFieldValue = (field: FieldName): FieldValue => {
+      if (!isCellMenu) {
+        return data[field]
+      }
+
+      const selection = EDITOR_TO_SELECTION.get(editor)
+
+      if (!selection?.length) {
+        return data[field]
+      }
+
+      let commonValue: FieldValue
+      let hasValue = false
+      let isMixed = false
+
+      selection.forEach(row => {
+        row.forEach(cell => {
+          const [cellNode] = cell[0]
+          const value = cellNode[field] || ''
+
+          if (!hasValue) {
+            commonValue = value
+            hasValue = true
+            return
+          }
+
+          if (commonValue !== value) {
+            isMixed = true
+          }
+        })
+      })
+
+      return isMixed ? undefined : commonValue
+    }
+
     // 初始化所有表单的值
     $content.find('[name]').each(elem => {
-      $(elem).val(data[$(elem).attr('name')])
+      const name = $(elem).attr('name') as FieldName
+      const value = getCommonFieldValue(name)
+
+      if (value == null) {
+        $(elem).val('')
+        $(elem).attr('data-mixed', 'true')
+        if (elem instanceof HTMLInputElement && elem.type !== 'hidden') {
+          elem.placeholder = t('tableModule.modal.mixed')
+        }
+        return
+      }
+
+      $(elem).val(value)
     })
 
-    const updateTextAlignButton = value => {
-      $content.find('.w-e-table-property-align-button').each(button => {
+    $content.find('select,input[name="borderWidth"]').on('change', e => {
+      const target = e.currentTarget
+
+      if (target == null) {
+        return
+      }
+      markChanged($(target).attr('name'))
+      $(target).attr('data-mixed', 'false')
+    })
+
+    const updateButtonGroup = (field: FieldName, value: FieldValue) => {
+      $content.find(`[data-field="${field}"]`).each(button => {
         const $buttonElem = $(button)
         const isActive = $buttonElem.attr('data-value') === value
 
@@ -167,9 +315,10 @@ class TableProperty implements IButtonMenu {
       })
     }
 
-    updateTextAlignButton($content.find('[name="textAlign"]').val() || '')
+    updateButtonGroup('textAlign', getCommonFieldValue('textAlign') || '')
+    updateButtonGroup('verticalAlign', getCommonFieldValue('verticalAlign') || '')
 
-    $content.find('.w-e-table-property-align-button').on('click', e => {
+    $content.find('[data-field]').on('click', e => {
       const button = e.currentTarget
 
       if (button == null) {
@@ -178,9 +327,11 @@ class TableProperty implements IButtonMenu {
 
       const $buttonElem = $(button)
       const value = $buttonElem.attr('data-value') || ''
+      const field = $buttonElem.attr('data-field') as FieldName
 
-      $content.find('[name="textAlign"]').val(value)
-      updateTextAlignButton(value)
+      $content.find(`[name="${field}"]`).val(value)
+      updateButtonGroup(field, value)
+      markChanged(field)
     })
 
     const setSelectedColor = (elem, color) => {
@@ -203,11 +354,16 @@ class TableProperty implements IButtonMenu {
         let $panel = $elem.data('panel')
 
         if (!$panel) {
+          const colorMark = $elem.data('mark')
+
           $panel = this.getPanelContentElem(editor, {
-            mark: $elem.data('mark'),
+            mark: colorMark,
             selectedColor,
             callback: color => {
+              const fieldName = colorMark === 'color' ? 'borderColor' : 'backgroundColor'
+
               $('[type="hidden"]', elem).val(color || '')
+              markChanged(fieldName)
               setSelectedColor(elem, color)
               $panel.hide()
             },
@@ -224,9 +380,20 @@ class TableProperty implements IButtonMenu {
 
     $button.on('click', () => {
       const props = Array.from($content.find('[name]')).reduce((obj, elem) => {
-        obj[$(elem).attr('name')] = $(elem).val()
+        const field = $(elem).attr('name') as FieldName
+
+        if (!changedFields.has(field)) {
+          return obj
+        }
+
+        obj[field] = $(elem).val()
         return obj
       }, {})
+
+      if (Object.keys(props).length === 0) {
+        editor.focus()
+        return
+      }
 
       const selection = EDITOR_TO_SELECTION.get(editor)
 

--- a/packages/table-module/src/module/parse-style-html.ts
+++ b/packages/table-module/src/module/parse-style-html.ts
@@ -35,17 +35,29 @@ function convertPtToPx(cssValue: string): string {
   })
 }
 
-export function parseStyleHtml(elem: DOMElement, node: Descendant, _editor: IDomEditor): Descendant {
-  if (!['TABLE', 'TD', 'TH'].includes(elem.tagName)) { return node }
+export function parseStyleHtml(
+  elem: DOMElement,
+  node: Descendant,
+  _editor: IDomEditor
+): Descendant {
+  if (!['TABLE', 'TD', 'TH'].includes(elem.tagName)) {
+    return node
+  }
 
   const $elem = $(elem)
 
   const tableNode = node as TableCellElement
   let backgroundColor = getStyleValue($elem, 'background-color')
 
-  if (!backgroundColor) { backgroundColor = getStyleValue($elem, 'background') } // word 背景色
-  if (!backgroundColor) { backgroundColor = $elem.attr('bgcolor') || '' }
-  if (!backgroundColor) { backgroundColor = $elem.attr('data-w-e-background-color') || '' }
+  if (!backgroundColor) {
+    backgroundColor = getStyleValue($elem, 'background')
+  } // word 背景色
+  if (!backgroundColor) {
+    backgroundColor = $elem.attr('bgcolor') || ''
+  }
+  if (!backgroundColor) {
+    backgroundColor = $elem.attr('data-w-e-background-color') || ''
+  }
   if (backgroundColor) {
     tableNode.backgroundColor = backgroundColor
   }
@@ -64,12 +76,21 @@ export function parseStyleHtml(elem: DOMElement, node: Descendant, _editor: IDom
   for (let i = 0; i < classList.length; i += 1) {
     const className = classList[i]
 
-    if (!className.startsWith('w-e-table-border-style-')) { continue }
+    if (!className.startsWith('w-e-table-border-style-')) {
+      continue
+    }
     borderStyleFromClass = className.replace('w-e-table-border-style-', '')
     break
   }
 
-  const hasDataBorder = !!(dataBorderWidth || dataBorderLine || dataBorderColor || borderAttr || borderColorAttr || borderStyleFromClass)
+  const hasDataBorder = !!(
+    dataBorderWidth ||
+    dataBorderLine ||
+    dataBorderColor ||
+    borderAttr ||
+    borderColorAttr ||
+    borderStyleFromClass
+  )
 
   if (!border && elem.tagName === 'TD' && !hasDataBorder) {
     // https://github.com/wangeditor-next/wangEditor-next/blob/master/packages/table-module/src/assets/index.less#L20
@@ -80,20 +101,32 @@ export function parseStyleHtml(elem: DOMElement, node: Descendant, _editor: IDom
   let [borderWidth, borderStyle, borderColor] = border?.split(' ') || []
 
   borderWidth = getStyleValue($elem, 'border-width') || borderWidth // border 宽度
-  if (!borderWidth) { borderWidth = dataBorderWidth }
-  if (!borderWidth) { borderWidth = borderAttr }
+  if (!borderWidth) {
+    borderWidth = dataBorderWidth
+  }
+  if (!borderWidth) {
+    borderWidth = borderAttr
+  }
   if (borderWidth) {
     tableNode.borderWidth = convertPtToPx(borderWidth.trim())
   }
   borderStyle = getStyleValue($elem, 'border-style') || borderStyle // border 样式
-  if (!borderStyle) { borderStyle = dataBorderLine }
-  if (!borderStyle) { borderStyle = borderStyleFromClass }
+  if (!borderStyle) {
+    borderStyle = dataBorderLine
+  }
+  if (!borderStyle) {
+    borderStyle = borderStyleFromClass
+  }
   if (borderStyle) {
     tableNode.borderStyle = borderStyle === 'none' ? '' : borderStyle
   }
   borderColor = getStyleValue($elem, 'border-color') || borderColor // border 颜色
-  if (!borderColor) { borderColor = borderColorAttr }
-  if (!borderColor) { borderColor = dataBorderColor }
+  if (!borderColor) {
+    borderColor = borderColorAttr
+  }
+  if (!borderColor) {
+    borderColor = dataBorderColor
+  }
   if (borderColor) {
     tableNode.borderColor = borderColor
   }
@@ -101,10 +134,27 @@ export function parseStyleHtml(elem: DOMElement, node: Descendant, _editor: IDom
   let textAlign = getStyleValue($elem, 'text-align')
 
   textAlign = getStyleValue($elem, 'text-align') || textAlign // 文本 对齐
-  if (!textAlign) { textAlign = $elem.attr('align') || '' }
-  if (!textAlign) { textAlign = $elem.attr('data-w-e-text-align') || '' }
+  if (!textAlign) {
+    textAlign = $elem.attr('align') || ''
+  }
+  if (!textAlign) {
+    textAlign = $elem.attr('data-w-e-text-align') || ''
+  }
   if (textAlign) {
     tableNode.textAlign = textAlign
   }
+
+  let verticalAlign = getStyleValue($elem, 'vertical-align')
+
+  if (!verticalAlign) {
+    verticalAlign = $elem.attr('valign') || ''
+  }
+  if (!verticalAlign) {
+    verticalAlign = $elem.attr('data-w-e-vertical-align') || ''
+  }
+  if (verticalAlign) {
+    tableNode.verticalAlign = verticalAlign
+  }
+
   return node
 }

--- a/packages/table-module/src/module/render-style.ts
+++ b/packages/table-module/src/module/render-style.ts
@@ -11,15 +11,18 @@ import { TableCellElement, TableCellProperty } from './custom-types'
  * @returns vnode
  */
 export function renderStyle(node: Descendant, vnode: VNode): VNode {
-  if (!Element.isElement(node)) { return vnode }
+  if (!Element.isElement(node)) {
+    return vnode
+  }
 
-  const {
-    backgroundColor, borderWidth, borderStyle, borderColor, textAlign,
-  } = node as TableCellElement
+  const { backgroundColor, borderWidth, borderStyle, borderColor, textAlign, verticalAlign } =
+    node as TableCellElement
 
   const props: TableCellProperty = {}
 
-  if (backgroundColor) { props.backgroundColor = backgroundColor }
+  if (backgroundColor) {
+    props.backgroundColor = backgroundColor
+  }
   if (borderWidth) {
     const pureNumericRegex = /^\d+(\.\d+)?$/
 
@@ -30,9 +33,18 @@ export function renderStyle(node: Descendant, vnode: VNode): VNode {
       props.borderWidth = borderWidth
     }
   }
-  if (borderStyle) { props.borderStyle = borderStyle === 'none' ? '' : borderStyle }
-  if (borderColor) { props.borderColor = borderColor }
-  if (textAlign) { props.textAlign = textAlign }
+  if (borderStyle) {
+    props.borderStyle = borderStyle === 'none' ? '' : borderStyle
+  }
+  if (borderColor) {
+    props.borderColor = borderColor
+  }
+  if (textAlign) {
+    props.textAlign = textAlign
+  }
+  if (verticalAlign) {
+    props.verticalAlign = verticalAlign
+  }
 
   const styleVnode: VNode = vnode
 

--- a/packages/table-module/src/module/style-to-html.ts
+++ b/packages/table-module/src/module/style-to-html.ts
@@ -27,7 +27,9 @@ const REPORTED_UNSUPPORTED_BORDER_STYLE = new Set<string>()
 function getBorderStyleClass(borderStyle: string): string {
   const val = (borderStyle || '').trim().toLowerCase()
 
-  if (!val || val === 'none') { return '' }
+  if (!val || val === 'none') {
+    return ''
+  }
   return `w-e-table-border-style-${val}`
 }
 
@@ -37,12 +39,16 @@ function normalizeBorderStyle(borderStyle: string): string {
 
 function resolveBorderStyleAction(
   editor: IDomEditor | undefined,
-  borderStyle: string,
+  borderStyle: string
 ): 'skip' | 'class' | 'inline' | 'preserve-data' {
   const normalized = normalizeBorderStyle(borderStyle)
 
-  if (!normalized || normalized === 'none') { return 'skip' }
-  if (SUPPORTED_TABLE_BORDER_STYLE.has(normalized)) { return 'class' }
+  if (!normalized || normalized === 'none') {
+    return 'skip'
+  }
+  if (SUPPORTED_TABLE_BORDER_STYLE.has(normalized)) {
+    return 'class'
+  }
 
   const policy = getClassStylePolicy(editor)
   let fallback: 'preserve-data' | 'inline' | 'throw' = 'preserve-data'
@@ -80,13 +86,17 @@ function resolveBorderStyleAction(
 }
 
 export function styleToHtml(node, elemHtml, editor?: IDomEditor) {
-  if (node.type !== 'table' && node.type !== 'table-cell') { return elemHtml }
+  if (node.type !== 'table' && node.type !== 'table-cell') {
+    return elemHtml
+  }
 
-  const {
-    backgroundColor, borderWidth, borderStyle, borderColor, textAlign,
-  } = node
+  const { backgroundColor, borderWidth, borderStyle, borderColor, textAlign, verticalAlign } = node
 
-  if (!(backgroundColor || borderWidth || borderStyle || borderColor || textAlign)) { return elemHtml }
+  if (
+    !(backgroundColor || borderWidth || borderStyle || borderColor || textAlign || verticalAlign)
+  ) {
+    return elemHtml
+  }
 
   const $elem = $(elemHtml)
   const textStyleMode = getTextStyleMode(editor)
@@ -131,15 +141,33 @@ export function styleToHtml(node, elemHtml, editor?: IDomEditor) {
       $elem.attr('data-w-e-text-align', textAlign)
     }
 
+    if (verticalAlign) {
+      $elem.attr('valign', verticalAlign)
+      $elem.attr('data-w-e-vertical-align', verticalAlign)
+    }
+
     return getOuterHTML($elem)
   }
 
   // 设置样式
-  if (backgroundColor) { $elem.css('background-color', backgroundColor) }
-  if (borderWidth) { $elem.css('border-width', `${borderWidth}px`) }
-  if (borderStyle) { $elem.css('border-style', borderStyle === 'none' ? '' : borderStyle) }
-  if (borderColor) { $elem.css('border-color', borderColor) }
-  if (textAlign) { $elem.css('text-align', textAlign) }
+  if (backgroundColor) {
+    $elem.css('background-color', backgroundColor)
+  }
+  if (borderWidth) {
+    $elem.css('border-width', `${borderWidth}px`)
+  }
+  if (borderStyle) {
+    $elem.css('border-style', borderStyle === 'none' ? '' : borderStyle)
+  }
+  if (borderColor) {
+    $elem.css('border-color', borderColor)
+  }
+  if (textAlign) {
+    $elem.css('text-align', textAlign)
+  }
+  if (verticalAlign) {
+    $elem.css('vertical-align', verticalAlign)
+  }
 
   // 输出 html
   return getOuterHTML($elem)


### PR DESCRIPTION
## Summary
- Split table and cell property modal fields so table properties focus on width/border/background, while cell properties handle cell border/background/text alignment.
- Add vertical alignment support for table cells with render, parse, toHtml, and class-mode round-trip coverage.
- Apply only user-changed fields in batch cell selection so mixed/unchanged cell styles are not overwritten.

## Verification
- pnpm --filter @wangeditor-next/table-module test -- __tests__/menu/property-menu.test.ts __tests__/style-to-html.test.ts __tests__/parse-html.test.ts __tests__/render-style.test.ts
- pnpm --filter @wangeditor-next/table-module test
- pnpm --filter @wangeditor-next/table-module build
- pnpm eslint --quiet --no-error-on-unmatched-pattern packages/table-module/src/module/menu/TableProperty.ts packages/table-module/src/module/menu/CellProperty.ts packages/table-module/src/module/menu/DeleteRow.ts packages/table-module/src/module/parse-style-html.ts packages/table-module/src/module/render-style.ts packages/table-module/src/module/style-to-html.ts packages/table-module/__tests__/menu/property-menu.test.ts packages/table-module/__tests__/render-style.test.ts packages/table-module/__tests__/parse-html.test.ts packages/table-module/__tests__/style-to-html.test.ts
- pnpm --filter @wangeditor-next/core test -- __tests__/editor/plugins/with-content.test.ts __tests__/create/content-to-html.test.ts
- pnpm --filter @wangeditor-next/editor test -- __tests__/create.test.ts __tests__/core.test.ts
- pnpm build
- git diff --check

## Risk / rollback
- Patch-level UI behavior refinement for table-module property modals.
- Rollback: revert this commit to restore the previous property modal behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added table cell vertical alignment (top/middle/bottom) across parsing, rendering, and the property editor.

* **Improvements**
  * Redesign of the table property modal for clearer layout, sizing, alignment controls, and a refreshed color picker.
  * Refined border/width behavior, including better defaults and submitting only modified fields.
  * Improved mixed-value handling for multi-cell selection, plus expanded locale labels.

* **Tests**
  * Updated and added coverage for vertical alignment, mixed-state UI behavior, and HTML conversion/parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->