### PR TITLE
docs: fix stale README package badges

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -1,13 +1,13 @@
 # wangEditor-next 5
 
-[![codecov](https://codecov.io/gh/wangeditor-next/wangeditor-next-next/branch/master/graph/badge.svg?token=0ZSXFXJPK3)](https://codecov.io/gh/wangeditor-next/wangeditor-next-next)
-[![GitHub stars](https://img.shields.io/github/stars/wangeditor-next/wangeditor-next-next)](https://github.com/wangeditor-next/wangEditor-next/stargazers)
+[![codecov](https://codecov.io/gh/wangeditor-next/wangEditor-next/graph/badge.svg?token=0ZSXFXJPK3)](https://codecov.io/gh/wangeditor-next/wangEditor-next)
+[![GitHub stars](https://img.shields.io/github/stars/wangeditor-next/wangEditor-next)](https://github.com/wangeditor-next/wangEditor-next/stargazers)
 
 [Chinese](./README.md)
 
 ## Introduction
 
-The original project [wangeditor-next](https://github.com/wangeditor-next/wangeditor-next) is temporarily not maintained due to the author's [personal reasons](https://juejin.cn/post/7272735633458413602). This project is a forked version that will continue to be maintained with minimal breaking changes.
+The original project [wangEditor](https://github.com/wangeditor-team/wangEditor) is temporarily not maintained due to the author's [personal reasons](https://juejin.cn/post/7272735633458413602). This project is a forked version that will continue to be maintained with minimal breaking changes.
 
 An open-source web rich text editor that is ready to use out of the box with simple configuration. It supports JS, Vue, and React.
 
@@ -27,7 +27,7 @@ An open-source web rich text editor that is ready to use out of the box with sim
 
 ### For Vue or React
 ```shell
-npm i wangeditor-next/editor
+npm install @wangeditor-next/editor --save
 ```
 
 ### For HTML using CDN resources

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![bundle][bundle-src]][bundle-href]
 [![JSDocs][jsdocs-src]][jsdocs-href]
 [![License][license-src]][license-href]
-[![codecov](https://codecov.io/gh/wangeditor-next/wangeditor-next/graph/badge.svg?token=0ZSXFXJPK3)](https://codecov.io/gh/wangeditor-next/wangeditor-next)
+[![codecov](https://codecov.io/gh/wangeditor-next/wangEditor-next/graph/badge.svg?token=0ZSXFXJPK3)](https://codecov.io/gh/wangeditor-next/wangEditor-next)
 
 🌍 [English](./README-en.md) | 中文
 
@@ -100,7 +100,7 @@ pnpm demo:yjs:vue3
 ## 贡献者
 
 <a href="https://github.com/wangeditor-next/wangEditor-next/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=wangeditor-next/wangeditor-next" />
+  <img src="https://contrib.rocks/image?repo=wangeditor-next/wangEditor-next" />
 </a>
 
 ## License
@@ -111,11 +111,11 @@ pnpm demo:yjs:vue3
 
 [npm-version-src]: https://img.shields.io/npm/v/@wangeditor-next/editor?style=flat&colorA=080f12&colorB=1fa669
 [npm-version-href]: https://npmjs.com/package/@wangeditor-next/editor
-[npm-downloads-src]: https://img.shields.io/npm/dm/@wangeditor-next/core?style=flat&colorA=080f12&colorB=1fa669
+[npm-downloads-src]: https://img.shields.io/npm/dm/@wangeditor-next/editor?style=flat&colorA=080f12&colorB=1fa669
 [npm-downloads-href]: https://npmjs.com/package/@wangeditor-next/editor
 [bundle-src]: https://img.shields.io/bundlephobia/minzip/@wangeditor-next/editor?style=flat&colorA=080f12&colorB=1fa669&label=minzip
 [bundle-href]: https://bundlephobia.com/result?p=@wangeditor-next/editor
-[license-src]: https://img.shields.io/github/license/wangeditor-next/wangeditor-next.svg?style=flat&colorA=080f12&colorB=1fa669
+[license-src]: https://img.shields.io/github/license/wangeditor-next/wangEditor-next.svg?style=flat&colorA=080f12&colorB=1fa669
 [license-href]: https://github.com/wangeditor-next/wangEditor-next/blob/master/LICENSE
 [jsdocs-src]: https://img.shields.io/badge/jsdocs-reference-080f12?style=flat&colorA=080f12&colorB=1fa669
 [jsdocs-href]: https://www.jsdocs.io/package/@wangeditor-next/editor

--- a/apps/demo-html/examples/menu.html
+++ b/apps/demo-html/examples/menu.html
@@ -46,7 +46,7 @@
           'deleteImage',
         ],
       }
-      // 其他参考 https://github.com/wangeditor-next/wangeditor-next/blob/master/packages/editor/src/init-default-config/config/hoverbar.ts
+      // 其他参考 https://github.com/wangeditor-next/wangEditor-next/blob/master/packages/editor/src/init-default-config/config/hoverbar.ts
     }
 
     // 各个菜单的配置

--- a/packages/basic-modules/package.json
+++ b/packages/basic-modules/package.json
@@ -4,7 +4,7 @@
   "description": "wangEditor basic modules",
   "author": "cycleccc <2991205548@qq.com>",
   "type": "module",
-  "homepage": "https://github.com/wangeditor-next/wangeditor-next#readme",
+  "homepage": "https://github.com/wangeditor-next/wangEditor-next#readme",
   "license": "MIT",
   "types": "dist/basic-modules/src/index.d.ts",
   "main": "dist/index.js",
@@ -41,7 +41,7 @@
     "size-stats": "cross-env NODE_ENV=production:size_stats rollup -c rollup.config.js"
   },
   "bugs": {
-    "url": "https://github.com/wangeditor-next/wangeditor-next/issues"
+    "url": "https://github.com/wangeditor-next/wangEditor-next/issues"
   },
   "peerDependencies": {
     "@wangeditor-next/core": ">=1.9.2",

--- a/packages/code-highlight/package.json
+++ b/packages/code-highlight/package.json
@@ -4,7 +4,7 @@
   "description": "wangEditor code-highlight module",
   "author": "cycleccc <2991205548@qq.com>",
   "type": "module",
-  "homepage": "https://github.com/wangeditor-next/wangeditor-next#readme",
+  "homepage": "https://github.com/wangeditor-next/wangEditor-next#readme",
   "license": "MIT",
   "types": "dist/code-highlight/src/index.d.ts",
   "main": "dist/index.js",
@@ -41,7 +41,7 @@
     "size-stats": "cross-env NODE_ENV=production:size_stats rollup -c rollup.config.js"
   },
   "bugs": {
-    "url": "https://github.com/wangeditor-next/wangeditor-next/issues"
+    "url": "https://github.com/wangeditor-next/wangEditor-next/issues"
   },
   "peerDependencies": {
     "@wangeditor-next/core": ">=1.9.2",

--- a/packages/core/__tests__/editor/plugins/with-dom.test.ts
+++ b/packages/core/__tests__/editor/plugins/with-dom.test.ts
@@ -47,7 +47,7 @@ describe('editor DOM API', () => {
           'deleteImage',
         ],
       },
-      // 其他参考 https://github.com/wangeditor-next/wangeditor-next/blob/master/packages/editor/src/init-default-config/config/hoverbar.ts
+      // 其他参考 https://github.com/wangeditor-next/wangEditor-next/blob/master/packages/editor/src/init-default-config/config/hoverbar.ts
     }
     const editor = createEditor({ config: editorConfig })
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,7 @@
   "description": "wangEditor core",
   "author": "cycleccc <2991205548@qq.com>",
   "type": "module",
-  "homepage": "https://github.com/wangeditor-next/wangeditor-next#readme",
+  "homepage": "https://github.com/wangeditor-next/wangEditor-next#readme",
   "license": "MIT",
   "types": "dist/core/src/index.d.ts",
   "main": "dist/index.js",
@@ -46,7 +46,7 @@
     "size-stats": "cross-env NODE_ENV=production:size_stats rollup -c rollup.config.js"
   },
   "bugs": {
-    "url": "https://github.com/wangeditor-next/wangeditor-next/issues"
+    "url": "https://github.com/wangeditor-next/wangEditor-next/issues"
   },
   "peerDependencies": {
     "@uppy/core": "^2.1.1 || ^5.0.0",

--- a/packages/editor/README-en.md
+++ b/packages/editor/README-en.md
@@ -59,4 +59,4 @@ const { editor, toolbar } = factory.create({
 import { createUploader } from '@wangeditor-next/editor/upload'
 ```
 
-You can [commit an issue]((https://github.com/wangeditor-next/wangeditor-next/issues)) if you have any question.
+You can [commit an issue](https://github.com/wangeditor-next/wangEditor-next/issues) if you have any question.

--- a/packages/editor/demo/js/custom-elem.js
+++ b/packages/editor/demo/js/custom-elem.js
@@ -112,13 +112,13 @@
         rightContainer.innerHTML = `
         <a href="https://wangeditor-next.github.io/docs/en/">Document</a>
         &nbsp;
-        <a href="https://github.com/wangeditor-next/wangeditor-next/tree/master/packages/editor/demo">Source</a>
+        <a href="https://github.com/wangeditor-next/wangEditor-next/tree/master/packages/editor/demo">Source</a>
       `
       } else {
         rightContainer.innerHTML = `
         <a href="https://wangeditor-next.github.io/docs/">文档</a>
         &nbsp;
-        <a href="https://github.com/wangeditor-next/wangeditor-next/tree/master/packages/editor/demo">源码</a>
+        <a href="https://github.com/wangeditor-next/wangEditor-next/tree/master/packages/editor/demo">源码</a>
       `
       }
 

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -11,7 +11,7 @@
   ],
   "author": "cycleccc <29912005548@qq.com>",
   "type": "module",
-  "homepage": "https://github.com/wangeditor-next/wangeditor-next#readme",
+  "homepage": "https://github.com/wangeditor-next/wangEditor-next#readme",
   "license": "MIT",
   "types": "dist/editor/src/index.d.ts",
   "main": "dist/index.js",
@@ -61,7 +61,7 @@
     "size-stats": "cross-env NODE_ENV=production:size_stats rollup -c rollup.config.js"
   },
   "bugs": {
-    "url": "https://github.com/wangeditor-next/wangeditor-next/issues"
+    "url": "https://github.com/wangeditor-next/wangEditor-next/issues"
   },
   "dependencies": {
     "@uppy/core": "^5.0.0",

--- a/packages/list-module/package.json
+++ b/packages/list-module/package.json
@@ -4,7 +4,7 @@
   "description": "wangEditor list module",
   "author": "cycleccc <2991205548@qq.com>",
   "type": "module",
-  "homepage": "https://github.com/wangeditor-next/wangeditor-next#readme",
+  "homepage": "https://github.com/wangeditor-next/wangEditor-next#readme",
   "license": "MIT",
   "types": "dist/list-module/src/index.d.ts",
   "main": "dist/index.js",
@@ -41,7 +41,7 @@
     "size-stats": "cross-env NODE_ENV=production:size_stats rollup -c rollup.config.js"
   },
   "bugs": {
-    "url": "https://github.com/wangeditor-next/wangeditor-next/issues"
+    "url": "https://github.com/wangeditor-next/wangEditor-next/issues"
   },
   "peerDependencies": {
     "@wangeditor-next/core": ">=1.9.2",

--- a/packages/plugin-attachment/package.json
+++ b/packages/plugin-attachment/package.json
@@ -38,7 +38,7 @@
     "size-stats": "cross-env NODE_ENV=production:size_stats rollup -c rollup.config.js"
   },
   "bugs": {
-    "url": "https://github.com/wangeditor-next/wangeditor-next/issues"
+    "url": "https://github.com/wangeditor-next/wangEditor-next/issues"
   },
   "peerDependencies": {
     "@wangeditor-next/editor": "5.7.13",

--- a/packages/plugin-ctrl-enter/package.json
+++ b/packages/plugin-ctrl-enter/package.json
@@ -38,7 +38,7 @@
     "size-stats": "cross-env NODE_ENV=production:size_stats rollup -c rollup.config.js"
   },
   "bugs": {
-    "url": "https://github.com/wangeditor-next/wangeditor-next/issues"
+    "url": "https://github.com/wangeditor-next/wangEditor-next/issues"
   },
   "peerDependencies": {
     "@wangeditor-next/editor": "5.7.13"

--- a/packages/plugin-float-image/README-en.md
+++ b/packages/plugin-float-image/README-en.md
@@ -4,11 +4,11 @@
 
 <br/>
 <br/>
-<a href="https://github.com/hqwlkj/wangEditor-plugin-float-image/releases">
-<img src="https://img.shields.io/github/v/release/hqwlkj/wangEditor-plugin-float-image" alt=""/>
+<a href="https://www.npmjs.com/package/@wangeditor-next/plugin-float-image">
+<img src="https://img.shields.io/npm/v/%40wangeditor-next%2Fplugin-float-image" alt=""/>
 </a>
-<a href="https://www.npmjs.com/package/wangeditor-plugin-float-image">
-<img src="https://img.shields.io/github/downloads/hqwlkj/wangEditor-plugin-float-image/total" alt=""/>
+<a href="https://www.npmjs.com/package/@wangeditor-next/plugin-float-image">
+<img src="https://img.shields.io/npm/dm/%40wangeditor-next%2Fplugin-float-image" alt=""/>
 </a>
 
 ## Introduction
@@ -35,7 +35,7 @@ npm i @wangeditor-next/plugin-float-image
 
 ```js
 import { Boot } from '@wangeditor-next/editor'
-import floatImageModule from 'wangeditor-plugin-float-image'
+import floatImageModule from '@wangeditor-next/plugin-float-image'
 
 // Register
 // You should register this before create editor, and register only once (not repeatedly).
@@ -92,4 +92,4 @@ Support i18n.
 
 ## LICENSE
 
-[MIT](https://github.com/hqwlkj/wangEditor-plugin-float-image/blob/master/LICENSE)
+[MIT](https://github.com/wangeditor-next/wangEditor-next/blob/master/LICENSE)

--- a/packages/plugin-float-image/README.md
+++ b/packages/plugin-float-image/README.md
@@ -4,11 +4,11 @@
 
 <br/>
 <br/>
-<a href="https://github.com/hqwlkj/wangEditor-plugin-float-image/releases">
-<img src="https://img.shields.io/github/v/release/hqwlkj/wangEditor-plugin-float-image" alt=""/>
+<a href="https://www.npmjs.com/package/@wangeditor-next/plugin-float-image">
+<img src="https://img.shields.io/npm/v/%40wangeditor-next%2Fplugin-float-image" alt=""/>
 </a>
-<a href="https://www.npmjs.com/package/wangeditor-plugin-float-image">
-<img src="https://img.shields.io/github/downloads/hqwlkj/wangEditor-plugin-float-image/total" alt=""/>
+<a href="https://www.npmjs.com/package/@wangeditor-next/plugin-float-image">
+<img src="https://img.shields.io/npm/dm/%40wangeditor-next%2Fplugin-float-image" alt=""/>
 </a>
 
 ## 介绍
@@ -35,7 +35,7 @@ npm i @wangeditor-next/plugin-float-image
 
 ```js
 import { Boot } from '@wangeditor-next/editor'
-import floatImageModule from 'wangeditor-plugin-float-image'
+import floatImageModule from '@wangeditor-next/plugin-float-image'
 
 // 注册。要在创建编辑器之前注册，且只能注册一次，不可重复注册。
 Boot.registerModule(floatImageModule)
@@ -91,4 +91,4 @@ const editorConfig: Partial<IEditorConfig> = {
 
 ## 许可证
 
-[MIT](https://github.com/hqwlkj/wangEditor-plugin-float-image/blob/master/LICENSE)
+[MIT](https://github.com/wangeditor-next/wangEditor-next/blob/master/LICENSE)

--- a/packages/plugin-float-image/package.json
+++ b/packages/plugin-float-image/package.json
@@ -38,7 +38,7 @@
     "size-stats": "cross-env NODE_ENV=production:size_stats rollup -c rollup.config.js"
   },
   "bugs": {
-    "url": "https://github.com/wangeditor-next/wangeditor-next/issues"
+    "url": "https://github.com/wangeditor-next/wangEditor-next/issues"
   },
   "peerDependencies": {
     "@wangeditor-next/editor": ">=5.7.8",

--- a/packages/plugin-formula/package.json
+++ b/packages/plugin-formula/package.json
@@ -38,7 +38,7 @@
     "size-stats": "cross-env NODE_ENV=production:size_stats rollup -c rollup.config.js"
   },
   "bugs": {
-    "url": "https://github.com/wangeditor-next/wangeditor-next/issues"
+    "url": "https://github.com/wangeditor-next/wangEditor-next/issues"
   },
   "devDependencies": {
     "@wangeditor-next-shared/rollup-config": "workspace:^",

--- a/packages/plugin-link-card/package.json
+++ b/packages/plugin-link-card/package.json
@@ -38,7 +38,7 @@
     "size-stats": "cross-env NODE_ENV=production:size_stats rollup -c rollup.config.js"
   },
   "bugs": {
-    "url": "https://github.com/wangeditor-next/wangeditor-next/issues"
+    "url": "https://github.com/wangeditor-next/wangEditor-next/issues"
   },
   "peerDependencies": {
     "@wangeditor-next/editor": ">=5.7.8",

--- a/packages/plugin-markdown/package.json
+++ b/packages/plugin-markdown/package.json
@@ -38,7 +38,7 @@
     "size-stats": "cross-env NODE_ENV=production:size_stats rollup -c rollup.config.js"
   },
   "bugs": {
-    "url": "https://github.com/wangeditor-next/wangeditor-next/issues"
+    "url": "https://github.com/wangeditor-next/wangEditor-next/issues"
   },
   "peerDependencies": {
     "@wangeditor-next/editor": ">=5.7.8",

--- a/packages/plugin-mention/README-en.md
+++ b/packages/plugin-mention/README-en.md
@@ -4,7 +4,7 @@
 
 ## Introduction
 
-[wangeditor-next](https://github.com/cycleccc/wangEditor-next) mention plugin, like `@James`.
+[wangeditor-next](https://github.com/wangeditor-next/wangEditor-next) mention plugin, like `@James`.
 
 ![](./_img/demo.png)
 
@@ -86,4 +86,3 @@ You will get a mention's HTML format like this. You need to `decodeURIComponent`
 ```html
 <span data-w-e-type="mention" data-w-e-is-void data-w-e-is-inline data-value="James" data-info="%7B%22x%22%3A10%7D">@James</span>
 ```
-

--- a/packages/plugin-mention/README.md
+++ b/packages/plugin-mention/README.md
@@ -4,7 +4,7 @@
 
 ## 介绍
 
-[wangeditor-next](https://github.com/cycleccc/wangEditor-next) mention 插件，如 `@张三`。
+[wangeditor-next](https://github.com/wangeditor-next/wangEditor-next) mention 插件，如 `@张三`。
 
 ![](./_img/demo.png)
 

--- a/packages/plugin-mention/package.json
+++ b/packages/plugin-mention/package.json
@@ -38,7 +38,7 @@
     "size-stats": "cross-env NODE_ENV=production:size_stats rollup -c rollup.config.js"
   },
   "bugs": {
-    "url": "https://github.com/wangeditor-next/wangeditor-next/issues"
+    "url": "https://github.com/wangeditor-next/wangEditor-next/issues"
   },
   "peerDependencies": {
     "@wangeditor-next/editor": ">=5.7.8",

--- a/packages/table-module/package.json
+++ b/packages/table-module/package.json
@@ -4,7 +4,7 @@
   "description": "wangEditor table module",
   "author": "cycleccc <2991205548@qq.com>",
   "type": "module",
-  "homepage": "https://github.com/wangeditor-next/wangeditor-next#readme",
+  "homepage": "https://github.com/wangeditor-next/wangEditor-next#readme",
   "license": "MIT",
   "types": "dist/table-module/src/index.d.ts",
   "main": "dist/index.js",
@@ -41,7 +41,7 @@
     "size-stats": "cross-env NODE_ENV=production:size_stats rollup -c rollup.config.js"
   },
   "bugs": {
-    "url": "https://github.com/wangeditor-next/wangeditor-next/issues"
+    "url": "https://github.com/wangeditor-next/wangEditor-next/issues"
   },
   "peerDependencies": {
     "@wangeditor-next/core": ">=1.9.2",

--- a/packages/upload-image-module/package.json
+++ b/packages/upload-image-module/package.json
@@ -4,7 +4,7 @@
   "description": "wangEditor upload-image module",
   "author": "cycleccc <2991205548@qq.com>",
   "type": "module",
-  "homepage": "https://github.com/wangeditor-next/wangeditor-next#readme",
+  "homepage": "https://github.com/wangeditor-next/wangEditor-next#readme",
   "license": "MIT",
   "types": "dist/upload-image-module/src/index.d.ts",
   "main": "dist/index.js",
@@ -41,7 +41,7 @@
     "size-stats": "cross-env NODE_ENV=production:size_stats rollup -c rollup.config.js"
   },
   "bugs": {
-    "url": "https://github.com/wangeditor-next/wangeditor-next/issues"
+    "url": "https://github.com/wangeditor-next/wangEditor-next/issues"
   },
   "peerDependencies": {
     "@uppy/core": "^2.0.3 || ^5.0.0",

--- a/packages/video-module/package.json
+++ b/packages/video-module/package.json
@@ -4,7 +4,7 @@
   "description": "wangEditor video module",
   "author": "cycleccc <2991205548@qq.com>",
   "type": "module",
-  "homepage": "https://github.com/wangeditor-next/wangeditor-next#readme",
+  "homepage": "https://github.com/wangeditor-next/wangEditor-next#readme",
   "license": "MIT",
   "types": "dist/video-module/src/index.d.ts",
   "main": "dist/index.js",
@@ -41,7 +41,7 @@
     "size-stats": "cross-env NODE_ENV=production:size_stats rollup -c rollup.config.js"
   },
   "bugs": {
-    "url": "https://github.com/wangeditor-next/wangeditor-next/issues"
+    "url": "https://github.com/wangeditor-next/wangEditor-next/issues"
   },
   "peerDependencies": {
     "@uppy/core": "^2.1.4 || ^5.0.0",

--- a/packages/yjs-for-react/package.json
+++ b/packages/yjs-for-react/package.json
@@ -4,7 +4,7 @@
   "description": "React specific components/utils for wangeditor-next-yjs.",
   "author": "cycleccc <2991205548@qq.com>",
   "type": "module",
-  "homepage": "https://github.com/wangeditor-next/wangeditor-next#readme",
+  "homepage": "https://github.com/wangeditor-next/wangEditor-next#readme",
   "license": "MIT",
   "types": "dist/yjs-for-react/src/index.d.ts",
   "main": "dist/index.js",
@@ -52,7 +52,7 @@
     "@wangeditor-next-shared/rollup-config": "workspace:^"
   },
   "bugs": {
-    "url": "https://github.com/wangeditor-next/wangeditor-next/issues"
+    "url": "https://github.com/wangeditor-next/wangEditor-next/issues"
   },
   "dependencies": {
     "use-sync-external-store": "^1.2.0",

--- a/packages/yjs-for-vue/package.json
+++ b/packages/yjs-for-vue/package.json
@@ -4,7 +4,7 @@
   "description": "Vue specific components/utils for wangeditor-next-yjs.",
   "author": "wbccb",
   "type": "module",
-  "homepage": "https://github.com/wangeditor-next/wangeditor-next#readme",
+  "homepage": "https://github.com/wangeditor-next/wangEditor-next#readme",
   "license": "MIT",
   "types": "dist/yjs-for-vue/src/index.d.ts",
   "main": "dist/index.js",
@@ -51,7 +51,7 @@
     "@wangeditor-next-shared/rollup-config": "workspace:^"
   },
   "bugs": {
-    "url": "https://github.com/wangeditor-next/wangeditor-next/issues"
+    "url": "https://github.com/wangeditor-next/wangEditor-next/issues"
   },
   "dependencies": {
     "y-protocols": "^1.0.5"

--- a/packages/yjs/package.json
+++ b/packages/yjs/package.json
@@ -4,7 +4,7 @@
   "author": "cycleccc <2991205548@qq.com>",
   "type": "module",
   "description": "Yjs binding for wangeditor-next.",
-  "homepage": "https://github.com/wangeditor-next/wangeditor-next#readme",
+  "homepage": "https://github.com/wangeditor-next/wangEditor-next#readme",
   "keywords": [
     "slate",
     "wangEditor",
@@ -53,7 +53,7 @@
     "yjs": "^13.5.29"
   },
   "bugs": {
-    "url": "https://github.com/wangeditor-next/wangeditor-next/issues"
+    "url": "https://github.com/wangeditor-next/wangEditor-next/issues"
   },
   "dependencies": {
     "y-protocols": "^1.0.5"


### PR DESCRIPTION
## Summary

- update plugin-float-image README badges to use the published `@wangeditor-next/plugin-float-image` npm package
- replace stale package/repository links in root, editor, mention, package metadata, and demo files
- fix the root README downloads badge so it reports `@wangeditor-next/editor` downloads instead of `@wangeditor-next/core`
- normalize current GitHub repository links to `wangeditor-next/wangEditor-next` across packages/apps metadata

## Verification

- `rg` check confirms stale `hqwlkj/wangEditor-plugin-float-image`, `wangeditor-next-next`, old package-name references, and current lowercase repo links are gone from active README/package/app entries
- `git diff --check`
- parsed all `packages/**/package.json` and `apps/**/package.json`
- fetched updated badge and GitHub URLs and verified they return current values, including `@wangeditor-next/plugin-float-image` v2.0.8 and npm downloads

## Notes

- Documentation and package metadata only; no package behavior changed and no changeset is needed.
- Historical `CHANGELOG.md` links and explicit `wangeditor-next-v5` issue comments were left unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated badges, homepage/license links, and “report an issue” URLs across the main README and package READMEs to point to the current project locations.
  * Corrected installation commands and package import examples to use the current scoped package names.
  * Fixed/adjusted a few documentation link formats and small non-functional text/formatting issues.
* **Chores**
  * Refreshed package metadata URLs and demo navigation links to align with the updated repository targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->