### PR TITLE
fix(table): 修复 setHtml 后表格行列拖拽

### DIFF
--- a/.changeset/quiet-tables-resize.md
+++ b/.changeset/quiet-tables-resize.md
@@ -1,0 +1,10 @@
+---
+'@wangeditor-next/table-module': patch
+'@wangeditor-next/editor': patch
+---
+
+Fix row and column resize handles after `setHtml` when the current selection is outside the table.
+
+Table measurement and resizer state now update the rendered table by its Slate path. Row dragging also
+keeps the target table path captured on pointer down, so imported tables expose working resize handles
+without first selecting a cell.

--- a/packages/table-module/__tests__/column-resize.test.ts
+++ b/packages/table-module/__tests__/column-resize.test.ts
@@ -7,6 +7,8 @@ import {
   handleCellBorderHighlight,
   handleCellBorderMouseDown,
   handleCellBorderVisible,
+  observerTableResize,
+  unObserveTableResize,
 } from '../src/module/column-resize'
 import { TableElement } from '../src/module/custom-types'
 
@@ -77,13 +79,68 @@ describe('column resize module', () => {
   })
 
   afterEach(() => {
+    unObserveTableResize()
     document.body.style.cursor = ''
     window.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+    vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
 
   test('getColumnWidthRatios returns normalized ratios', () => {
     expect(getColumnWidthRatios([100, 200, 100])).toEqual([0.25, 0.5, 0.25])
+  })
+
+  test('observerTableResize updates the rendered table when selection is outside it', () => {
+    const tableNode = createTable([80, 120, 100])
+    const container = document.createElement('div')
+    const table = document.createElement('table')
+    const row = document.createElement('tr')
+    let resizeCallback: ResizeObserverCallback | undefined
+    const observe = vi.fn()
+    const disconnect = vi.fn()
+
+    vi.spyOn(row, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      width: 320,
+      height: 40,
+      bottom: 40,
+      right: 320,
+      toJSON: () => ({}),
+    } as DOMRect)
+    table.appendChild(row)
+    container.appendChild(table)
+
+    vi.stubGlobal('ResizeObserver', class {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallback = callback
+      }
+
+      observe = observe
+
+      disconnect = disconnect
+    })
+    vi.spyOn(core.DomEditor, 'findPath').mockReturnValue([2] as slate.Path)
+    const setNodesSpy = vi.spyOn(slate.Transforms, 'setNodes').mockImplementation(() => {})
+
+    observerTableResize(editor, container, tableNode)
+    resizeCallback?.([
+      {
+        contentRect: {
+          width: 320,
+          height: 80,
+        } as DOMRectReadOnly,
+      } as ResizeObserverEntry,
+    ], {} as ResizeObserver)
+
+    expect(observe).toHaveBeenCalledWith(table)
+    expect(setNodesSpy).toHaveBeenCalledWith(
+      editor,
+      { scrollWidth: 320, height: 80, rowHeights: [40] },
+      { at: [2] },
+    )
   })
 
   test('handleCellBorderVisible does nothing when editor is disabled', () => {
@@ -109,14 +166,15 @@ describe('column resize module', () => {
     } as MouseEvent
 
     vi.spyOn(editor, 'isDisabled').mockReturnValue(false)
-    const setNodesSpy = vi.spyOn(slate.Transforms, 'setNodes')
+    vi.spyOn(core.DomEditor, 'findPath').mockReturnValue([2] as slate.Path)
+    const setNodesSpy = vi.spyOn(slate.Transforms, 'setNodes').mockImplementation(() => {})
 
     handleCellBorderVisible(editor, table, event, 300)
 
     expect(setNodesSpy).toHaveBeenCalledWith(
       editor,
       { isHoverCellBorder: true, resizingIndex: 0 },
-      { mode: 'highest' },
+      { at: [2] },
     )
   })
 
@@ -132,34 +190,38 @@ describe('column resize module', () => {
     } as MouseEvent
 
     vi.spyOn(editor, 'isDisabled').mockReturnValue(false)
-    const setNodesSpy = vi.spyOn(slate.Transforms, 'setNodes')
+    vi.spyOn(core.DomEditor, 'findPath').mockReturnValue([2] as slate.Path)
+    const setNodesSpy = vi.spyOn(slate.Transforms, 'setNodes').mockImplementation(() => {})
 
     handleCellBorderVisible(editor, table, event, 300)
 
     expect(setNodesSpy).toHaveBeenCalledWith(
       editor,
       { isHoverCellBorder: false, resizingIndex: -1 },
-      { mode: 'highest' },
+      { at: [2] },
     )
   })
 
   test('handleCellBorderHighlight toggles resizing state', () => {
-    const setNodesSpy = vi.spyOn(slate.Transforms, 'setNodes')
+    const table = createTable([80, 120, 100])
 
-    handleCellBorderHighlight(editor, { type: 'mouseenter' } as MouseEvent)
-    handleCellBorderHighlight(editor, { type: 'mouseleave' } as MouseEvent)
+    vi.spyOn(core.DomEditor, 'findPath').mockReturnValue([2] as slate.Path)
+    const setNodesSpy = vi.spyOn(slate.Transforms, 'setNodes').mockImplementation(() => {})
+
+    handleCellBorderHighlight(editor, table, { type: 'mouseenter' } as MouseEvent)
+    handleCellBorderHighlight(editor, table, { type: 'mouseleave' } as MouseEvent)
 
     expect(setNodesSpy).toHaveBeenNthCalledWith(
       1,
       editor,
       { isResizing: true },
-      { mode: 'highest' },
+      { at: [2] },
     )
     expect(setNodesSpy).toHaveBeenNthCalledWith(
       2,
       editor,
       { isResizing: false },
-      { mode: 'highest' },
+      { at: [2] },
     )
   })
 

