### PR TITLE
fix(table): support resizing tables without height

### DIFF
--- a/.changeset/fix-table-heightless-column-resize.md
+++ b/.changeset/fix-table-heightless-column-resize.md
@@ -1,0 +1,5 @@
+---
+"@wangeditor-next/table-module": patch
+---
+
+Fix column resizing for tables without an explicit height.

--- a/packages/table-module/__tests__/render-elem.test.ts
+++ b/packages/table-module/__tests__/render-elem.test.ts
@@ -189,4 +189,67 @@ describe('table module - render elem', () => {
     // 验证使用默认高度 30px
     expect(firstRowResizer.data?.style?.minHeight).toBe('30px')
   })
+
+  it('render table column resizer with measured row heights when table height is not specified', () => {
+    const elem = {
+      type: 'table',
+      width: 'auto',
+      columnWidths: [100, 120],
+      rowHeights: [34, 46],
+      children: [
+        {
+          type: 'table-row',
+          children: [
+            { type: 'table-cell', children: [{ text: 'A1' }] },
+            { type: 'table-cell', children: [{ text: 'B1' }] },
+          ],
+        },
+        {
+          type: 'table-row',
+          children: [
+            { type: 'table-cell', children: [{ text: 'A2' }] },
+            { type: 'table-cell', children: [{ text: 'B2' }] },
+          ],
+        },
+      ],
+    }
+
+    const observerVnode = renderTableConf.renderElem(elem, null, editor) as any
+    const containerVnode = observerVnode.children[0] as any
+    const columnResizer = containerVnode.children[1] as any
+    const firstHotzone = columnResizer.children[0].children[0] as any
+    const secondHotzone = columnResizer.children[1].children[0] as any
+
+    expect(firstHotzone.data?.style?.height).toBe('80px')
+    expect(secondHotzone.data?.style?.height).toBe('80px')
+  })
+
+  it('render table column resizer with default row heights before measurement is available', () => {
+    const elem = {
+      type: 'table',
+      width: 'auto',
+      columnWidths: [100],
+      children: [
+        {
+          type: 'table-row',
+          children: [
+            { type: 'table-cell', children: [{ text: 'A1' }] },
+          ],
+        },
+        {
+          type: 'table-row',
+          children: [
+            { type: 'table-cell', children: [{ text: 'A2' }] },
+          ],
+        },
+      ],
+    }
+
+    const observerVnode = renderTableConf.renderElem(elem, null, editor) as any
+    const containerVnode = observerVnode.children[0] as any
+    const columnResizer = containerVnode.children[1] as any
+    const firstHotzone = columnResizer.children[0].children[0] as any
+
+    expect(firstHotzone.data?.style?.height).toBe('60px')
+  })
 })

--- a/packages/table-module/src/module/render-elem/render-table.tsx
+++ b/packages/table-module/src/module/render-elem/render-table.tsx
@@ -60,6 +60,41 @@ function getContentEditable(editor: IDomEditor, tableElem: SlateElement): boolea
   return false
 }
 
