### PR TITLE
fix(core): stabilize Vue3 production image selection and paste order

### DIFF
--- a/.changeset/bright-walls-tap.md
+++ b/.changeset/bright-walls-tap.md
@@ -1,0 +1,6 @@
+---
+"@wangeditor-next/core": patch
+"@wangeditor-next/editor": patch
+---
+
+Fix Vue3 production builds losing selected image hoverbar actions and keep pasted Word-like HTML blocks in source order.

--- a/packages/core/__tests__/editor/plugins/with-content.test.ts
+++ b/packages/core/__tests__/editor/plugins/with-content.test.ts
@@ -706,4 +706,33 @@ describe('editor content API', () => {
     expect(editor.getText()).toBe('hello world')
     expect(editor.getHtml()).toContain('hello world')
   })
+
+  it('insertData keeps Word-like html blocks in source order', () => {
+    const editor = createEditor()
+
+    editor.select(getStartLocation(editor))
+    editor.insertData({
+      getData(type: string) {
+        if (type === 'text/html') {
+          return `
+            <html><body>
+              <div class="WordSection1">
+                <p class="MsoTitle"><span style="font-size:22pt;font-family:宋体">测试标题</span></p>
+                <p class="MsoNormal"><span style="font-family:宋体">第一段内容</span></p>
+                <p class="MsoNormal"><span style="font-family:宋体">第二段内容</span></p>
+              </div>
+            </body></html>`
+        }
+        if (type === 'text/plain') { return '测试标题\n第一段内容\n第二段内容' }
+        return ''
+      },
+    } as DataTransfer)
+
+    expect(editor.children.map(node => Node.string(node))).toEqual([
+      '测试标题',
+      '第一段内容',
+      '第二段内容',
+    ])
+    expect(editor.getText()).toBe('测试标题\n第一段内容\n第二段内容')
+  })
 })

--- a/packages/core/src/editor/dom-editor.ts
+++ b/packages/core/src/editor/dom-editor.ts
@@ -777,21 +777,44 @@ export const DomEditor = {
     return nodes.map(node => Node.string(node)).join('')
   },
 
