### PR TITLE
fix(table): convert Word table widths from pt to px

### DIFF
--- a/.changeset/gentle-word-tables.md
+++ b/.changeset/gentle-word-tables.md
@@ -1,0 +1,5 @@
+---
+"@wangeditor-next/table-module": patch
+---
+
+Fix Word table imports so `pt` column widths are converted to CSS pixels.

--- a/packages/table-module/__tests__/parse-html.test.ts
+++ b/packages/table-module/__tests__/parse-html.test.ts
@@ -352,6 +352,41 @@ describe('table - parse html', () => {
     })
   })
 
+  it('regression #905: table should parse Word pt column widths as CSS pixels', () => {
+    const html = [
+      '<table style="width:auto;table-layout: fixed;">',
+      '<tr>',
+      '<td width="593" style="width:29.65pt">研究中心</td>',
+      '<td width="4045" style="width:202.25pt">受试者编号</td>',
+      '<td width="362" style="width:18.1pt">例数</td>',
+      '</tr>',
+      '<tr>',
+      '<td width="593" style="width:29.65pt">01</td>',
+      '<td width="4045" style="width:202.25pt">S01001~S01009</td>',
+      '<td width="362" style="width:18.1pt">15</td>',
+      '</tr>',
+      '</table>',
+    ].join('')
+    const $table = $(html)
+    const stubEditor = {
+      isInline: () => false,
+    } as any
+    const rows = Array.from($table.find('tr')).map(row => {
+      const cells = Array.from(row.children).map(cell =>
+        parseCellHtmlConf.parseElemHtml(cell as HTMLTableCellElement, [], stubEditor),
+      )
+
+      return parseRowHtmlConf.parseElemHtml(row as HTMLTableRowElement, cells, stubEditor)
+    })
+    const table = parseTableHtmlConf.parseElemHtml($table[0], rows as any, stubEditor)
+
+    expect(table).toMatchObject({
+      type: 'table',
+      width: 'auto',
+      columnWidths: [40, 270, 24],
+    })
+  })
+
   it('table should parse caption text', () => {
     const html = [
       '<table style="width:100%;table-layout:fixed">',

--- a/packages/table-module/src/module/parse-elem-html.ts
+++ b/packages/table-module/src/module/parse-elem-html.ts
@@ -19,6 +19,21 @@ function parsePixelSize(value: string | null | undefined, fallback = 0): number 
   return parsedValue
 }
 
+function parseCssPixelSize(value: string | null | undefined, fallback = 0): number {
+  const rawValue = (value || '').trim().toLowerCase()
+  const parsedValue = parseFloat(rawValue)
+
+  if (Number.isNaN(parsedValue)) {
+    return fallback
+  }
+
+  if (rawValue.endsWith('pt')) {
+    return Math.round((parsedValue * 4) / 3)
+  }
+
+  return Math.round(parsedValue)
+}
+
 function getColgroupWidths(colgroupElements: HTMLCollection | null): number[] {
   if (!colgroupElements || colgroupElements.length === 0) { return [] }
 
@@ -26,10 +41,7 @@ function getColgroupWidths(colgroupElements: HTMLCollection | null): number[] {
 
   Array.from(colgroupElements).forEach((col: any) => {
     const span = parseInt(col.getAttribute('span') || '1', 10)
-    const width = parseInt(
-      col.getAttribute('width') || getStyleValue($(col), 'width') || '90',
-      10,
-    )
+    const width = parseCssPixelSize(col.getAttribute('width') || getStyleValue($(col), 'width'), 90)
 
     if (Number.isNaN(width)) { return }
 
@@ -171,7 +183,7 @@ function parseTableHtml(
 
     Array.from(tdList).forEach(td => {
       const colSpan = parseInt($(td).attr('colSpan') || '1', 10) // 获取 colSpan，默认为 1
-      const width = parseInt(getStyleValue($(td), 'width') || '90', 10) // 获取 width，默认为 90
+      const width = parseCssPixelSize(getStyleValue($(td), 'width'), 90) // 获取 width，默认为 90
 
       // 根据 colSpan 的值来填充 columnWidths 数组
       columnWidths.push(width)


### PR DESCRIPTION
## Summary

- convert imported Word table `pt` column widths to CSS pixel widths
- add regression coverage for issue #905 table import widths
- add a patch changeset for `@wangeditor-next/table-module`

## Verification

- `pnpm --filter @wangeditor-next/table-module test`
- `pnpm exec turbo build --filter=@wangeditor-next/table-module --filter=@wangeditor-next/editor --filter=@wangeditor-next/plugin-markdown`

Fixes #905


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Word table column width conversion when importing documents. Table column widths specified in pt units are now correctly converted to CSS pixel values for proper layout rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->