### PR TITLE
fix(table): 修复调整热区阻断跨单元格拖选

### DIFF
--- a/.changeset/calm-cells-select.md
+++ b/.changeset/calm-cells-select.md
@@ -1,0 +1,7 @@
+---
+'@wangeditor-next/table-module': patch
+'@wangeditor-next/editor': patch
+---
+
+Keep cross-cell mouse selection anchored when wrapped table content or resize hotzones cause the
+browser's native range to collapse. Text selection inside a single cell remains unchanged.

--- a/packages/table-module/__tests__/cell-selection.test.ts
+++ b/packages/table-module/__tests__/cell-selection.test.ts
@@ -1,0 +1,132 @@
+import * as core from '@wangeditor-next/core'
+import { IDomEditor } from '@wangeditor-next/core'
+import * as slate from 'slate'
+import { createEditor, Transforms } from 'slate'
+
+import {
+  getCellDragSelectionRange,
+  handleCellDragSelectionMouseDown,
+  handleCellDragSelectionMouseMove,
+} from '../src/module/cell-selection'
+
+function createTableEditor(): IDomEditor {
+  const editor = createEditor()
+
+  editor.children = [
+    {
+      type: 'table',
+      children: [
+        {
+          type: 'table-row',
+          children: [
+            { type: 'table-cell', children: [{ text: 'first' }] },
+            { type: 'table-cell', children: [{ text: 'middle' }] },
+            { type: 'table-cell', children: [{ text: 'last' }] },
+          ],
+        },
+      ],
+    },
+  ]
+
+  const domEditor = editor as IDomEditor
+
+  domEditor.isDisabled = () => false
+  return domEditor
+}
+
+function createCellMouseEvent(
+  type: string,
+  target: HTMLElement,
+  init: MouseEventInit = {},
+): MouseEvent {
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    ...init,
+  })
+
+  Object.defineProperty(event, 'target', { value: target })
+  return event
+}
+
+describe('cell drag selection', () => {
+  afterEach(() => {
+    window.dispatchEvent(new MouseEvent('mouseup'))
+    vi.restoreAllMocks()
+  })
+
+  test('creates a forward range that includes both boundary cells', () => {
+    const editor = createTableEditor()
+
+    expect(getCellDragSelectionRange(editor, [0, 0, 0], [0, 0, 2])).toEqual({
+      anchor: { path: [0, 0, 0, 0], offset: 0 },
+      focus: { path: [0, 0, 2, 0], offset: 4 },
+    })
+  })
+
+  test('preserves the drag direction for a backward range', () => {
+    const editor = createTableEditor()
+
+    expect(getCellDragSelectionRange(editor, [0, 0, 2], [0, 0, 0])).toEqual({
+      anchor: { path: [0, 0, 2, 0], offset: 4 },
+      focus: { path: [0, 0, 0, 0], offset: 0 },
+    })
+  })
+
+  test('ignores an active drag after setHtml replaces the anchor table', () => {
+    const editor = createTableEditor()
+    const table = editor.children[0] as slate.Element
+    const firstCell = (table.children[0] as slate.Element).children[0] as slate.Element
+    const cellElement = document.createElement('td')
+    const anchorPathRef = slate.Editor.pathRef(editor, [0, 0, 0])
+    const select = vi.fn()
+
+    cellElement.dataset.blockType = 'table-cell'
+    editor.select = select
+    vi.spyOn(core.DomEditor, 'toSlateNode').mockReturnValue(firstCell)
+    vi.spyOn(core.DomEditor, 'findPath').mockReturnValue([0, 0, 0])
+    vi.spyOn(slate.Editor, 'pathRef').mockReturnValue(anchorPathRef)
+
+    handleCellDragSelectionMouseDown(
+      editor,
+      createCellMouseEvent('mousedown', cellElement, { button: 0 }),
+    )
+    // setHtml removes the old table before inserting the replacement document.
+    Transforms.removeNodes(editor, { at: [0] })
+    Transforms.insertNodes(
+      editor,
+      { type: 'paragraph', children: [{ text: 'replacement' }] } as slate.Element,
+      { at: [0] },
+    )
+
+    expect(anchorPathRef.current).toBeNull()
+
+    handleCellDragSelectionMouseMove(
+      editor,
+      createCellMouseEvent('mousemove', cellElement, { buttons: 1 }),
+    )
+
+    expect(select).not.toHaveBeenCalled()
+    expect(core.DomEditor.toSlateNode).toHaveBeenCalledTimes(1)
+  })
+
+  test('releases the anchor path reference when the drag stops', () => {
+    const editor = createTableEditor()
+    const table = editor.children[0] as slate.Element
+    const firstCell = (table.children[0] as slate.Element).children[0] as slate.Element
+    const cellElement = document.createElement('td')
+    const anchorPathRef = slate.Editor.pathRef(editor, [0, 0, 0])
+
+    cellElement.dataset.blockType = 'table-cell'
+    vi.spyOn(core.DomEditor, 'toSlateNode').mockReturnValue(firstCell)
+    vi.spyOn(core.DomEditor, 'findPath').mockReturnValue([0, 0, 0])
+    vi.spyOn(slate.Editor, 'pathRef').mockReturnValue(anchorPathRef)
+
+    handleCellDragSelectionMouseDown(
+      editor,
+      createCellMouseEvent('mousedown', cellElement, { button: 0 }),
+    )
+    window.dispatchEvent(new MouseEvent('mouseup'))
+
+    expect(anchorPathRef.current).toBeNull()
+  })
+})

