### PR TITLE
fix(table): export numeric table height with unit

### DIFF
--- a/.changeset/fix-table-height-unit.md
+++ b/.changeset/fix-table-height-unit.md
@@ -1,0 +1,5 @@
+---
+"@wangeditor-next/table-module": patch
+---
+
+Fix table HTML export so numeric table heights include a CSS unit.

--- a/packages/editor/__tests__/create.test.ts
+++ b/packages/editor/__tests__/create.test.ts
@@ -235,6 +235,26 @@ describe('create editor and toolbar', () => {
     expect(exportedHtml).toContain('<colgroup contentEditable="false"><col width=120></col><col width=80></col></colgroup>')
   })
 
+  test('getHtml exports table height with a valid css unit', () => {
+    const html = `<table style="width: 240px;table-layout: fixed;height:93">
+      <tbody>
+        <tr><td>A</td><td>B</td></tr>
+        <tr><td>C</td><td>D</td></tr>
+      </tbody>
+    </table>`
+
+    const editor = customCreateEditor({ html })
+    const exportedHtml = editor.getHtml()
+
+    editor.setHtml(exportedHtml)
+    const roundTripHtml = editor.getHtml()
+
+    expect(exportedHtml).toContain('height:93px')
+    expect(exportedHtml).not.toContain('height:93"')
+    expect(roundTripHtml).toContain('height:93px')
+    expect(roundTripHtml).not.toContain('height:93"')
+  })
+
   test('class mode preserve-data policy keeps unknown token through setHtml/getHtml', () => {
     const html = '<p><span style="color: rgb(1, 2, 3);">hello</span></p>'
     const editor = customCreateEditor({

--- a/packages/table-module/__tests__/elem-to-html.test.ts
+++ b/packages/table-module/__tests__/elem-to-html.test.ts
@@ -183,6 +183,34 @@ describe('TableModule module', () => {
       )
     })
 
+    test('tableToHtmlConf should append px unit for numeric table height', () => {
+      const element = {
+        type: 'table',
+        width: 'auto',
+        height: 93,
+        children: [],
+      }
+      const res = tableToHtmlConf.elemToHtml(element, '<tr><td>123</td></tr>')
+
+      expect(res).toBe(
+        '<table style="width: auto;table-layout: fixed;height:93px"><tbody><tr><td>123</td></tr></tbody></table>',
+      )
+    })
+
+    test('tableToHtmlConf should fallback invalid table height to auto', () => {
+      const element = {
+        type: 'table',
+        width: 'auto',
+        height: 'invalid',
+        children: [],
+      }
+      const res = tableToHtmlConf.elemToHtml(element, '<tr><td>123</td></tr>')
+
+      expect(res).toBe(
+        '<table style="width: auto;table-layout: fixed;height:auto"><tbody><tr><td>123</td></tr></tbody></table>',
+      )
+    })
+
     test('tableToHtmlConf should avoid inline style in class mode', () => {
       const element = {
         type: 'table',
@@ -201,6 +229,26 @@ describe('TableModule module', () => {
         '<table class="w-e-table-layout-fixed" width="100%" height="60px" data-w-e-table-height="60px"><tbody><tr><td>123</td></tr></tbody></table>',
       )
       expect(res).not.toContain('style=')
+    })
+
+    test('tableToHtmlConf should append px unit for numeric table height in class mode', () => {
+      const element = {
+        type: 'table',
+        width: '100%',
+        height: 93,
+        children: [],
+      }
+      const mockEditor = {
+        getConfig() {
+          return { textStyleMode: 'class' }
+        },
+      } as any
+      const res = tableToHtmlConf.elemToHtml(element, '<tr><td>123</td></tr>', mockEditor)
+
+      expect(res).toBe(
+        '<table class="w-e-table-layout-fixed" width="100%" height="93px" data-w-e-table-height="93px"><tbody><tr><td>123</td></tr></tbody></table>',
+      )
+      expect(res).not.toContain('height="93"')
     })
 
     test('tableToHtmlConf should escape caption html', () => {

--- a/packages/table-module/src/module/elem-to-html.ts
+++ b/packages/table-module/src/module/elem-to-html.ts
@@ -10,6 +10,8 @@ import { TableCellElement, TableElement, TableRowElement } from './custom-types'
 
 type TableWidthExportMode = 'adaptive' | 'explicit'
 
+const CSS_LENGTH_WITH_UNIT_REGEXP = /^-?(?:\d+|\d*\.\d+)(?:px|em|rem|%|vh|vw|vmin|vmax|pt|pc|cm|mm|in|ch|ex|lh|rlh)$/i
+
 function escapeHtml(raw: string): string {
   return raw
     .replace(/&/g, '&amp;')
@@ -57,6 +59,26 @@ function getExportTableWidth(tableNode: TableElement, editor?: IDomEditor): stri
   return 'auto'
 }
 
+function formatTableHeight(height: TableElement['height'] | string = 'auto'): string {
+  const heightValue = `${height || ''}`.trim()
+
+  if (!heightValue || heightValue === 'auto') {
+    return 'auto'
+  }
+
+  const numericHeight = Number(heightValue)
+
+  if (Number.isFinite(numericHeight)) {
+    return `${numericHeight}px`
+  }
+
+  if (CSS_LENGTH_WITH_UNIT_REGEXP.test(heightValue)) {
+    return heightValue
+  }
+
+  return 'auto'
+}
+
 function tableToHtml(elemNode: Element, childrenHtml: string, editor?: IDomEditor): string {
   const tableNode = elemNode as TableElement
   const { columnWidths, caption, height = 'auto' } = tableNode
@@ -70,17 +92,17 @@ function tableToHtml(elemNode: Element, childrenHtml: string, editor?: IDomEdito
   const colgroupStr = cols ? `<colgroup contentEditable="false">${cols}</colgroup>` : ''
   const exportedWidth = getExportTableWidth(tableNode, editor)
   const textStyleMode = getTextStyleMode(editor)
+  const exportedHeight = formatTableHeight(height)
 
   if (textStyleMode === 'class') {
     const widthAttr = exportedWidth ? ` width="${exportedWidth}"` : ''
-    const heightValue = String(height || '').trim()
-    const heightAttr = heightValue && heightValue !== 'auto' ? ` height="${heightValue}"` : ''
-    const heightDataAttr = heightValue ? ` data-w-e-table-height="${heightValue}"` : ''
+    const heightAttr = exportedHeight !== 'auto' ? ` height="${exportedHeight}"` : ''
+    const heightDataAttr = ` data-w-e-table-height="${exportedHeight}"`
 
     return `<table class="w-e-table-layout-fixed"${widthAttr}${heightAttr}${heightDataAttr}>${captionStr}${colgroupStr}<tbody>${childrenHtml}</tbody></table>`
   }
 
-  return `<table style="width: ${exportedWidth};table-layout: fixed;height:${height}">${captionStr}${colgroupStr}<tbody>${childrenHtml}</tbody></table>`
+  return `<table style="width: ${exportedWidth};table-layout: fixed;height:${exportedHeight}">${captionStr}${colgroupStr}<tbody>${childrenHtml}</tbody></table>`
 }
 
 function tableRowToHtml(elem: Element, childrenHtml: string, editor?: IDomEditor): string {


### PR DESCRIPTION
## Summary
- Normalize exported table height values so numeric heights become valid CSS lengths with `px`.
- Keep valid unit values and `auto`, and fall back invalid height tokens to `auto`.
- Add table-module serialization tests plus an editor getHtml/setHtml round-trip regression.

## Verification
- pnpm exec eslint packages/table-module/src/module/elem-to-html.ts packages/table-module/__tests__/elem-to-html.test.ts packages/editor/__tests__/create.test.ts --no-error-on-unmatched-pattern
- pnpm vitest run packages/table-module/__tests__/elem-to-html.test.ts packages/table-module/__tests__/parse-html.test.ts packages/editor/__tests__/create.test.ts
- pnpm turbo build --filter=@wangeditor-next/table-module --filter=@wangeditor-next/editor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Table heights now export with the correct CSS unit, so numeric values are saved as `px` instead of appearing without a unit.
  * Invalid or unsupported table height values now fall back to `auto` for more consistent HTML output.
  * HTML round-trips preserve the corrected table height format, including in class-based table rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->