### PR TITLE
fix(table): convert Word percent table widths

### DIFF
--- a/.changeset/smart-word-columns.md
+++ b/.changeset/smart-word-columns.md
@@ -1,0 +1,5 @@
+---
+"@wangeditor-next/table-module": patch
+---
+
+Fix Word table imports so percentage column widths are converted to usable pixel widths.

--- a/packages/table-module/__tests__/parse-html.test.ts
+++ b/packages/table-module/__tests__/parse-html.test.ts
@@ -387,6 +387,41 @@ describe('table - parse html', () => {
     })
   })
 
+  it('regression #909: table should parse Word percent column widths as CSS pixels', () => {
+    const html = [
+      '<table style="width:auto;table-layout: fixed;">',
+      '<tr>',
+      '<td width="auto" style="width:11.86%">研究中心</td>',
+      '<td width="auto" style="width:80.9%">受试者编号</td>',
+      '<td width="auto" style="width:7.24%">例数</td>',
+      '</tr>',
+      '<tr>',
+      '<td width="auto" style="width:11.86%">01</td>',
+      '<td width="auto" style="width:80.9%">S01001~S01009</td>',
+      '<td width="auto" style="width:7.24%">15</td>',
+      '</tr>',
+      '</table>',
+    ].join('')
+    const $table = $(html)
+    const stubEditor = {
+      isInline: () => false,
+    } as any
+    const rows = Array.from($table.find('tr')).map(row => {
+      const cells = Array.from(row.children).map(cell =>
+        parseCellHtmlConf.parseElemHtml(cell as HTMLTableCellElement, [], stubEditor),
+      )
+
+      return parseRowHtmlConf.parseElemHtml(row as HTMLTableRowElement, cells, stubEditor)
+    })
+    const table = parseTableHtmlConf.parseElemHtml($table[0], rows as any, stubEditor)
+
+    expect(table).toMatchObject({
+      type: 'table',
+      width: 'auto',
+      columnWidths: [71, 485, 43],
+    })
+  })
+
   it('table should parse caption text', () => {
     const html = [
       '<table style="width:100%;table-layout:fixed">',

--- a/packages/table-module/src/module/parse-elem-html.ts
+++ b/packages/table-module/src/module/parse-elem-html.ts
@@ -9,6 +9,8 @@ import { Descendant, Text } from 'slate'
 import $, { DOMElement, getStyleValue, getTagName } from '../utils/dom'
 import { TableCellElement, TableElement, TableRowElement } from './custom-types'
 
+const DEFAULT_PERCENT_TABLE_WIDTH = 600
+
 function parsePixelSize(value: string | null | undefined, fallback = 0): number {
   const parsedValue = parseInt(value || '', 10)
 
@@ -19,7 +21,11 @@ function parsePixelSize(value: string | null | undefined, fallback = 0): number 
   return parsedValue
 }
 
-function parseCssPixelSize(value: string | null | undefined, fallback = 0): number {
+function parseCssPixelSize(
+  value: string | null | undefined,
+  fallback = 0,
+  percentageBase = 0,
+): number {
   const rawValue = (value || '').trim().toLowerCase()
   const parsedValue = parseFloat(rawValue)
 
@@ -30,18 +36,30 @@ function parseCssPixelSize(value: string | null | undefined, fallback = 0): numb
   if (rawValue.endsWith('pt')) {
     return Math.round((parsedValue * 4) / 3)
   }
+  if (rawValue.endsWith('%')) {
+    const base = percentageBase > 0 ? percentageBase : DEFAULT_PERCENT_TABLE_WIDTH
+
+    return Math.round((parsedValue / 100) * base)
+  }
 
   return Math.round(parsedValue)
 }
 
-function getColgroupWidths(colgroupElements: HTMLCollection | null): number[] {
+function getColgroupWidths(
+  colgroupElements: HTMLCollection | null,
+  percentageBase: number,
+): number[] {
   if (!colgroupElements || colgroupElements.length === 0) { return [] }
 
   const columnWidths: number[] = []
 
   Array.from(colgroupElements).forEach((col: any) => {
     const span = parseInt(col.getAttribute('span') || '1', 10)
-    const width = parseCssPixelSize(col.getAttribute('width') || getStyleValue($(col), 'width'), 90)
+    const width = parseCssPixelSize(
+      col.getAttribute('width') || getStyleValue($(col), 'width'),
+      90,
+      percentageBase,
+    )
 
     if (Number.isNaN(width)) { return }
 
@@ -51,6 +69,18 @@ function getColgroupWidths(colgroupElements: HTMLCollection | null): number[] {
   })
 
   return columnWidths
+}
+
+function getTableWidthPixelBase($table: ReturnType<typeof $>): number {
+  const styleWidth = getStyleValue($table, 'width')
+  const widthAttr = $table.attr('width') || ''
+  const rawWidth = styleWidth || widthAttr
+
+  if (!rawWidth || rawWidth.trim() === '100%') {
+    return 0
+  }
+
+  return parseCssPixelSize(rawWidth, 0)
 }
 
 function parseCellHtml(
@@ -174,7 +204,8 @@ function parseTableHtml(
   }
   const tdList = $elem.find('tr')[0]?.children || []
   const colgroupElments: HTMLCollection = $elem.find('colgroup')[0]?.children || null
-  const colgroupWidths = getColgroupWidths(colgroupElments)
+  const percentageBase = getTableWidthPixelBase($elem)
+  const colgroupWidths = getColgroupWidths(colgroupElments, percentageBase)
 
   if (colgroupWidths.length > 0) {
     tableELement.columnWidths = colgroupWidths
@@ -183,7 +214,7 @@ function parseTableHtml(
 
     Array.from(tdList).forEach(td => {
       const colSpan = parseInt($(td).attr('colSpan') || '1', 10) // 获取 colSpan，默认为 1
-      const width = parseCssPixelSize(getStyleValue($(td), 'width'), 90) // 获取 width，默认为 90
+      const width = parseCssPixelSize(getStyleValue($(td), 'width'), 90, percentageBase) // 获取 width，默认为 90
 
       // 根据 colSpan 的值来填充 columnWidths 数组
       columnWidths.push(width)


### PR DESCRIPTION
## Summary

- convert imported Word percentage column widths into usable pixel widths
- preserve the existing #905 `pt` column-width conversion behavior
- add regression coverage for issue #909
- add a patch changeset for `@wangeditor-next/table-module`

## Verification

- `pnpm exec vitest run packages/table-module/__tests__/parse-html.test.ts -t "#905|#909|microsoft excel" --reporter=verbose`
- `PLAYWRIGHT_SKIP_BUILD=1 pnpm exec playwright test --project=chromium tests/e2e/issue-909-repro.spec.ts` (temporary local repro spec)
- `pnpm exec turbo build --filter=@wangeditor-next/table-module --filter=@wangeditor-next/editor --filter=@wangeditor-next/plugin-markdown`
- `pnpm --filter @wangeditor-next/table-module test`

Fixes #909


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Word table imports now correctly convert percentage-based column widths to pixel widths, ensuring imported tables display properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->