--- a/packages/table-module/src/module/cell-selection.ts
+++ b/packages/table-module/src/module/cell-selection.ts
@@ -1,0 +1,174 @@
+import { DomEditor, IDomEditor } from '@wangeditor-next/core'
+import {
+  Editor,
+  Element as SlateElement,
+  Path,
+  PathRef,
+  Range,
+} from 'slate'
+
+/**
+ * Keeps one mouse drag isolated per editor. The PathRef invalidates the drag when setHtml removes
+ * its anchor table, while eventWindow ensures listeners are detached from the correct document.
+ */
+interface CellDragSelectionState {
+  anchorPathRef: PathRef
+  lastTargetPath: Path
+  isCrossCellSelecting: boolean
+  eventWindow: Window
+  stop: () => void
+}
+
+/** Editor-scoped storage prevents multiple editors from overwriting each other's active drag. */
+const EDITOR_TO_CELL_DRAG_SELECTION = new WeakMap<IDomEditor, CellDragSelectionState>()
+
+/** Releases DOM listeners and Slate path tracking together so neither outlives the drag. */
+function clearCellDragSelection(editor: IDomEditor) {
+  const state = EDITOR_TO_CELL_DRAG_SELECTION.get(editor)
+
+  if (!state) { return }
+
+  state.eventWindow.removeEventListener('mouseup', state.stop)
+  state.eventWindow.removeEventListener('blur', state.stop)
+  state.anchorPathRef.unref()
+  EDITOR_TO_CELL_DRAG_SELECTION.delete(editor)
+}
+
+/** Resolves the direct cell or the cell underneath a resize hotzone in the same DOM root. */
+function getCellElement(event: MouseEvent): HTMLElement | null {
+  if (event.target instanceof HTMLElement) {
+    const cell = event.target.closest<HTMLElement>('[data-block-type="table-cell"]')
+
+    if (cell) { return cell }
+  }
+
+  const target = event.target
+  const ownerDocument = target instanceof Node ? target.ownerDocument : null
+  const root = target instanceof Node ? target.getRootNode() : null
+  const pointLookupRoot = root && 'elementsFromPoint' in root
+    ? root as Document | ShadowRoot
+    : ownerDocument || document
+
+  // A visible resize hotzone may sit above the cell while an existing selection is extended.
+  return pointLookupRoot.elementsFromPoint(event.clientX, event.clientY)
+    .map(element => element.closest<HTMLElement>('[data-block-type="table-cell"]'))
+    .find((element): element is HTMLElement => element != null) || null
+}
+
+/** Uses the target document's window for iframe-safe listener registration and cleanup. */
+function getEventWindow(event: MouseEvent): Window {
+  const targetDocument = event.target instanceof Node ? event.target.ownerDocument : null
+
+  return event.view as Window | null || targetDocument?.defaultView || window
+}
+
+/** Maps the pointer target to a live Slate cell path, treating stale DOM nodes as no target. */
+function getCellPath(editor: IDomEditor, event: MouseEvent): Path | null {
+  const cellElement = getCellElement(event)
+
+  if (!cellElement) { return null }
+
+  try {
+    const cellNode = DomEditor.toSlateNode(editor, cellElement)
+
+    if (!SlateElement.isElement(cellNode) || DomEditor.getNodeType(cellNode) !== 'table-cell') {
+      return null
+    }
+
+    return DomEditor.findPath(editor, cellNode)
+  } catch {
+    // The DOM node can become stale if setHtml replaces the table during a drag.
+    return null
+  }
+}
+
+/** Cell paths end with row and column segments, so the remaining prefix identifies the table. */
+function isCellInSameTable(anchorPath: Path, targetPath: Path): boolean {
+  if (anchorPath.length < 3 || targetPath.length < 3) { return false }
+
+  return Path.equals(anchorPath.slice(0, -2), targetPath.slice(0, -2))
+}
+
+/** Builds a directional Slate range that includes both boundary cells completely. */
+export function getCellDragSelectionRange(
+  editor: IDomEditor,
+  anchorPath: Path,
+  targetPath: Path,
+): Range {
+  if (Path.compare(anchorPath, targetPath) <= 0) {
+    return {
+      anchor: Editor.start(editor, anchorPath),
+      focus: Editor.end(editor, targetPath),
+    }
+  }
+
+  return {
+    anchor: Editor.end(editor, anchorPath),
+    focus: Editor.start(editor, targetPath),
+  }
+}
+
+/** Records the starting cell without disturbing native text selection inside that cell. */
+export function handleCellDragSelectionMouseDown(editor: IDomEditor, event: MouseEvent) {
+  clearCellDragSelection(editor)
+
+  if (editor.isDisabled() || event.button !== 0) { return }
+
+  const anchorPath = getCellPath(editor, event)
+
+  if (!anchorPath) { return }
+
+  const stop = () => clearCellDragSelection(editor)
+  const eventWindow = getEventWindow(event)
+
+  // setHtml removes this PathRef, preventing an old drag from selecting replacement content.
+  EDITOR_TO_CELL_DRAG_SELECTION.set(editor, {
+    anchorPathRef: Editor.pathRef(editor, anchorPath),
+    lastTargetPath: anchorPath,
+    isCrossCellSelecting: false,
+    eventWindow,
+    stop,
+  })
+  eventWindow.addEventListener('mouseup', stop)
+  eventWindow.addEventListener('blur', stop)
+}
+
+/**
+ * Takes over only after the pointer crosses into another cell. This avoids Chrome collapsing the
+ * native range for wrapped cells while preserving ordinary text selection within one cell.
+ */
+export function handleCellDragSelectionMouseMove(editor: IDomEditor, event: MouseEvent) {
+  const state = EDITOR_TO_CELL_DRAG_SELECTION.get(editor)
+
+  if (!state) { return }
+
+  if ((event.buttons & 1) === 0) {
+    clearCellDragSelection(editor)
+    return
+  }
+
+  const anchorPath = state.anchorPathRef.current
+
+  // The anchor becomes null when setHtml replaces the table while the mouse is still pressed.
+  if (!anchorPath) {
+    clearCellDragSelection(editor)
+    return
+  }
+
+  const targetPath = getCellPath(editor, event)
+
+  if (!targetPath || !isCellInSameTable(anchorPath, targetPath)) { return }
+
+  const isAnchorCell = Path.equals(anchorPath, targetPath)
+
+  if (!state.isCrossCellSelecting && isAnchorCell) { return }
+
+  // Once cross-cell selection starts, suppress Chrome's collapsing native range on every move.
+  event.preventDefault()
+
+  if (Path.equals(state.lastTargetPath, targetPath)) { return }
+
+  state.isCrossCellSelecting = true
+  state.lastTargetPath = targetPath
+  editor.select(getCellDragSelectionRange(editor, anchorPath, targetPath))
+}