+  getSelectedVoidNode(editor: IDomEditor): Element | null {
+    const { selection } = editor
+
+    if (!selection) { return null }
+    const voidEntry = Editor.void(editor, { at: selection })
+
+    if (!voidEntry) { return null }
+    const [node] = voidEntry
+
+    return Element.isElement(node) ? node : null
+  },
+
   getSelectedElems(editor: IDomEditor): Element[] {
     const elems: Element[] = []
+    const selectedVoidNode = DomEditor.getSelectedVoidNode(editor)
+
+    if (selectedVoidNode) {
+      elems.push(selectedVoidNode)
+    }
 
     const nodeEntries = Editor.nodes(editor, { universal: true })
 
     for (const nodeEntry of nodeEntries) {
       const [node] = nodeEntry
 
-      if (Element.isElement(node)) { elems.push(node) }
+      if (Element.isElement(node) && node !== selectedVoidNode) { elems.push(node) }
     }
 
     return elems
   },
 
   getSelectedNodeByType(editor: IDomEditor, type: string): Node | null {
+    const selectedVoidNode = DomEditor.getSelectedVoidNode(editor)
+
+    if (selectedVoidNode && this.checkNodeType(selectedVoidNode, type)) {
+      return selectedVoidNode
+    }
+
     const [nodeEntry] = Editor.nodes(editor, {
       match: n => this.checkNodeType(n, type),
       universal: true,
@@ -812,6 +835,10 @@ export const DomEditor = {
   },
 
   isNodeSelected(editor: IDomEditor, node: Node): boolean {
+    const selectedVoidNode = DomEditor.getSelectedVoidNode(editor)
+
+    if (selectedVoidNode === node) { return true }
+
     const [nodeEntry] = Editor.nodes(editor, {
       match: n => n === node,
       universal: true,
@@ -966,15 +993,7 @@ export const DomEditor = {
    * @param editor editor
    */
   isSelectedVoidNode(editor: IDomEditor): boolean {
-    const voidNodes = Editor.nodes(editor, {
-      match: n => editor.isVoid(n as Element),
-    })
-    let len = 0
-
-    for (const n of voidNodes) {
-      if (n) { len += 1 }
-    }
-    return len > 0
+    return DomEditor.getSelectedVoidNode(editor) != null
   },
 
   /**
@@ -988,11 +1007,13 @@ export const DomEditor = {
 
     if (Range.isExpanded(selection)) { return false }
 
-    const selectedNode = DomEditor.getSelectedNodeByType(editor, 'paragraph')
+    const topLevelPath = [selection.focus.path[0]]
 
-    if (selectedNode === null) { return false }
+    if (!Editor.hasPath(editor, topLevelPath)) { return false }
+    const [selectedNode] = Editor.node(editor, topLevelPath)
 
-    const { children } = selectedNode as Element
+    if (!Element.isElement(selectedNode) || selectedNode.type !== 'paragraph') { return false }
+    const { children } = selectedNode
 
     if (children.length !== 1) { return false }
 

--- a/packages/core/src/editor/plugins/with-content.ts
+++ b/packages/core/src/editor/plugins/with-content.ts
@@ -43,7 +43,14 @@ const getMatches = (e: IDomEditor, path: Path) => {
  * @param editor editor
  * @param elem slate elem
  */
-function insertElemToEditor(editor: IDomEditor, elem: Element) {
+function insertElemToEditor(editor: IDomEditor, elem: Node) {
+  if (Text.isText(elem)) {
+    editor.insertNode(elem)
+    return
+  }
+
+  if (!Element.isElement(elem)) { return }
+
   if (editor.isInline(elem)) {
     // inline elem 直接插入
     editor.insertNode(elem)
@@ -52,7 +59,22 @@ function insertElemToEditor(editor: IDomEditor, elem: Element) {
     if (elem.type === 'link') { editor.insertFragment([{ text: '' }]) }
   } else {
     // block elem ，另起一行插入 —— 重要
-    Transforms.insertNodes(editor, elem, { mode: 'highest' })
+    const { selection } = editor
+
+    if (!selection) { return }
+    const topLevelPath = [selection.focus.path[0]]
+
+    if (DomEditor.isSelectedEmptyParagraph(editor)) {
+      Transforms.removeNodes(editor, { at: topLevelPath })
+      Transforms.insertNodes(editor, elem, { at: topLevelPath })
+      Transforms.select(editor, Editor.end(editor, topLevelPath))
+      return
+    }
+
+    const insertPath = Path.next(topLevelPath)
+
+    Transforms.insertNodes(editor, elem, { at: insertPath })
+    Transforms.select(editor, Editor.end(editor, insertPath))
   }
 }
 

--- a/packages/core/src/menus/bar/HoverBar.ts
+++ b/packages/core/src/menus/bar/HoverBar.ts
@@ -274,11 +274,16 @@ class HoverBar {
 
       // 定义了 match 则用 match 。未定义 match 则用 elemType
       const matchFn = match || ((_editor: IDomEditor, n: Node) => DomEditor.checkNodeType(n, elemType))
+      const selectedNode = match
+        ? null
+        : DomEditor.getSelectedNodeByType(editor, elemType)
 
-      const [nodeEntry] = Editor.nodes(editor, {
-        match: n => matchFn(editor, n),
-        universal: true,
-      })
+      const [nodeEntry] = selectedNode
+        ? [[selectedNode]]
+        : Editor.nodes(editor, {
+          match: n => matchFn(editor, n),
+          universal: true,
+        })
 
       // 匹配成功（找到第一个就停止，不再继续找了）
       if (nodeEntry != null) {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,8 +3,8 @@ import { defineConfig, devices } from '@playwright/test'
 let webServerCommand = 'pnpm turbo build --filter=@wangeditor-next/editor --filter=@wangeditor-next/plugin-markdown && pnpm --filter @wangeditor-next/demo-html run serve'
 const reactDemoDevCommand = 'pnpm --filter @wangeditor-next/demo-react exec vite --host 127.0.0.1 --port 3102 --strictPort'
 const vue3DemoDevCommand = 'pnpm --filter @wangeditor-next/demo-vue3 exec vite --force --host 127.0.0.1 --port 3103 --strictPort'
-const reactDemoPreviewCommand = 'pnpm --filter @wangeditor-next/demo-react run build && pnpm --filter @wangeditor-next/demo-react exec vite preview --host 127.0.0.1 --port 3102 --strictPort'
-const vue3DemoPreviewCommand = 'pnpm --filter @wangeditor-next/demo-vue3 run build && pnpm --filter @wangeditor-next/demo-vue3 exec vite preview --host 127.0.0.1 --port 3103 --strictPort'
+const reactDemoPreviewCommand = 'pnpm turbo build --filter=@wangeditor-next/editor-for-react --filter=@wangeditor-next/demo-react && pnpm --filter @wangeditor-next/demo-react exec vite preview --host 127.0.0.1 --port 3102 --strictPort'
+const vue3DemoPreviewCommand = 'pnpm turbo build --filter=@wangeditor-next/demo-vue3 && pnpm --filter @wangeditor-next/demo-vue3 exec vite preview --host 127.0.0.1 --port 3103 --strictPort'
 let reactDemoCommand = reactDemoDevCommand
 let vue3DemoCommand = vue3DemoDevCommand
 
@@ -16,7 +16,7 @@ if (process.env.PLAYWRIGHT_SKIP_BUILD) {
   webServerCommand = 'pnpm turbo build --force --filter=@wangeditor-next/editor --filter=@wangeditor-next/plugin-markdown && pnpm --filter @wangeditor-next/demo-html run serve'
 }
 
-if (process.env.CI && process.env.PLAYWRIGHT_WRAPPER_PREVIEW === '1') {
+if (process.env.PLAYWRIGHT_WRAPPER_PREVIEW === '1') {
   reactDemoCommand = reactDemoPreviewCommand
   vue3DemoCommand = vue3DemoPreviewCommand
 }

--- a/tests/e2e/framework-regression.spec.ts
+++ b/tests/e2e/framework-regression.spec.ts
@@ -351,6 +351,112 @@ test.describe('Framework parity regression', () => {
     expect(pageErrors).toEqual([])
   })
 
+  test('vue3-wrapper: regression #919 production build should keep image hoverbar and paste order', async ({ page }) => {
+    test.skip(
+      process.env.PLAYWRIGHT_WRAPPER_PREVIEW !== '1',
+      'regression #919 requires wrapper production preview',
+    )
+
+    const pageErrors: string[] = []
+
+    page.on('pageerror', err => {
+      pageErrors.push(err?.stack || err?.message || String(err))
+    })
+
+    await openTarget(page, targets.find(target => target.name === 'vue3-wrapper')!)
+
+    await page.evaluate(() => {
+      const globalWindow = window as any
+      const editor = globalWindow.vue3Editor
+
+      if (!editor) {
+        throw new Error('vue3 editor not ready')
+      }
+
+      editor.clear()
+      editor.dangerouslyInsertHtml(
+        '<p><img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" alt="tiny" /></p>',
+      )
+    })
+    await page.locator('[data-testid="editor-textarea"] img').first().click({ force: true })
+    await page.waitForTimeout(500)
+
+    const imageState = await page.evaluate(() => {
+      const visibleHoverbar = Array.from(document.querySelectorAll('.w-e-hover-bar')).find(el => {
+        const style = window.getComputedStyle(el)
+        const rect = el.getBoundingClientRect()
+
+        return style.display !== 'none'
+          && style.visibility !== 'hidden'
+          && rect.width > 0
+          && rect.height > 0
+      })
+
+      return {
+        selectedImage: !!document.querySelector('.w-e-selected-image-container'),
+        hoverbarVisible: !!visibleHoverbar,
+        menuKeys: visibleHoverbar
+          ? Array.from(visibleHoverbar.querySelectorAll('[data-menu-key]')).map(el => el.getAttribute('data-menu-key'))
+          : [],
+      }
+    })
+
+    expect(imageState.selectedImage).toBe(true)
+    expect(imageState.hoverbarVisible).toBe(true)
+    expect(imageState.menuKeys).toEqual(expect.arrayContaining([
+      'imageWidth30',
+      'editorImageSizeMenu',
+      'editImage',
+      'deleteImage',
+    ]))
+
+    await openTarget(page, targets.find(target => target.name === 'vue3-wrapper')!)
+
+    const wordLikeHtml = `
+      <html><body>
+        <div class="WordSection1">
+          <p class="MsoTitle"><span style="font-size:22pt;font-family:宋体">测试标题</span></p>
+          <p class="MsoNormal"><span style="font-family:宋体">第一段内容</span></p>
+          <p class="MsoNormal"><span style="font-family:宋体">第二段内容</span></p>
+        </div>
+      </body></html>`
+
+    const pasteState = await page.evaluate(({ html }) => {
+      const globalWindow = window as any
+      const editor = globalWindow.vue3Editor
+
+      if (!editor) {
+        throw new Error('vue3 editor not ready')
+      }
+
+      editor.clear()
+      editor.focus()
+
+      const transfer = new DataTransfer()
+
+      transfer.setData('text/html', html)
+      transfer.setData('text/plain', '测试标题\n第一段内容\n第二段内容')
+      editor.insertData(transfer)
+
+      return {
+        text: editor.getText(),
+        children: editor.children.map((node: any) => {
+          return Array.isArray(node.children)
+            ? node.children.map((child: any) => child.text || '').join('')
+            : ''
+        }),
+      }
+    }, { html: wordLikeHtml })
+
+    expect(pasteState.children).toEqual([
+      '测试标题',
+      '第一段内容',
+      '第二段内容',
+    ])
+    expect(pasteState.text).toBe('测试标题\n第一段内容\n第二段内容')
+    expect(pageErrors).toEqual([])
+  })
+
   for (const target of targets) {
     test(`${target.name}: ime composition should not throw`, async ({ page }) => {
       const pageErrors: string[] = []


### PR DESCRIPTION
## Summary

Fixes #919.

This patch stabilizes the two Vue3 production-build symptoms reported in the issue:

- selected inserted/uploaded images now resolve the selected void node before hoverbar matching, so image size/edit/delete actions are shown in the production bundle
- Word-like HTML paste now inserts block nodes at an explicit top-level path and moves selection explicitly, preserving the source order instead of letting the title move after later paragraphs

It also adds a production-preview Playwright regression for the Vue3 wrapper and enables `PLAYWRIGHT_WRAPPER_PREVIEW=1` outside CI so this production-only path can be reproduced locally.

## Notes

The repro points to production bundle behavior, not a simple Vite-version-only issue. The fix is in core selection and insertion logic, so it should apply across wrapper builds.

## Verification

- `pnpm --filter @wangeditor-next/core test -- with-content.test.ts dom-editor.test.ts`
- `PLAYWRIGHT_WRAPPER_PREVIEW=1 PLAYWRIGHT_SKIP_BUILD=1 pnpm exec playwright test --project=chromium tests/e2e/framework-regression.spec.ts -g "#919"`
- `pnpm turbo build --filter=@wangeditor-next/core --filter=@wangeditor-next/editor --filter=@wangeditor-next/demo-vue3 --filter=@wangeditor-next/editor-for-react --filter=@wangeditor-next/demo-react`

Build completed with existing warnings around circular dependencies, missing Rollup globals, stale browserslist/baseline data, and large demo chunks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Vue 3 production builds so selected image hoverbar actions remain available.
  * Improved paste handling so Word-like HTML content keeps the correct order when inserted.
  * Selection behavior for images, blocks, and empty paragraphs is now more consistent, reducing cases where the wrong item appears selected.
* **Tests**
  * Added end-to-end coverage for Vue 3 preview builds to verify image hoverbar behavior and paste ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->