### PR TITLE
fix(formula): keep long formula modal visible

### DIFF
--- a/.changeset/calm-formulas-align.md
+++ b/.changeset/calm-formulas-align.md
@@ -1,0 +1,6 @@
+---
+'@wangeditor-next/core': patch
+'@wangeditor-next/plugin-formula': patch
+---
+
+Keep long formulas and their edit modal within the editor's visible bounds.

--- a/packages/core/__tests__/menus/position.test.ts
+++ b/packages/core/__tests__/menus/position.test.ts
@@ -246,7 +246,7 @@ describe('menu position helpers', () => {
     expect(styleStore.left).toBe('60px')
   })
 
-  it('correctPosition adjusts bottom and right when element is out of bounds', async () => {
+  it('correctPosition adjusts bottom and right to the container bounds', async () => {
     const editor = {} as IDomEditor
 
     mockTextContainer({
@@ -262,7 +262,8 @@ describe('menu position helpers', () => {
     }
 
     const positionElem = {
-      offset: () => ({ top: -10, left: -5 }),
+      // The element is still inside the viewport, but 10px left of the editor container.
+      offset: () => ({ top: -10, left: 10 }),
       width: () => 30,
       height: () => 20,
       attr: () => 'bottom: 10px; right: 10px;',
@@ -279,6 +280,6 @@ describe('menu position helpers', () => {
     await flushPromises()
 
     expect(styleStore.bottom).toBe('0px')
-    expect(styleStore.right).toBe('5px')
+    expect(styleStore.right).toBe('0px')
   })
 })

--- a/packages/core/src/menus/helpers/position.ts
+++ b/packages/core/src/menus/helpers/position.ts
@@ -313,11 +313,11 @@ export function correctPosition(editor: IDomEditor, $positionElem: Dom7Array) {
 
     if (styleStr.indexOf('right') >= 0) {
       // 设置了 right ，则有可能超过 textContainer 的左边界
-      if (positionElemLeft < 0) {
+      if (relativeLeft < 0) {
         // 已超出了左边界
         const curRightStr = $positionElem.css('right')
         const curRight = parseInt(curRightStr.toString(), 10)
-        const newRight = curRight - Math.abs(positionElemLeft) // 保证左边界和 textContainer 对齐即可，右边界不管
+        const newRight = curRight - Math.abs(relativeLeft) // 保证左边界和 textContainer 对齐即可，右边界不管
 
         $positionElem.css('right', `${newRight}px`)
       }

--- a/packages/plugin-formula/__tests__/module.test.ts
+++ b/packages/plugin-formula/__tests__/module.test.ts
@@ -1,4 +1,11 @@
+import { DomEditor } from '@wangeditor-next/editor'
+import { afterEach, vi } from 'vitest'
+
 import module from '../src'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 describe('plugin-formula module', () => {
   it('exposes module config', () => {
@@ -8,5 +15,19 @@ describe('plugin-formula module', () => {
     expect(module.elemsToHtml?.length).toBeGreaterThan(0)
     expect(module.parseElemsHtml?.length).toBeGreaterThan(0)
     expect(module.menus?.length).toBeGreaterThan(0)
+  })
+
+  it('constrains wide formulas to the editor width', () => {
+    vi.spyOn(DomEditor, 'isNodeSelected').mockReturnValue(false)
+
+    const renderElem = module.renderElems?.[0].renderElem
+    const vnode = renderElem?.(
+      { type: 'formula', value: 'x', children: [{ text: '' }] },
+      null,
+      {} as any,
+    ) as any
+
+    expect(vnode.data.style.maxWidth).toBe('100%')
+    expect(vnode.data.style.overflowX).toBe('auto')
   })
 })

--- a/packages/plugin-formula/__tests__/register-custom-elem.test.ts
+++ b/packages/plugin-formula/__tests__/register-custom-elem.test.ts
@@ -15,4 +15,23 @@ describe('plugin-formula custom element', () => {
 
     elem.remove()
   })
+
+  it('wraps formula parse errors within the card width', () => {
+    const elem = document.createElement('w-e-formula-card')
+
+    elem.setAttribute('data-value', String.raw`\left`)
+    document.body.appendChild(elem)
+
+    const contentElem = elem.firstElementChild as HTMLElement
+    const errorElem = elem.querySelector('.katex-error') as HTMLElement
+
+    expect(elem.style.display).toBe('inline-block')
+    expect(elem.style.maxWidth).toBe('100%')
+    expect(contentElem.style.maxWidth).toBe('100%')
+    expect(errorElem.style.whiteSpace).toBe('normal')
+    expect(errorElem.style.overflowWrap).toBe('anywhere')
+    expect(errorElem.style.wordBreak).toBe('break-word')
+
+    elem.remove()
+  })
 })

--- a/packages/plugin-formula/src/module/render-elem.ts
+++ b/packages/plugin-formula/src/module/render-elem.ts
@@ -32,6 +32,8 @@ function renderFormula(elem: SlateElement, children: VNode[] | null, editor: IDo
       },
       style: {
         display: 'inline-block', // inline
+        maxWidth: '100%',
+        overflowX: 'auto',
         marginLeft: '3px',
         marginRight: '3px',
         border: selected // 选中/不选中，样式不一样

--- a/packages/plugin-formula/src/register-custom-elem/index.ts
+++ b/packages/plugin-formula/src/register-custom-elem/index.ts
@@ -44,7 +44,10 @@ class WangEditorFormulaCard extends HTMLElement {
     const document = this.ownerDocument || window.document
     const span = document.createElement('span')
 
+    this.style.display = 'inline-block'
+    this.style.maxWidth = '100%'
     span.style.display = 'inline-block'
+    span.style.maxWidth = '100%'
     this.appendChild(span)
     this.span = span
 
@@ -58,6 +61,14 @@ class WangEditorFormulaCard extends HTMLElement {
       throwOnError: false,
       output: 'htmlAndMathml',
     })
+
+    const errorElem = span.querySelector<HTMLElement>('.katex-error')
+
+    if (errorElem) {
+      errorElem.style.whiteSpace = 'normal'
+      errorElem.style.overflowWrap = 'anywhere'
+      errorElem.style.wordBreak = 'break-word'
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- constrain formula cards to the editor width and allow oversized formulas to scroll horizontally
- wrap KaTeX parse errors so invalid input cannot expand the editor indefinitely
- correct right-positioned modals against the editor container instead of the viewport
- add focused regression coverage and patch changesets for core and plugin-formula

Closes #920

## Verification

- `pnpm --filter @wangeditor-next/core test -- __tests__/menus/position.test.ts`
- `pnpm vitest run packages/plugin-formula/__tests__/module.test.ts packages/plugin-formula/__tests__/register-custom-elem.test.ts`
- ESLint on all changed TypeScript files
- `pnpm --filter @wangeditor-next/core build`
- `pnpm --filter @wangeditor-next/editor build`
- `pnpm --filter @wangeditor-next/plugin-formula build`
- Chromium: a 7293px formula stays inside a 960px formula container, and the 300px edit modal remains inside the editor bounds with no page errors

## Risk and rollback

- Long unbreakable formulas can now show a horizontal scrollbar instead of expanding beyond the editor.
- Modal correction changes only the existing right-positioned overflow branch and aligns it with the other container-relative checks.
- Rollback by reverting commit `ab84ea29`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Long formulas now stay within the editor’s visible width and can scroll horizontally when needed.
  - Formula editing cards are constrained to the editor boundaries.
  - Formula parsing errors now wrap correctly instead of overflowing the layout.
  - Improved positioning for menus near container edges, preventing them from extending beyond visible bounds.
- **Tests**
  - Added coverage for wide formulas, parse-error layouts, and boundary positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->