--- a/packages/table-module/src/module/render-elem/render-table.tsx
+++ b/packages/table-module/src/module/render-elem/render-table.tsx
@@ -14,6 +14,10 @@ import {
 import { h, jsx, VNode } from 'snabbdom'
 
 import {
+  handleCellDragSelectionMouseDown,
+  handleCellDragSelectionMouseMove,
+} from '../cell-selection'
+import {
   getColumnWidthRatios,
   handleCellBorderHighlight,
   handleCellBorderMouseDown,
@@ -136,6 +140,8 @@ function renderTable(elemNode: SlateElement, children: VNode[] | null, editor: I
           // @ts-ignore 如果用户行为是获取焦点输入文本时，需释放选区
           if (e.target.closest('[data-block-type="table-cell"]')) {
             TableCursor.unselect(editor)
+            // Capture the anchor before native selection updates can be interrupted by a hotzone.
+            handleCellDragSelectionMouseDown(editor, e)
           }
 
           // 是否需要定位到 table 内部
@@ -155,6 +161,8 @@ function renderTable(elemNode: SlateElement, children: VNode[] | null, editor: I
             editor.select(tableStart)
           } // 选中 table 内部
         },
+        // Resize hotzones are siblings of the table, so selection tracking belongs on the container.
+        mousemove: (e: MouseEvent) => handleCellDragSelectionMouseMove(editor, e),
       }}
     >
       <table

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -985,6 +985,111 @@ test.describe('Basic Editor', () => {
     expect(hoverAtDomBorder.resizingRowIndex).toBe(0)
   })
 
