### PR TITLE
fix(list): preserve leading paragraph in nested list html

### DIFF
--- a/.changeset/fix-nested-list-leading-paragraph.md
+++ b/.changeset/fix-nested-list-leading-paragraph.md
@@ -1,0 +1,5 @@
+---
+"@wangeditor-next/list-module": patch
+---
+
+Fix nested list HTML parsing so leading paragraph content inside list items is preserved before child lists.

--- a/packages/list-module/__tests__/issue-877-roundtrip.test.ts
+++ b/packages/list-module/__tests__/issue-877-roundtrip.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @description issue #877 nested list leading paragraph round-trip
+ */
+
+import { $ } from 'dom7'
+
+import createEditor from '../../../tests/utils/create-editor'
+import { parseItemHtmlConf } from '../src/module/parse-elem-html'
+
+describe('list issue #877 round-trip', () => {
+  it('parse li should keep leading paragraph text before nested list items', () => {
+    const editor = createEditor()
+    const $ol = $('<ol><li></li></ol>')
+    const children: any[] = [
+      {
+        type: 'paragraph',
+        children: [{ text: '需求材料收尾与评审', bold: true }],
+      },
+      {
+        type: 'list-item',
+        ordered: false,
+        level: 1,
+        children: [{ text: '行动', bold: true }, { text: '：整合材料' }],
+      },
+    ]
+
+    const elems = parseItemHtmlConf.parseElemHtml($ol.find('li')[0], children, editor) as any[]
+
+    expect(elems).toEqual([
+      {
+        type: 'list-item',
+        ordered: true,
+        level: 0,
+        children: [{ text: '需求材料收尾与评审', bold: true }],
+      },
+      {
+        type: 'list-item',
+        ordered: false,
+        level: 1,
+        children: [{ text: '行动', bold: true }, { text: '：整合材料' }],
+      },
+    ])
+  })
+
+  it('setHtml/getHtml should not drop li leading paragraph before nested list', () => {
+    const editor = createEditor()
+    const html = `
+<ol>
+  <li>
+    <p><strong>需求材料收尾与评审（01月25日-26日，高优先级）</strong></p>
+    <ul>
+      <li><strong>行动</strong>：整合上周的需求分析与讨论成果，完成招标需求说明书/技术规格书的最终版本。</li>
+      <li><strong>产出</strong>：组织一次内部评审会，确认需求材料。</li>
+      <li><strong>目标</strong>：锁定需求基线。</li>
+    </ul>
+  </li>
+</ol>`
+
+    editor.setHtml(html)
+    const output = editor.getHtml()
+    const wrapper = document.createElement('div')
+
+    wrapper.innerHTML = output
+
+    expect(output).toContain('需求材料收尾与评审（01月25日-26日，高优先级）')
+    expect(output).toContain('<strong>需求材料收尾与评审（01月25日-26日，高优先级）</strong>')
+    expect(wrapper.querySelectorAll('ol > li')).toHaveLength(1)
+    expect(wrapper.querySelectorAll('ol > li > ul > li')).toHaveLength(3)
+    expect(wrapper.querySelector('ol > li')?.textContent).toContain('行动')
+  })
+})

--- a/packages/list-module/src/module/parse-elem-html.ts
+++ b/packages/list-module/src/module/parse-elem-html.ts
@@ -5,7 +5,7 @@
 
 import { DomEditor, IDomEditor } from '@wangeditor-next/core'
 import { Dom7Array } from 'dom7'
-import { Descendant, Text } from 'slate'
+import { Descendant, Element as SlateElement, Text } from 'slate'
 
 import $, { DOMElement, getTagName } from '../utils/dom'
 import { ListItemElement, OrderedListType } from './custom-types'
@@ -72,6 +72,36 @@ function getLevel($elem: Dom7Array): number {
   return Math.max(0, listAncestorCount - 1)
 }
 
+function isStructuralWhitespaceText(child: Descendant): boolean {
+  return Text.isText(child) && child.text.trim() === ''
+}
+
+function appendTextLikeChildren(
+  target: Descendant[],
+  children: Descendant[],
+  editor: IDomEditor,
+) {
+  children.forEach(child => {
+    if (isStructuralWhitespaceText(child)) {
+      return
+    }
+
+    if (Text.isText(child)) {
+      target.push(child)
+      return
+    }
+
+    if (editor.isInline(child)) {
+      target.push(child)
+      return
+    }
+
+    if (SlateElement.isElement(child)) {
+      appendTextLikeChildren(target, child.children, editor)
+    }
+  })
+}
+
 function parseItemHtml(
   elem: DOMElement,
   children: Descendant[],
@@ -82,6 +112,10 @@ function parseItemHtml(
   const nestedListChildren: ListItemElement[] = []
 
   children.forEach(child => {
+    if (isStructuralWhitespaceText(child)) {
+      return
+    }
+
     if (Text.isText(child)) {
       normalizedChildren.push(child)
       return
@@ -94,6 +128,11 @@ function parseItemHtml(
 
     if (DomEditor.checkNodeType(child, 'list-item')) {
       nestedListChildren.push(child as ListItemElement)
+      return
+    }
+
+    if (SlateElement.isElement(child)) {
+      appendTextLikeChildren(normalizedChildren, child.children, editor)
     }
   })
 


### PR DESCRIPTION
## Summary
- preserve paragraph text inside list items when parsing nested list HTML
- skip structural whitespace text so formatted nested lists do not export stray blank content
- add regression coverage for #877 direct parsing and setHtml/getHtml round-trip

## Tests
- pnpm --filter @wangeditor-next/list-module test
- pnpm --filter @wangeditor-next/editor test -- create.test.ts
- pnpm --filter @wangeditor-next/list-module build
- pnpm exec eslint --quiet --no-error-on-unmatched-pattern packages/list-module/src/module/parse-elem-html.ts packages/list-module/__tests__/issue-877-roundtrip.test.ts

Closes #877

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed nested list parsing so text from a leading paragraph inside list items is preserved.
  * Improved round-trip handling for complex nested lists, including formatted text, without dropping content.

* **Tests**
  * Added coverage for nested list scenarios to verify HTML import/export keeps list structure and leading paragraph content intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->