### PR TITLE
fix(editor-for-react): keep editor style on root

### DIFF
--- a/.changeset/tidy-react-editors.md
+++ b/.changeset/tidy-react-editors.md
@@ -1,0 +1,5 @@
+---
+"@wangeditor-next/editor-for-react": patch
+---
+
+Keep Editor style and className props on the actual editor root when using the built-in loading overlay.

--- a/packages/editor-for-react/__tests__/editor.test.tsx
+++ b/packages/editor-for-react/__tests__/editor.test.tsx
@@ -57,7 +57,6 @@ async function flushPromises() {
 }
 
 // 当前测试运行环境会把 tsx 编译到 jsx() 调用，补充全局 jsx 工厂即可执行组件渲染
-// eslint-disable-next-line no-underscore-dangle
 (globalThis as any).jsx = React.createElement
 
 describe('editor-for-react onChange behavior', () => {
@@ -217,6 +216,44 @@ describe('editor-for-react onChange behavior', () => {
 
     expect(createEditor).toHaveBeenCalledTimes(1)
     expect(container.querySelector('[data-w-e-loading-overlay="true"]')).toBeNull()
+
+    await act(async () => {
+      ReactDOM.unmountComponentAtNode(container)
+    })
+  })
+
+  it('keeps style and className on the editor selector when loading overlay is enabled', async () => {
+    const onChange = vi.fn()
+    const container = document.createElement('div')
+
+    document.body.appendChild(container)
+    await act(async () => {
+      ReactDOM.render(
+        React.createElement(Editor as any, {
+          value: '<p>123</p>',
+          onChange,
+          defaultConfig: {},
+          mode: 'default',
+          loading: true,
+          loadingText: 'Uploading...',
+          className: 'custom-editor',
+          style: { height: '360px', overflowY: 'hidden' },
+        }),
+        container,
+      )
+    })
+    await flushPromises()
+    await flushPromises()
+
+    const selector = createEditor.mock.calls[0][0].selector as HTMLDivElement
+
+    expect(createEditor).toHaveBeenCalledTimes(1)
+    expect(selector).toBe(container.querySelector('[data-w-e-react-editor-container="true"]'))
+    expect(selector.className).toBe('custom-editor')
+    expect(selector.style.height).toBe('360px')
+    expect(selector.style.overflowY).toBe('hidden')
+    expect(selector.style.position).toBe('relative')
+    expect(selector.querySelector('[data-w-e-loading-overlay="true"]')?.textContent).toBe('Uploading...')
 
     await act(async () => {
       ReactDOM.unmountComponentAtNode(container)

--- a/packages/editor-for-react/src/components/Editor.tsx
+++ b/packages/editor-for-react/src/components/Editor.tsx
@@ -10,6 +10,7 @@ import {
 import React, {
   useCallback, useEffect, useRef, useState,
 } from 'react'
+import ReactDOM from 'react-dom'
 
 interface IProps {
   defaultContent?: SlateDescendant[]
@@ -34,10 +35,16 @@ function EditorComponent(props: Partial<IProps>) {
     defaultContent = [], onCreated, defaultHtml = '', value = '', onChange, defaultConfig = {}, mode = 'default', style = {}, className,
     loading = false, loadingText = 'Loading...',
   } = props
-  const ref = useRef<HTMLDivElement>(null)
+  const ref = useRef<HTMLDivElement | null>(null)
+  const [editorRoot, setEditorRoot] = useState<HTMLDivElement | null>(null)
   const latestHtmlRef = useRef('')
   const isSyncingFromPropsRef = useRef(false)
   const [editor, setEditor] = useState<ICustomDomEditor | null>(null)
+
+  const setRootRef = useCallback((node: HTMLDivElement | null) => {
+    ref.current = node
+    setEditorRoot(node)
+  }, [])
 
   const handleCreated = useCallback((createdEditor: IDomEditor) => {
     // 组件属性 onCreated
@@ -61,7 +68,6 @@ function EditorComponent(props: Partial<IProps>) {
   useEffect(() => {
     if (editor == null) { return }
 
-    // eslint-disable-next-line no-underscore-dangle
     editor.__react_on_change = (e: IDomEditor) => {
       const latestHtml = e.getHtml()
       const prevHtml = latestHtmlRef.current
@@ -83,7 +89,6 @@ function EditorComponent(props: Partial<IProps>) {
       if (onChangeFromConfig) { onChangeFromConfig(e) }
     }
     return () => {
-      // eslint-disable-next-line no-underscore-dangle
       editor.__react_on_change = undefined
     }
   }, [editor, defaultConfig, onChange])
@@ -117,7 +122,6 @@ function EditorComponent(props: Partial<IProps>) {
       config: {
         ...defaultConfig,
         onCreated: handleCreated,
-        // eslint-disable-next-line no-underscore-dangle
         onChange: (e: IDomEditor) => newEditor?.__react_on_change?.(e),
         onDestroyed: handleDestroyed,
       },
@@ -141,12 +145,12 @@ function EditorComponent(props: Partial<IProps>) {
 
   return (
     <div
+      ref={setRootRef}
       style={{ ...style, position: style.position || 'relative' }}
       className={className}
       data-w-e-react-editor-container="true"
     >
-      <div style={{ minHeight: '1px' }} ref={ref}></div>
-      {loading && (
+      {loading && editorRoot && ReactDOM.createPortal((
       <div
         data-w-e-loading-overlay="true"
         style={{
@@ -164,7 +168,7 @@ function EditorComponent(props: Partial<IProps>) {
       >
         {loadingText}
       </div>
-      )}
+      ), editorRoot)}
     </div>
   )
 }

--- a/tests/e2e/framework-regression.spec.ts
+++ b/tests/e2e/framework-regression.spec.ts
@@ -307,6 +307,50 @@ async function setSelectedTableWidthMode(page: Page, width: '100%' | 'auto') {
 test.describe('Framework parity regression', () => {
   test.describe.configure({ timeout: process.env.CI ? 240_000 : 90_000 })
 
+  test('react-wrapper: regression #907 Editor style should apply to the actual editor root', async ({ page }) => {
+    const pageErrors: string[] = []
+
+    page.on('pageerror', err => {
+      pageErrors.push(err?.stack || err?.message || String(err))
+    })
+
+    await openTarget(page, targets.find(target => target.name === 'react-wrapper')!)
+
+    const snapshot = await page.evaluate(() => {
+      const host = document.querySelector('[data-testid="editor-textarea"] [data-w-e-textarea="true"]')
+      const textContainer = host?.querySelector('.w-e-text-container')
+      const scroll = host?.querySelector('.w-e-scroll')
+
+      if (!host || !textContainer || !scroll) {
+        throw new Error('react editor DOM not ready')
+      }
+
+      const read = (el: Element) => {
+        const computedStyle = getComputedStyle(el)
+        const rect = el.getBoundingClientRect()
+
+        return {
+          attrStyle: el.getAttribute('style') || '',
+          height: rect.height,
+          computedHeight: computedStyle.height,
+          overflowY: computedStyle.overflowY,
+        }
+      }
+
+      return {
+        host: read(host),
+        textContainer: read(textContainer),
+        scroll: read(scroll),
+      }
+    })
+
+    expect(snapshot.host.attrStyle).toContain('height: 360px')
+    expect(snapshot.host.attrStyle).toContain('overflow-y: hidden')
+    expect(snapshot.textContainer.height).toBeGreaterThan(300)
+    expect(snapshot.scroll.height).toBeGreaterThan(300)
+    expect(pageErrors).toEqual([])
+  })
+
   for (const target of targets) {
     test(`${target.name}: ime composition should not throw`, async ({ page }) => {
       const pageErrors: string[] = []


### PR DESCRIPTION
## Summary

- Restore React `Editor` style/className props to the actual editor root used by `createEditor`
- Render the built-in loading overlay through a portal so it no longer requires an extra wrapper node
- Add unit and Playwright regression coverage for issue #907

## Root Cause

Commit `6c98f0c` added a wrapper for the built-in loading overlay. That moved the public `style` and `className` props from the real editor selector node to the wrapper, while `createEditor({ selector })` still mounted the editor into an inner node. As a result, styles like `height` and `overflowY` no longer affected `.w-e-text-container` in the React demo.

## Verification

- `pnpm exec vitest run packages/editor-for-react/__tests__/editor.test.tsx packages/editor-for-react/__tests__/exports.test.ts --passWithNoTests`
- `pnpm exec eslint --no-error-on-unmatched-pattern packages/editor-for-react/src/components/Editor.tsx packages/editor-for-react/__tests__/editor.test.tsx tests/e2e/framework-regression.spec.ts`
- `pnpm turbo build --filter=@wangeditor-next/editor --filter=@wangeditor-next/editor-for-react --filter=@wangeditor-next/demo-react`
- `PLAYWRIGHT_SKIP_BUILD=1 pnpm exec playwright test --project=chromium tests/e2e/framework-regression.spec.ts -g "#907"`

Fixes #907


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where `style` and `className` props were not properly preserved on the editor root element when the built-in loading overlay is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->