+  test('regression #935: first-row multi-cell selection should survive the row resize hotzone', async ({ page }) => {
+    await page.evaluate(() => {
+      const editor = (window as any).wangEditorExampleBridge?.editor
+
+      if (!editor) {
+        throw new Error('editor not ready')
+      }
+
+      editor.setHtml(`
+        <p>before table</p>
+        <table style="width: 839px; table-layout: fixed; height: 80px;">
+          <colgroup contenteditable="false">
+            <col width="65" />
+            <col width="75" />
+            <col width="75" />
+            <col width="84" />
+            <col width="75" />
+            <col width="64" />
+            <col width="64" />
+            <col width="64" />
+            <col width="64" />
+            <col width="64" />
+            <col width="64" />
+            <col width="81" />
+          </colgroup>
+          <tbody>
+            <tr style="height: 71px;">
+              <td><strong>需求编号</strong></td>
+              <td><strong>需求名称</strong></td>
+              <td><strong>测试状态</strong></td>
+              <td><strong>延迟提测天数</strong></td>
+              <td><strong>设计案例数</strong></td>
+              <td><strong>执行案例数</strong></td>
+              <td><strong>测试进度</strong></td>
+              <td><strong>缺陷总数</strong></td>
+              <td><strong>未决缺陷数</strong></td>
+              <td><strong>冒烟不通过次数</strong></td>
+              <td><strong>测试人员</strong></td>
+              <td><strong>开发人员</strong></td>
+            </tr>
+            <tr>
+              <td>REQ-DEMO-001</td><td>年度报表导出清晰度优化示例需求</td><td>测试中</td>
+              <td>1.2</td><td>9</td><td>8</td><td>88%</td><td>0</td><td>0</td><td>0</td>
+              <td>测试人员甲</td><td>开发人员甲</td>
+            </tr>
+            <tr>
+              <td>REQ-DEMO-002</td><td>电子文档模板更新与兼容性验证示例需求</td><td>测试中</td>
+              <td>未延期</td><td>18</td><td>15</td><td>83%</td><td>0</td><td>0</td><td>0</td>
+              <td>测试人员乙</td><td>开发人员乙</td>
+            </tr>
+            <tr>
+              <td>REQ-DEMO-003</td><td>业务流程重构与数据校验示例需求</td><td>测试中</td>
+              <td>0.1</td><td>30</td><td>18</td><td>60%</td><td>0</td><td>0</td><td>0</td>
+              <td>测试人员丙</td><td>开发人员丙</td>
+            </tr>
+          </tbody>
+        </table>
+        <p>after table</p>
+      `.replace(/>\s+</g, '><').trim())
+    })
+
+    const firstRowCells = page.locator(
+      '[data-testid="editor-textarea"] table tr:first-child td',
+    )
+
+    await expect(firstRowCells).toHaveCount(12)
+    await expect(firstRowCells.first()).toHaveText('需求编号')
+    await page.locator('[data-testid="editor-textarea"] p').first().click()
+    const firstCell = await firstRowCells.nth(0).boundingBox()
+    const lastCell = await firstRowCells.nth(4).boundingBox()
+
+    if (!firstCell || !lastCell) {
+      throw new Error('first-row cells are not visible')
+    }
+
+    await page.mouse.move(
+      firstCell.x + firstCell.width / 2,
+      firstCell.y + firstCell.height / 2,
+    )
+    await page.mouse.down()
+    await page.mouse.move(
+      lastCell.x + lastCell.width / 2,
+      lastCell.y + lastCell.height - 2,
+      { steps: 60 },
+    )
+    await page.mouse.up()
+
+    const selectionState = await page.evaluate(() => {
+      const editor = (window as any).wangEditorExampleBridge?.editor
+      const tableSelection = editor?.getTableSelection?.() || []
+
+      return {
+        cells: tableSelection.flat().length,
+        selectedCells: document.querySelectorAll(
+          '[data-testid="editor-textarea"] table .w-e-selected',
+        ).length,
+      }
+    })
+
+    expect(selectionState).toEqual({
+      cells: 5,
+      selectedCells: 5,
+    })
+  })
+
   test('regression #297: column resize should work after setHtml without selecting table first', async ({ page }) => {
     await page.evaluate(() => {
       const editor = (window as any).wangEditorExampleBridge?.editor


### PR DESCRIPTION
问题：setHtml 渲染固定列宽表格后，首行拖选经过行调整热区时，覆盖层会截断 mousemove，导致多单元格选区被清空。

修复：在表格容器跟踪拖选锚点，跨单元格后显式更新 Slate 选区；使用 PathRef 避免表格替换后复用失效路径。

## Changes Overview

Fix table multi-cell drag selection when the pointer crosses a resize hotzone, especially on the first row of tables loaded through `setHtml`.

Normal text selection within a single cell remains unchanged.

## Implementation Approach

- Capture the anchor cell on `mousedown`.
- Track drag state per editor using `WeakMap` and Slate `PathRef`.
- Handle `mousemove` on the table container because resize hotzones are siblings of the table.
- Resolve cells beneath resize overlays through the owning `Document` or `ShadowRoot`.
- Explicitly update the Slate range after the pointer crosses into another cell.
- Release event listeners and path references on `mouseup`, window blur, or invalidation caused by `setHtml`.

## Testing Done

- Added unit tests for:
  - Forward multi-cell selection.
  - Backward multi-cell selection.
  - Anchor invalidation after `setHtml` replaces the table.
  - PathRef cleanup when dragging stops.
- Added Chromium real-mouse E2E coverage for #935 using a sanitized 12-column fixed-layout table.
- Repeated the #935 E2E scenario 5 times successfully.
- Ran the complete table-module test suite: 260 tests passed.
- Ran table-module TypeScript checks and ESLint.
- Built the editor production bundle successfully.

## Verification Steps

1. Run the regression test:

   ```bash
   corepack pnpm exec playwright test tests/e2e/editor.spec.ts \
     --project=chromium \
     --grep "regression #935"
   ```

2. Alternatively, open the local Set HTML demo and load the sanitized reproduction HTML from #935.

3. In the first table row, drag from the middle of the first cell across several adjacent cells and finish near the row's bottom resize hotzone.

4. Confirm that all crossed cells remain selected.

5. Confirm that selecting text within a single cell still behaves as normal text selection.

## Additional Notes

- No public API changes.
- The fix is scoped to table multi-cell mouse selection.
- A patch changeset is included for `@wangeditor-next/table-module` and `@wangeditor-next/editor`.


## Checklist

- [x] I have created a [[changeset](https://github.com/changesets/changesets)](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Closes #935


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cross-cell table selection during mouse dragging.
  - Preserved selection when text wrapping or row/column resize areas cause native browser selection to collapse.
  - Handled table content replacement safely without leaving stale selections.

- **Tests**
  - Added coverage for forward and backward cell selection, table replacement, and resize-hotzone interactions.
  - Added an end-to-end regression test for selecting multiple cells in the first row.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->