--- a/packages/table-module/__tests__/column-resize.test.ts
+++ b/packages/table-module/__tests__/column-resize.test.ts
@@ -123,6 +123,7 @@ describe('column resize module', () => {
       disconnect = disconnect
     })
     vi.spyOn(core.DomEditor, 'findPath').mockReturnValue([2] as slate.Path)
+    vi.spyOn(slate.Editor, 'node').mockReturnValue([tableNode, [2]] as slate.NodeEntry<slate.Node>)
     const setNodesSpy = vi.spyOn(slate.Transforms, 'setNodes').mockImplementation(() => {})
 
     observerTableResize(editor, container, tableNode)
@@ -141,6 +142,56 @@ describe('column resize module', () => {
       { scrollWidth: 320, height: 80, rowHeights: [40] },
       { at: [2] },
     )
+  })
+
+  test('disconnects each table observer and ignores stale callbacks after setHtml', async () => {
+    const callbacks: ResizeObserverCallback[] = []
+    const disconnected: boolean[] = []
+
+    vi.stubGlobal('ResizeObserver', class {
+      private readonly index: number
+
+      constructor(callback: ResizeObserverCallback) {
+        this.index = callbacks.length
+        callbacks.push(callback)
+        disconnected.push(false)
+      }
+
+      observe() {}
+
+      disconnect() {
+        disconnected[this.index] = true
+      }
+    })
+
+    const table = createTable([60, 60, 60])
+    const editorWithTables = createEditor({
+      content: [
+        { type: 'paragraph', children: [{ text: 'before' }] },
+        table,
+        { type: 'paragraph', children: [{ text: 'between' }] },
+        createTable([80, 80, 80]),
+      ],
+    })
+
+    expect(callbacks).toHaveLength(2)
+
+    editorWithTables.setHtml('<p>one</p><p>replacement</p><p>three</p>')
+    await Promise.resolve()
+
+    expect(disconnected).toEqual([true, true])
+
+    callbacks[0]([
+      {
+        contentRect: { width: 480, height: 40 } as DOMRectReadOnly,
+      } as ResizeObserverEntry,
+    ], {} as ResizeObserver)
+    await Promise.resolve()
+
+    expect(editorWithTables.children[1]).toEqual({
+      type: 'paragraph',
+      children: [{ text: 'replacement' }],
+    })
   })
 
   test('handleCellBorderVisible does nothing when editor is disabled', () => {

--- a/packages/table-module/__tests__/row-resize.test.ts
+++ b/packages/table-module/__tests__/row-resize.test.ts
@@ -107,7 +107,7 @@ describe('Row Resize Module', () => {
       expect(transformsSpy).not.toHaveBeenCalled()
     })
 
-    test('should set hover state when mouse is on row border', () => {
+    test('should update the rendered table when selection is outside it', () => {
       const table = createTableWithRows([30, 40, 50])
 
       // Create a mock target with closest method
@@ -134,15 +134,20 @@ describe('Row Resize Module', () => {
         target: mockTarget,
       } as MouseEvent
 
+      setEditorSelection(editor, {
+        anchor: { path: [0, 0], offset: 0 },
+        focus: { path: [0, 0], offset: 0 },
+      })
       vi.spyOn(editor, 'isDisabled').mockReturnValue(false)
-      const transformsSpy = vi.spyOn(slate.Transforms, 'setNodes')
+      vi.spyOn(core.DomEditor, 'findPath').mockReturnValue([2])
+      const transformsSpy = vi.spyOn(slate.Transforms, 'setNodes').mockImplementation(() => {})
 
       handleRowBorderVisible(editor, table, mockEvent)
 
       expect(transformsSpy).toHaveBeenCalledWith(
         editor,
         { isHoverRowBorder: true, resizingRowIndex: 0 },
-        { mode: 'highest' },
+        { at: [2] },
       )
     })
 
@@ -158,42 +163,49 @@ describe('Row Resize Module', () => {
       } as MouseEvent
 
       vi.spyOn(editor, 'isDisabled').mockReturnValue(false)
-      const transformsSpy = vi.spyOn(slate.Transforms, 'setNodes')
+      vi.spyOn(core.DomEditor, 'findPath').mockReturnValue([2])
+      const transformsSpy = vi.spyOn(slate.Transforms, 'setNodes').mockImplementation(() => {})
 
       handleRowBorderVisible(editor, table, mockEvent)
 
       expect(transformsSpy).toHaveBeenCalledWith(
         editor,
         { isHoverRowBorder: false, resizingRowIndex: -1 },
-        { mode: 'highest' },
+        { at: [2] },
       )
     })
   })
 
   describe('handleRowBorderHighlight', () => {
     test('should set resizing state on mouseenter', () => {
+      const table = createTableWithRows([30, 40, 50])
       const mockEvent = { type: 'mouseenter' } as MouseEvent
-      const transformsSpy = vi.spyOn(slate.Transforms, 'setNodes')
 
-      handleRowBorderHighlight(editor, mockEvent)
+      vi.spyOn(core.DomEditor, 'findPath').mockReturnValue([2])
+      const transformsSpy = vi.spyOn(slate.Transforms, 'setNodes').mockImplementation(() => {})
+
+      handleRowBorderHighlight(editor, table, mockEvent)
 
       expect(transformsSpy).toHaveBeenCalledWith(
         editor,
         { isResizingRow: true },
-        { mode: 'highest' },
+        { at: [2] },
       )
     })
 
     test('should clear resizing state on mouseleave', () => {
+      const table = createTableWithRows([30, 40, 50])
       const mockEvent = { type: 'mouseleave' } as MouseEvent
-      const transformsSpy = vi.spyOn(slate.Transforms, 'setNodes')
 
-      handleRowBorderHighlight(editor, mockEvent)
+      vi.spyOn(core.DomEditor, 'findPath').mockReturnValue([2])
+      const transformsSpy = vi.spyOn(slate.Transforms, 'setNodes').mockImplementation(() => {})
+
+      handleRowBorderHighlight(editor, table, mockEvent)
 
       expect(transformsSpy).toHaveBeenCalledWith(
         editor,
         { isResizingRow: false },
-        { mode: 'highest' },
+        { at: [2] },
       )
     })
   })
@@ -231,12 +243,9 @@ describe('Row Resize Module', () => {
       tableDom.appendChild(innerTable)
 
       vi.spyOn(editor, 'getMenuConfig').mockReturnValue({ minRowHeight: 35 } as any)
-      vi.spyOn(slate.Editor, 'nodes').mockReturnValue((function* () {
-        yield [table, [0]] as slate.NodeEntry<slate.Node>
-      }()))
-      vi.spyOn(core.DomEditor, 'getSelectedNodeByType').mockReturnValue(table as any)
+      vi.spyOn(slate.Editor, 'node').mockReturnValue([table, [2]] as slate.NodeEntry<slate.Node>)
       vi.spyOn(core.DomEditor, 'toDOMNode').mockReturnValue(tableDom)
-      vi.spyOn(core.DomEditor, 'findPath').mockReturnValue([0])
+      vi.spyOn(core.DomEditor, 'findPath').mockReturnValue([2])
       const setNodesSpy = vi.spyOn(slate.Transforms, 'setNodes').mockImplementation(() => {})
 
       handleRowBorderMouseDown(editor, table)
@@ -255,7 +264,7 @@ describe('Row Resize Module', () => {
       expect(setNodesSpy).toHaveBeenCalledWith(
         editor,
         { height: 65 } as TableRowElement,
-        { at: [0, 1] },
+        { at: [2, 1] },
       )
 
       window.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
@@ -271,10 +280,7 @@ describe('Row Resize Module', () => {
       const tableDom = document.createElement('div')
 
       vi.spyOn(editor, 'getMenuConfig').mockReturnValue({ minRowHeight: 45 } as any)
-      vi.spyOn(slate.Editor, 'nodes').mockReturnValue((function* () {
-        yield [table, [0]] as slate.NodeEntry<slate.Node>
-      }()))
-      vi.spyOn(core.DomEditor, 'getSelectedNodeByType').mockReturnValue(table as any)
+      vi.spyOn(slate.Editor, 'node').mockReturnValue([table, [0]] as slate.NodeEntry<slate.Node>)
       vi.spyOn(core.DomEditor, 'toDOMNode').mockReturnValue(tableDom)
       vi.spyOn(core.DomEditor, 'findPath').mockReturnValue([0])
       const setNodesSpy = vi.spyOn(slate.Transforms, 'setNodes').mockImplementation(() => {})
@@ -321,10 +327,7 @@ describe('Row Resize Module', () => {
       tableDom.appendChild(innerTable)
 
       vi.spyOn(editor, 'getMenuConfig').mockReturnValue({ minRowHeight: 30 } as any)
-      vi.spyOn(slate.Editor, 'nodes').mockReturnValue((function* () {
-        yield [table, [0]] as slate.NodeEntry<slate.Node>
-      }()))
-      vi.spyOn(core.DomEditor, 'getSelectedNodeByType').mockReturnValue(table as any)
+      vi.spyOn(slate.Editor, 'node').mockReturnValue([table, [0]] as slate.NodeEntry<slate.Node>)
       vi.spyOn(core.DomEditor, 'toDOMNode').mockReturnValue(tableDom)
       vi.spyOn(core.DomEditor, 'findPath').mockReturnValue([0])
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
@@ -383,7 +386,8 @@ describe('Row Resize Module', () => {
       } as MouseEvent
 
       vi.spyOn(editor, 'isDisabled').mockReturnValue(false)
-      const transformsSpy = vi.spyOn(slate.Transforms, 'setNodes')
+      vi.spyOn(core.DomEditor, 'findPath').mockReturnValue([2])
+      const transformsSpy = vi.spyOn(slate.Transforms, 'setNodes').mockImplementation(() => {})
 
       handleRowBorderVisible(editor, table, hoverEvent)
 
@@ -391,7 +395,7 @@ describe('Row Resize Module', () => {
       expect(transformsSpy).toHaveBeenCalledWith(
         editor,
         { isHoverRowBorder: true, resizingRowIndex: 0 },
-        { mode: 'highest' },
+        { at: [2] },
       )
 
       // 模拟鼠标按下
@@ -400,12 +404,12 @@ describe('Row Resize Module', () => {
       // 模拟鼠标进入高亮状态
       const enterEvent = { type: 'mouseenter' } as MouseEvent
 
-      handleRowBorderHighlight(editor, enterEvent)
+      handleRowBorderHighlight(editor, table, enterEvent)
 
       expect(transformsSpy).toHaveBeenCalledWith(
         editor,
         { isResizingRow: true },
-        { mode: 'highest' },
+        { at: [2] },
       )
     })
   })

--- a/packages/table-module/src/module/column-resize.ts
+++ b/packages/table-module/src/module/column-resize.ts
@@ -9,6 +9,7 @@ import {
 
 import $ from '../utils/dom'
 import { TableElement } from './custom-types'
+import { setTableNodeProps } from './helpers'
 
 /** *
  * 计算 cell border 距离 table 左侧距离
@@ -55,7 +56,11 @@ function getTableRowHeights(table: Element): number[] {
   })
 }
 
-export function observerTableResize(editor: IDomEditor, elm: Node | undefined) {
+export function observerTableResize(
+  editor: IDomEditor,
+  elm: Node | undefined,
+  elemNode: SlateElement,
+) {
   if (isHTMLElememt(elm)) {
     const table = elm.querySelector('table')
 
@@ -64,14 +69,14 @@ export function observerTableResize(editor: IDomEditor, elm: Node | undefined) {
         const rowHeights = getTableRowHeights(table)
 
         // 当非拖动引起的宽度变化，需要调整 columnWidths
-        Transforms.setNodes(
+        setTableNodeProps(
           editor,
+          elemNode,
           {
             scrollWidth: contentRect.width,
             height: contentRect.height,
             rowHeights,
-          } as TableElement,
-          { mode: 'highest' },
+          },
         )
       })
       resizeObserver.observe(table)
@@ -328,10 +333,10 @@ export function handleCellBorderVisible(
 
     if (clientX > rect.x + 5 && clientX < rect.x + rect.width - 5) {
       if (isHoverCellBorder) {
-        Transforms.setNodes(
+        setTableNodeProps(
           editor,
+          elemNode,
           { isHoverCellBorder: false, resizingIndex: -1 } as TableElement,
-          { mode: 'highest' },
         )
       }
       return
@@ -358,10 +363,10 @@ export function handleCellBorderVisible(
         ) {
           // 节流，防止多次引起Transforms.setNodes重绘
           if (resizingIndex === i) { return }
-          Transforms.setNodes(
+          setTableNodeProps(
             editor,
+            elemNode,
             { isHoverCellBorder: true, resizingIndex: i } as TableElement,
-            { mode: 'highest' },
           )
           return
         }
@@ -371,9 +376,7 @@ export function handleCellBorderVisible(
 
   // 鼠标移出时，重置
   if (isHoverCellBorder === true) {
-    Transforms.setNodes(editor, { isHoverCellBorder: false, resizingIndex: -1 } as TableElement, {
-      mode: 'highest',
-    })
+    setTableNodeProps(editor, elemNode, { isHoverCellBorder: false, resizingIndex: -1 })
   }
 }
 
@@ -381,11 +384,15 @@ export function handleCellBorderVisible(
  * 设置 class highlight
  * 将 render-cell.tsx 拖动功能迁移至 div.column-resize
  */
-export function handleCellBorderHighlight(editor: IDomEditor, e: MouseEvent) {
+export function handleCellBorderHighlight(
+  editor: IDomEditor,
+  elemNode: SlateElement,
+  e: MouseEvent,
+) {
   if (e.type === 'mouseenter') {
-    Transforms.setNodes(editor, { isResizing: true } as TableElement, { mode: 'highest' })
+    setTableNodeProps(editor, elemNode, { isResizing: true })
   } else {
-    Transforms.setNodes(editor, { isResizing: false } as TableElement, { mode: 'highest' })
+    setTableNodeProps(editor, elemNode, { isResizing: false })
   }
 }
 

--- a/packages/table-module/src/module/column-resize.ts
+++ b/packages/table-module/src/module/column-resize.ts
@@ -4,6 +4,7 @@ import {
   Editor,
   Element as SlateElement,
   Path,
+  PathRef,
   Transforms,
 } from 'slate'
 
@@ -44,7 +45,10 @@ export function getColumnWidthRatios(columnWidths: number[]) {
  * 监听 table 内部变化，如新增行、列，删除行列等操作，引起的高度变化。
  * ResizeObserver 需要即时释放，以免引起内存泄露
  */
-let resizeObserver: ResizeObserver | null = null
+const resizeObserverMap = new Map<Element, {
+  observer: ResizeObserver
+  tablePathRef: PathRef
+}>()
 
 function getTableRowHeights(table: Element): number[] {
   const tableRows = Array.from(table.querySelectorAll('tr'))
@@ -56,6 +60,27 @@ function getTableRowHeights(table: Element): number[] {
   })
 }
 
+function disconnectTableResizeObserver(elm: Element) {
+  const entry = resizeObserverMap.get(elm)
+
+  if (entry) {
+    entry.observer.disconnect()
+    entry.tablePathRef.unref()
+    resizeObserverMap.delete(elm)
+  }
+}
+
+export function unObserveTableResize(elm?: Node) {
+  if (isHTMLElememt(elm)) {
+    disconnectTableResizeObserver(elm)
+    return
+  }
+
+  for (const container of resizeObserverMap.keys()) {
+    disconnectTableResizeObserver(container)
+  }
+}
+
 export function observerTableResize(
   editor: IDomEditor,
   elm: Node | undefined,
@@ -65,29 +90,48 @@ export function observerTableResize(
     const table = elm.querySelector('table')
 
     if (table) {
-      resizeObserver = new ResizeObserver(([{ contentRect }]) => {
+      unObserveTableResize(elm)
+
+      let tablePathRef: PathRef
+
+      try {
+        tablePathRef = Editor.pathRef(editor, DomEditor.findPath(editor, elemNode))
+      } catch {
+        return
+      }
+
+      const observer = new ResizeObserver(([{ contentRect }]) => {
+        const tablePath = tablePathRef.current
+
+        if (tablePath === null) { return }
+
+        try {
+          const [node] = Editor.node(editor, tablePath)
+
+          if (Editor.isEditor(node) || !SlateElement.isElement(node) || node.type !== 'table') {
+            return
+          }
+        } catch {
+          return
+        }
+
         const rowHeights = getTableRowHeights(table)
 
         // 当非拖动引起的宽度变化，需要调整 columnWidths
-        setTableNodeProps(
+        Transforms.setNodes(
           editor,
-          elemNode,
           {
             scrollWidth: contentRect.width,
             height: contentRect.height,
             rowHeights,
-          },
+          } as TableElement,
+          { at: tablePath },
         )
       })
-      resizeObserver.observe(table)
-    }
-  }
-}
 
-export function unObserveTableResize() {
-  if (resizeObserver) {
-    resizeObserver?.disconnect()
-    resizeObserver = null
+      observer.observe(table)
+      resizeObserverMap.set(elm, { observer, tablePathRef })
+    }
   }
 }
 

--- a/packages/table-module/src/module/helpers.ts
+++ b/packages/table-module/src/module/helpers.ts
@@ -10,7 +10,6 @@ import { TableCellElement, TableElement } from './custom-types'
 
 /**
  * Update a rendered table by its own path instead of relying on the current selection.
- * Async DOM callbacks may retain a table node after setHtml replaces it, so stale paths are ignored.
  */
 export function setTableNodeProps(
   editor: IDomEditor,

--- a/packages/table-module/src/module/helpers.ts
+++ b/packages/table-module/src/module/helpers.ts
@@ -4,8 +4,27 @@
  */
 
 import { DomEditor, IDomEditor } from '@wangeditor-next/core'
+import { Element as SlateElement, Transforms } from 'slate'
 
 import { TableCellElement, TableElement } from './custom-types'
+
+/**
+ * Update a rendered table by its own path instead of relying on the current selection.
+ * Async DOM callbacks may retain a table node after setHtml replaces it, so stale paths are ignored.
+ */
+export function setTableNodeProps(
+  editor: IDomEditor,
+  tableNode: SlateElement,
+  props: Partial<TableElement>,
+) {
+  try {
+    const tablePath = DomEditor.findPath(editor, tableNode)
+
+    Transforms.setNodes(editor, props as TableElement, { at: tablePath })
+  } catch {
+    // The rendered table may have been removed before an async callback runs.
+  }
+}
 
 /**
  * 获取第一行所有 cells

--- a/packages/table-module/src/module/render-elem/render-table.tsx
+++ b/packages/table-module/src/module/render-elem/render-table.tsx
@@ -278,8 +278,8 @@ function renderTable(elemNode: SlateElement, children: VNode[] | null, editor: I
     {
       hook: {
         insert: ({ elm }: VNode) => observerTableResize(editor, elm, elemNode),
-        destroy: () => {
-          unObserveTableResize()
+        destroy: ({ elm }: VNode) => {
+          unObserveTableResize(elm)
         },
       },
     },

--- a/packages/table-module/src/module/render-elem/render-table.tsx
+++ b/packages/table-module/src/module/render-elem/render-table.tsx
@@ -224,8 +224,8 @@ function renderTable(elemNode: SlateElement, children: VNode[] | null, editor: I
                 }
                 style={{ height: `${columnResizerHeight}px` }}
                 on={{
-                  mouseenter: (e: MouseEvent) => handleCellBorderHighlight(editor, e),
-                  mouseleave: (e: MouseEvent) => handleCellBorderHighlight(editor, e),
+                  mouseenter: (e: MouseEvent) => handleCellBorderHighlight(editor, elemNode, e),
+                  mouseleave: (e: MouseEvent) => handleCellBorderHighlight(editor, elemNode, e),
                   mousedown: (_e: MouseEvent) => handleCellBorderMouseDown(editor, elemNode),
                 }}
               >
@@ -254,8 +254,8 @@ function renderTable(elemNode: SlateElement, children: VNode[] | null, editor: I
                 }
                 style={{ width: `${totalTableWidth}px` }}
                 on={{
-                  mouseenter: (e: MouseEvent) => handleRowBorderHighlight(editor, e),
-                  mouseleave: (e: MouseEvent) => handleRowBorderHighlight(editor, e),
+                  mouseenter: (e: MouseEvent) => handleRowBorderHighlight(editor, elemNode, e),
+                  mouseleave: (e: MouseEvent) => handleRowBorderHighlight(editor, elemNode, e),
                   mousedown: (_e: MouseEvent) => handleRowBorderMouseDown(editor, elemNode),
                 }}
               >
@@ -277,7 +277,7 @@ function renderTable(elemNode: SlateElement, children: VNode[] | null, editor: I
     'div',
     {
       hook: {
-        insert: ({ elm }: VNode) => observerTableResize(editor, elm),
+        insert: ({ elm }: VNode) => observerTableResize(editor, elm, elemNode),
         destroy: () => {
           unObserveTableResize()
         },

--- a/packages/table-module/src/module/row-resize.ts
+++ b/packages/table-module/src/module/row-resize.ts
@@ -1,10 +1,15 @@
 import { DomEditor, IDomEditor, isHTMLElememt } from '@wangeditor-next/core'
 import throttle from 'lodash.throttle'
-import { Editor, Element as SlateElement, Transforms } from 'slate'
+import {
+  Editor,
+  Element as SlateElement,
+  Path,
+  Transforms,
+} from 'slate'
 
-import { isOfType } from '../utils'
 import $ from '../utils/dom'
 import { TableElement, TableRowElement } from './custom-types'
+import { setTableNodeProps } from './helpers'
 
 /**
  * 计算行高度的比例
@@ -54,6 +59,7 @@ function getRowHeightsForResize(tableNode: TableElement): number[] {
 let isMouseDownForRowResize = false
 let clientYWhenMouseDown = 0
 let editorWhenMouseDownForRow: IDomEditor | null = null
+let tablePathWhenMouseDownForRow: Path | null = null
 const $window = $(window)
 
 /**
@@ -114,25 +120,43 @@ function calculateRowHeightsByBorderPosition(
 function onMouseMoveForRowHandler(event: Event) {
   if (!isMouseDownForRowResize) { return }
   if (editorWhenMouseDownForRow === null) { return }
+  if (tablePathWhenMouseDownForRow === null) { return }
   event.preventDefault()
 
   const { clientY } = event as MouseEvent
   const heightChange = clientY - clientYWhenMouseDown
 
-  const [[elemNode]] = Editor.nodes(editorWhenMouseDownForRow, {
-    match: isOfType(editorWhenMouseDownForRow, 'table'),
-  })
-  const tableNode = elemNode as TableElement
+  let tableNode: TableElement
+  let tablePath: Path
+
+  try {
+    const [node, path] = Editor.node(editorWhenMouseDownForRow, tablePathWhenMouseDownForRow)
+
+    if (Editor.isEditor(node) || !SlateElement.isElement(node) || node.type !== 'table') {
+      return
+    }
+
+    tableNode = node as TableElement
+    tablePath = path
+  } catch {
+    return
+  }
+
   const { resizingRowIndex = -1 } = tableNode
 
   // 优先使用 ResizeObserver 采集到的真实 DOM 行高
   const rowHeights = getRowHeightsForResize(tableNode)
 
   let adjustRowHeights: number[]
-  const selectedTableNode = DomEditor.getSelectedNodeByType(editorWhenMouseDownForRow, 'table') as TableElement
-  const tableDom = DomEditor.toDOMNode(editorWhenMouseDownForRow, selectedTableNode)
+  let tableDom: HTMLElement | null = null
 
-  const tableElement = tableDom.querySelector('.table')
+  try {
+    tableDom = DomEditor.toDOMNode(editorWhenMouseDownForRow, tableNode)
+  } catch {
+    tableDom = null
+  }
+
+  const tableElement = tableDom?.querySelector('.table')
 
   if (tableElement) {
     const tableRect = tableElement.getBoundingClientRect()
@@ -150,10 +174,7 @@ function onMouseMoveForRowHandler(event: Event) {
   }
 
   // 直接更新对应行元素的高度
-  const currentTableNode = DomEditor.getSelectedNodeByType(editorWhenMouseDownForRow, 'table') as TableElement
-
-  if (currentTableNode && resizingRowIndex >= 0 && resizingRowIndex < adjustRowHeights.length) {
-    const tablePath = DomEditor.findPath(editorWhenMouseDownForRow, currentTableNode)
+  if (resizingRowIndex >= 0 && resizingRowIndex < adjustRowHeights.length) {
     const rowPath = [...tablePath, resizingRowIndex]
 
     try {
@@ -172,8 +193,15 @@ function onMouseMoveForRowHandler(event: Event) {
 const onMouseMoveForRowThrottled = throttle(onMouseMoveForRowHandler, 100)
 
 function onMouseUpForRow(_event: Event) {
+  // Preserve the final movement when mouseup arrives before the throttle interval elapses.
+  if (isMouseDownForRowResize) {
+    onMouseMoveForRowThrottled.flush()
+  }
+  onMouseMoveForRowThrottled.cancel()
+
   isMouseDownForRowResize = false
   editorWhenMouseDownForRow = null
+  tablePathWhenMouseDownForRow = null
   document.body.style.cursor = ''
 
   // 解绑事件
@@ -216,11 +244,10 @@ export function handleRowBorderVisible(
         ) {
           // 节流，防止多次引起Transforms.setNodes重绘
           if (resizingRowIndex === i) { return }
-          Transforms.setNodes(
-            editor,
-            { isHoverRowBorder: true, resizingRowIndex: i } as TableElement,
-            { mode: 'highest' },
-          )
+          setTableNodeProps(editor, elemNode, {
+            isHoverRowBorder: true,
+            resizingRowIndex: i,
+          })
           return
         }
       }
@@ -229,8 +256,9 @@ export function handleRowBorderVisible(
 
   // 鼠标移出时，重置
   if (isHoverRowBorder === true) {
-    Transforms.setNodes(editor, { isHoverRowBorder: false, resizingRowIndex: -1 } as TableElement, {
-      mode: 'highest',
+    setTableNodeProps(editor, elemNode, {
+      isHoverRowBorder: false,
+      resizingRowIndex: -1,
     })
   }
 }
@@ -238,17 +266,27 @@ export function handleRowBorderVisible(
 /**
  * 设置行拖拽高亮
  */
-export function handleRowBorderHighlight(editor: IDomEditor, e: MouseEvent) {
+export function handleRowBorderHighlight(
+  editor: IDomEditor,
+  elemNode: SlateElement,
+  e: MouseEvent,
+) {
   if (e.type === 'mouseenter') {
-    Transforms.setNodes(editor, { isResizingRow: true } as TableElement, { mode: 'highest' })
+    setTableNodeProps(editor, elemNode, { isResizingRow: true })
   } else {
-    Transforms.setNodes(editor, { isResizingRow: false } as TableElement, { mode: 'highest' })
+    setTableNodeProps(editor, elemNode, { isResizingRow: false })
   }
 }
 
-export function handleRowBorderMouseDown(editor: IDomEditor, _elemNode: SlateElement) {
+export function handleRowBorderMouseDown(editor: IDomEditor, elemNode: SlateElement) {
   if (isMouseDownForRowResize) { return }
   editorWhenMouseDownForRow = editor
+
+  try {
+    tablePathWhenMouseDownForRow = DomEditor.findPath(editor, elemNode)
+  } catch {
+    tablePathWhenMouseDownForRow = null
+  }
 }
 
 function onMouseDownForRow(event: Event) {

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -1005,86 +1005,131 @@ test.describe('Basic Editor', () => {
       `)
     })
 
+    await page.locator('[data-testid="editor-textarea"] p').last().click()
+
     const metrics = await page.evaluate(() => {
       const table = document.querySelector('[data-testid="editor-textarea"] table.table') as HTMLTableElement | null
-      const firstCol = table?.querySelector('col') as HTMLTableColElement | null
+      const firstCell = table?.querySelector('tr > :first-child') as HTMLTableCellElement | null
 
-      if (!table || !firstCol) {
+      if (!table || !firstCell) {
         throw new Error('table not ready')
       }
 
       table.scrollIntoView({ block: 'center', inline: 'nearest' })
-      const tableRect = table.getBoundingClientRect()
-      const firstColWidth = Number(firstCol.getAttribute('width') || 0)
+      const firstCellRect = firstCell.getBoundingClientRect()
 
-      if (!Number.isFinite(firstColWidth) || firstColWidth <= 0) {
+      if (!Number.isFinite(firstCellRect.width) || firstCellRect.width <= 0) {
         throw new Error('first column width is invalid')
       }
 
       return {
-        borderX: tableRect.left + firstColWidth,
-        borderY: tableRect.top + tableRect.height / 2,
-        beforeWidth: firstColWidth,
+        borderX: firstCellRect.right,
+        borderY: firstCellRect.top + firstCellRect.height / 2,
+        beforeWidth: firstCellRect.width,
       }
     })
 
-    await page.locator('[data-testid="editor-textarea"] p').last().click()
-    await page.evaluate(() => {
-      const editor = (window as any).wangEditorExampleBridge?.editor
-      const tableNode = editor?.children?.find((n: any) => n?.type === 'table')
+    await page.mouse.move(metrics.borderX, metrics.borderY)
 
-      if (!tableNode) {
-        throw new Error('table node not found')
-      }
+    const firstResizeHandle = page.locator('.column-resizer .resizer-line-hotzone').first()
 
-      // 在 e2e 中直接设置索引，稳定触发列拖拽逻辑
-      tableNode.resizingIndex = 0
-    })
+    await expect(firstResizeHandle).toHaveClass(/visible/)
+    await firstResizeHandle.hover()
+    await expect(firstResizeHandle).toHaveClass(/highlight/)
 
-    await page.evaluate(({ borderX, borderY }) => {
-      const hotzone = document.querySelector('.column-resizer .resizer-line-hotzone') as HTMLElement | null
-
-      if (!hotzone) {
-        throw new Error('resize hotzone not found')
-      }
-
-      hotzone.dispatchEvent(new MouseEvent('mousedown', {
-        bubbles: true,
-        cancelable: true,
-        clientX: borderX,
-        clientY: borderY,
-      }))
-      window.dispatchEvent(new MouseEvent('mousemove', {
-        bubbles: true,
-        cancelable: true,
-        clientX: borderX + 60,
-        clientY: borderY,
-      }))
-      window.dispatchEvent(new MouseEvent('mouseup', {
-        bubbles: true,
-        cancelable: true,
-        clientX: borderX + 60,
-        clientY: borderY,
-      }))
-    }, {
-      borderX: metrics.borderX,
-      borderY: metrics.borderY,
-    })
+    await page.mouse.down()
+    await page.mouse.move(metrics.borderX + 60, metrics.borderY)
+    await page.mouse.up()
     await page.waitForTimeout(150)
 
     const afterWidth = await page.evaluate(() => {
-      const firstCol = document.querySelector(
-        '[data-testid="editor-textarea"] table col',
-      ) as HTMLTableColElement | null
+      const firstCell = document.querySelector(
+        '[data-testid="editor-textarea"] table tr > :first-child',
+      ) as HTMLTableCellElement | null
 
-      if (!firstCol) {
-        throw new Error('first table col not found')
+      if (!firstCell) {
+        throw new Error('first table cell not found')
       }
 
-      return Number(firstCol.getAttribute('width') || 0)
+      return firstCell.getBoundingClientRect().width
     })
 
     expect(afterWidth).toBeGreaterThan(metrics.beforeWidth + 8)
+  })
+
+  test('row resize should work after setHtml without selecting table first', async ({ page }) => {
+    await page.evaluate(() => {
+      const editor = (window as any).wangEditorExampleBridge?.editor
+
+      if (!editor) {
+        throw new Error('editor not ready')
+      }
+
+      editor.setHtml(`
+        <p>before table</p>
+        <table style="width: 100%;">
+          <tbody>
+            <tr><td>row-1-a</td><td>row-1-b</td></tr>
+            <tr><td>row-2-a</td><td>row-2-b</td></tr>
+          </tbody>
+        </table>
+        <p>after table</p>
+      `)
+    })
+
+    await page.locator('[data-testid="editor-textarea"] p').last().click()
+
+    const metrics = await page.evaluate(() => {
+      const firstRow = document.querySelector(
+        '[data-testid="editor-textarea"] table.table tr',
+      ) as HTMLTableRowElement | null
+
+      if (!firstRow) {
+        throw new Error('first table row not found')
+      }
+
+      firstRow.scrollIntoView({ block: 'center', inline: 'nearest' })
+      const firstRowRect = firstRow.getBoundingClientRect()
+
+      if (!Number.isFinite(firstRowRect.height) || firstRowRect.height <= 0) {
+        throw new Error('first row height is invalid')
+      }
+
+      return {
+        borderX: firstRowRect.left + firstRowRect.width / 2,
+        borderY: firstRowRect.bottom,
+        beforeHeight: firstRowRect.height,
+      }
+    })
+
+    await page.mouse.move(metrics.borderX, metrics.borderY)
+
+    const firstResizeHandle = page.locator(
+      '.row-resizer .resizer-line-hotzone-horizontal',
+    ).first()
+
+    await expect(firstResizeHandle).toHaveClass(/visible/)
+    await firstResizeHandle.hover()
+    await expect(firstResizeHandle).toHaveClass(/highlight/)
+
+    await page.mouse.down()
+    await page.mouse.move(metrics.borderX, metrics.borderY + 40)
+    await page.mouse.up()
+    await page.waitForTimeout(150)
+
+    const afterHeight = await page.evaluate(() => {
+      const firstRow = document.querySelector(
+        '[data-testid="editor-textarea"] table.table tr',
+      ) as HTMLTableRowElement | null
+
+      if (!firstRow) {
+        throw new Error('first table row not found')
+      }
+
+      return firstRow.getBoundingClientRect().height
+    })
+
+    expect(afterHeight).toBeGreaterThan(metrics.beforeHeight + 8)
   })
 
   test('regression #574: cutting batch-selected table cells should keep table shape and only clear selected cells', async ({ page }) => {


### PR DESCRIPTION
按目标表格 Slate path 更新尺寸和悬浮状态，移除对当前选区的依赖。

补充行列单测、真实拖拽 E2E 及 patch changeset。

## Changes Overview

Fix table row and column resize handles after `editor.setHtml()` when the current selection is outside the imported table.

Previously, resize handles only became available after selecting a table cell or resizing another boundary.

## Implementation Approach

- Update resize and measurement state using the rendered table's Slate path instead of the current selection.
- Pass the target table node to row and column hover/highlight handlers.
- Capture the table path when row resizing starts and use it throughout the drag operation.
- Flush the final throttled row movement on mouseup.
- Preserve stale-node protection when asynchronous `ResizeObserver` callbacks run after `setHtml()`.

## Testing Done

- Ran all `@wangeditor-next/table-module` tests: 255 passed.
- Added unit coverage for row and column resize state when the selection is outside the table.
- Added Playwright tests covering real row and column handle visibility and dragging after `setHtml()`.
- Ran the two focused Playwright scenarios: 2 passed.
- Type-checked `table-module` and `editor`.
- Built `table-module` and `editor`.
- Ran ESLint on all affected files.

## Verification Steps

1. Open the default editor example.
2. Use `editor.setHtml()` to insert a table between two paragraphs.
3. Place the editor selection in the paragraph after the table.
4. Hover over a column boundary and confirm the column resize handle appears.
5. Drag the handle and confirm the column width changes.
6. Hover over a row boundary and confirm the row resize handle appears.
7. Drag the handle and confirm the row height changes.
8. Confirm neither operation requires selecting a table cell first.

## Additional Notes

- No public API or serialized table structure changes were introduced.
- The same selection-dependent behavior affected both row and column resizing, so both paths are fixed together.
- A patch [changeset](https://github.com/changesets/changesets) is included for `@wangeditor-next/table-module` and `@wangeditor-next/editor`.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Additional Notes

- PR #822 removed the selection dependency from the column drag phase by capturing the target table path on `mousedown`.
- This PR completes the fix by applying the target table path to measurement, hover/highlight state, and row resizing.

## Related Issues

- Refs #297
- Follow-up to #822




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed table row/column resize handle behavior after `setHtml` when the cursor is outside the table.
  - Enabled functional resize handles for imported tables without requiring a cell selection.
  - Improved resize updates and stability during drag, including preserving the final movement.
  - Enhanced table size, column widths, and row-height recalculations during resizing.

- **Tests**
  - Added/updated regression coverage for table resizing using realistic hover and drag interactions for both column and row cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->