+function getColumnResizerHeight(tableElem: TableElement): number {
+  const {
+    height,
+    rowHeights = [],
+    children = [],
+  } = tableElem
+
+  if (typeof height === 'number' && Number.isFinite(height) && height > 0) {
+    return height
+  }
+
+  const hasMeasuredRowHeights = (
+    rowHeights.length === children.length
+    && rowHeights.every(rowHeight => (
+      typeof rowHeight === 'number'
+      && Number.isFinite(rowHeight)
+      && rowHeight > 0
+    ))
+  )
+
+  if (hasMeasuredRowHeights) {
+    return rowHeights.reduce((total, rowHeight) => total + rowHeight, 0)
+  }
+
+  return children.reduce((total, rowNode) => {
+    const rowHeight = (rowNode as TableRowElement).height
+
+    return total + (
+      typeof rowHeight === 'number' && Number.isFinite(rowHeight) && rowHeight > 0
+        ? rowHeight
+        : 30
+    )
+  }, 0)
+}
+
 function renderTable(elemNode: SlateElement, children: VNode[] | null, editor: IDomEditor): VNode {
   // 是否可编辑
   const editable = getContentEditable(editor, elemNode)
@@ -68,7 +103,6 @@ function renderTable(elemNode: SlateElement, children: VNode[] | null, editor: I
   const {
     width: tableWidth = 'auto',
     caption,
-    height,
     columnWidths = [],
     rowHeights = [],
     scrollWidth = 0,
@@ -79,6 +113,7 @@ function renderTable(elemNode: SlateElement, children: VNode[] | null, editor: I
     resizingRowIndex,
     isResizingRow,
   } = elemNode as TableElement
+  const columnResizerHeight = getColumnResizerHeight(elemNode as TableElement)
 
   // 光标是否选中
   const selected = DomEditor.isNodeSelected(editor, elemNode)
@@ -187,7 +222,7 @@ function renderTable(elemNode: SlateElement, children: VNode[] | null, editor: I
                     isHoverCellBorder && index === resizingIndex ? 'visible ' : ''
                   }${isResizing && index === resizingIndex ? 'highlight' : ''}`
                 }
-                style={{ height: `${height}px` }}
+                style={{ height: `${columnResizerHeight}px` }}
                 on={{
                   mouseenter: (e: MouseEvent) => handleCellBorderHighlight(editor, e),
                   mouseleave: (e: MouseEvent) => handleCellBorderHighlight(editor, e),

--- a/tests/e2e/framework-regression.spec.ts
+++ b/tests/e2e/framework-regression.spec.ts
@@ -1135,6 +1135,62 @@ test.describe('Framework parity regression', () => {
       expect(pageErrors).toEqual([])
     })
 
+    test(`${target.name}: regression #923 table without height should allow column resize`, async ({ page }) => {
+      const pageErrors: string[] = []
+
+      page.on('pageerror', err => {
+        pageErrors.push(err?.stack || err?.message || String(err))
+      })
+
+      await openTarget(page, target)
+      await clearEditor(page)
+      await create2x2TableByApi(page)
+
+      await page.evaluate(() => {
+        const table = document.querySelector('[data-testid="editor-textarea"] table.table') as HTMLTableElement | null
+
+        if (!table) {
+          throw new Error('table not ready')
+        }
+
+        table.removeAttribute('height')
+        table.style.height = ''
+
+        const globalWindow = window as any
+        const editor = globalWindow.wangEditorExampleBridge?.editor
+          || globalWindow.vue2Editor
+          || globalWindow.vue3Editor
+          || globalWindow.reactEditor
+        const tableNode = (editor?.children || []).find((node: any) => node?.type === 'table')
+
+        if (!tableNode) {
+          throw new Error('table node not ready')
+        }
+
+        delete tableNode.height
+      })
+      await page.waitForTimeout(120)
+
+      const hotzoneHeight = await page
+        .locator('[data-testid="editor-textarea"] .column-resizer')
+        .last()
+        .locator('.column-resizer-item')
+        .first()
+        .locator('.resizer-line-hotzone')
+        .evaluate((hotzone: HTMLElement) => hotzone.getBoundingClientRect().height)
+      const before = await getLastTableWidths(page)
+      const dragged = await dispatchSyntheticFirstColumnResize(page, 60)
+
+      await page.waitForTimeout(240)
+      const after = await getLastTableWidths(page)
+
+      expect(hotzoneHeight).toBeGreaterThan(0)
+      expect(dragged).toBe(true)
+      expect(before[0] || 0).toBeGreaterThan(0)
+      expect(after[0] || 0).toBeGreaterThan(before[0] || 0)
+      expect(pageErrors).toEqual([])
+    })
+
     test(`${target.name}: regression #505 fast drag should keep effective resize`, async ({ page }) => {
       const pageErrors: string[] = []
 


### PR DESCRIPTION
## Summary
- Keep table column resize handles usable when the table node has no explicit height.
- Derive the resize handle height from runtime row height snapshots, row element heights, or default row height instead of requiring serialized table height.
- Add unit and Playwright regression coverage for issue #923.

## Verification
- pnpm exec eslint packages/table-module/src/module/render-elem/render-table.tsx packages/table-module/__tests__/render-elem.test.ts tests/e2e/framework-regression.spec.ts --no-error-on-unmatched-pattern
- pnpm vitest run packages/table-module/__tests__/render-elem.test.ts packages/table-module/__tests__/column-resize.test.ts packages/table-module/__tests__/parse-html.test.ts
- pnpm turbo build --filter=@wangeditor-next/editor --filter=@wangeditor-next/plugin-markdown
- PLAYWRIGHT_SKIP_BUILD=1 pnpm exec playwright test --project=chromium tests/e2e/framework-regression.spec.ts -g "#923"

Fixes #923


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed table column resizing so it works correctly even when a table has no explicit height.
  * Improved the resize handle area to use a reliable measured height, helping keep the resizer visible and usable.
  * Added regression coverage to confirm tables without a height can still be resized without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->