### PR TITLE
fix(types): remove internal paths from declarations

### DIFF
--- a/.changeset/clean-public-types.md
+++ b/.changeset/clean-public-types.md
@@ -1,0 +1,10 @@
+---
+'@wangeditor-next/core': patch
+'@wangeditor-next/editor': patch
+'@wangeditor-next/list-module': patch
+'@wangeditor-next/table-module': patch
+'@wangeditor-next/yjs': patch
+---
+
+Remove monorepo-only imports from published declarations and expose subpath declaration mappings for
+TypeScript consumers using classic Node module resolution.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test-c:split": "node scripts/test-coverage-split.js",
     "dev": "cross-env FORCE_COLOR=1 turbo dev",
     "dev:sh": "sh scripts/build-base.sh dev",
-    "build": "cross-env FORCE_COLOR=1 turbo build",
+    "build": "cross-env FORCE_COLOR=1 turbo build && pnpm check:published-types",
     "typecheck": "node scripts/typecheck-all.js",
     "publish": "pnpm changeset publish",
     "prerelease": "pnpm build",
@@ -46,7 +46,8 @@
     "smoke:demo:yjs:react": "pnpm --filter @wangeditor-next/demo-yjs-react run smoke",
     "smoke:demo:yjs:vue3": "pnpm --filter @wangeditor-next/demo-yjs-vue3 run smoke",
     "smoke:demos": "pnpm exec turbo build --filter=@wangeditor-next/demo-react --filter=@wangeditor-next/demo-vue3 --filter=@wangeditor-next/demo-yjs-react --filter=@wangeditor-next/demo-yjs-vue3",
-    "check:editor:pack-size": "node scripts/check-editor-pack-size.js"
+    "check:editor:pack-size": "node scripts/check-editor-pack-size.js",
+    "check:published-types": "node scripts/check-published-types.js"
   },
   "workspaces": [
     "apps/*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,6 +7,13 @@
   "homepage": "https://github.com/wangeditor-next/wangEditor-next#readme",
   "license": "MIT",
   "types": "dist/core/src/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "upload": [
+        "dist/core/src/upload.d.ts"
+      ]
+    }
+  },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "exports": {

--- a/packages/core/src/config/interface.ts
+++ b/packages/core/src/config/interface.ts
@@ -3,8 +3,6 @@
  * @author wangfupeng
  */
 
-import type { ImageElement } from 'packages/basic-modules/src/modules/image/custom-types'
-import type { VideoElement } from 'packages/video-module/src/module/custom-types'
 import type {
   Descendant, Node, NodeEntry, Range,
 } from 'slate'
@@ -13,6 +11,31 @@ import type { IDomEditor } from '../editor/interface'
 import type { IMenuGroup } from '../menus/interface'
 import type { IUploadConfig } from '../upload/interface'
 import type { DOMElement } from '../utils/dom'
+
+type EmptyText = { text: '' }
+
+type ImageElement = {
+  type: 'image'
+  src: string
+  alt?: string
+  href?: string
+  width?: string
+  height?: string
+  style?: { width?: string; height?: string }
+  children: EmptyText[]
+}
+
+type VideoElement = {
+  type: 'video'
+  key?: string
+  src: string
+  poster?: string
+  align?: 'left' | 'center' | 'right'
+  width?: string
+  height?: string
+  style?: { width?: string; height?: string }
+  children: EmptyText[]
+}
 
 interface IHoverbarConf {
   // key 即 element type

--- a/packages/core/src/editor/interface.ts
+++ b/packages/core/src/editor/interface.ts
@@ -3,10 +3,9 @@
  * @author wangfupeng
  */
 
-import { NodeEntryWithContext } from '@wangeditor-next/table-module/src/utils'
 import ee from 'event-emitter'
 import {
-  Ancestor, Editor, Element, Location, Node,
+  Ancestor, Editor, Element, Location, Node, NodeEntry,
 } from 'slate'
 
 import {
@@ -16,6 +15,15 @@ import { IPositionStyle } from '../menus/interface'
 import { DOMElement } from '../utils/dom'
 
 export type ElementWithId = Element & { id: string }
+export type TableSelectionEntry = [
+  NodeEntry<Element & { type: unknown; rowSpan?: number; colSpan?: number; hidden?: boolean }>,
+  {
+    rtl: number
+    ltr: number
+    ttb: number
+    btt: number
+  },
+]
 type MoveOptions = Parameters<Editor['move']>[0]
 
 export type getMenuConfigReturnType<K> = K extends keyof IMenuConfig ? IMenuConfig[K] : ISingleMenuConfig
@@ -75,7 +83,7 @@ export interface IDomEditor extends Editor {
   move(distance: number, reverse?: boolean): void
   moveReverse: (distance: number) => void
   restoreSelection: () => void
-  getTableSelection?: () => NodeEntryWithContext[][] | null
+  getTableSelection?: () => TableSelectionEntry[][] | null
   getSelectionPosition: () => Partial<IPositionStyle>
   getNodePosition: (node: Node) => Partial<IPositionStyle>
   isSelectedAll: () => boolean

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,7 @@ export type {
   ClassStylePolicy,
   IClassStyleUnsupportedPayload,
   IEditorConfig,
+  ISingleMenuConfig,
   IToolbarConfig,
   IUploadImageConfig,
   IUploadVideoConfig,

--- a/packages/core/src/render/helper.ts
+++ b/packages/core/src/render/helper.ts
@@ -3,9 +3,7 @@
  * @author wangfupeng
  */
 
-import { ElementType } from 'packages/custom-types'
-
-export function genElemId(type:ElementType, id: string) {
+export function genElemId(type: string, id: string) {
   return `w-e-element-${type}-${id}`
 }
 

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -14,6 +14,16 @@
   "homepage": "https://github.com/wangeditor-next/wangEditor-next#readme",
   "license": "MIT",
   "types": "dist/editor/src/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "core": [
+        "dist/editor/src/core.d.ts"
+      ],
+      "upload": [
+        "dist/editor/src/upload.d.ts"
+      ]
+    }
+  },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "exports": {

--- a/packages/editor/src/Boot.ts
+++ b/packages/editor/src/Boot.ts
@@ -11,6 +11,7 @@ import type {
   IPreParseHtmlConf,
   IRegisterMenuConf,
   IRenderElemConf,
+  ISingleMenuConfig,
   IToolbarConfig,
   ParseStyleHtmlFnType,
   RenderStyleFnType,
@@ -28,7 +29,6 @@ import {
   registerStyleHandler,
   registerStyleToHtmlHandler,
 } from '@wangeditor-next/core'
-import type { ISingleMenuConfig } from 'packages/core/src/config/interface'
 
 import registerModule from './register-builtin-modules/register'
 

--- a/packages/list-module/src/utils/maps.ts
+++ b/packages/list-module/src/utils/maps.ts
@@ -4,6 +4,6 @@
  */
 
 import { IDomEditor } from '@wangeditor-next/core'
-import { Element as SlateElement } from 'slate'
+import { BaseElement } from 'slate'
 
-export const ELEM_TO_EDITOR = new WeakMap<SlateElement, IDomEditor>()
+export const ELEM_TO_EDITOR = new WeakMap<BaseElement, IDomEditor>()

--- a/packages/table-module/src/module/menu/CellProperty.ts
+++ b/packages/table-module/src/module/menu/CellProperty.ts
@@ -1,5 +1,5 @@
 import { IButtonMenu, IDomEditor, t } from '@wangeditor-next/core'
-import { Editor } from 'slate'
+import { Editor, NodeEntry } from 'slate'
 
 import { CELL_PROPERTY_SVG } from '../../constants/svg'
 import { isOfType } from '../../utils'
@@ -27,7 +27,7 @@ class CellProperty extends TableProperty implements IButtonMenu {
     'verticalAlign',
   ]
 
-  getModalContentNode(editor: IDomEditor) {
+  getModalContentNode(editor: IDomEditor): NodeEntry {
     const [node] = Editor.nodes(editor, {
       match: isOfType(editor, 'td'),
     })

--- a/packages/table-module/src/module/menu/TableProperty.ts
+++ b/packages/table-module/src/module/menu/TableProperty.ts
@@ -4,7 +4,9 @@
  */
 
 import { IButtonMenu, IDomEditor, t } from '@wangeditor-next/core'
-import { Editor, Transforms } from 'slate'
+import {
+  Editor, NodeEntry, Transforms,
+} from 'slate'
 
 import {
   CLEAN_SVG,
@@ -366,7 +368,7 @@ class TableProperty implements IButtonMenu {
     // 此处空着即可
   }
 
-  getModalContentNode(editor: IDomEditor) {
+  getModalContentNode(editor: IDomEditor): NodeEntry {
     const [node] = Editor.nodes(editor, {
       match: isOfType(editor, 'table'),
     })

--- a/packages/table-module/src/module/weak-maps.ts
+++ b/packages/table-module/src/module/weak-maps.ts
@@ -1,9 +1,9 @@
-import { Editor, Element } from 'slate'
+import { BaseEditor, BaseElement } from 'slate'
 
 import { NodeEntryWithContext } from '../utils'
 
 /** Weak reference between the `Editor` and the selected elements */
-export const EDITOR_TO_SELECTION = new WeakMap<Editor, NodeEntryWithContext[][]>()
+export const EDITOR_TO_SELECTION = new WeakMap<BaseEditor, NodeEntryWithContext[][]>()
 
 /** Weak reference between the `Editor` and a set of the selected elements */
-export const EDITOR_TO_SELECTION_SET = new WeakMap<Editor, WeakSet<Element>>()
+export const EDITOR_TO_SELECTION_SET = new WeakMap<BaseEditor, WeakSet<BaseElement>>()

--- a/packages/table-module/src/module/with-selection.ts
+++ b/packages/table-module/src/module/with-selection.ts
@@ -1,5 +1,5 @@
 import {
-  Editor, Element, Operation, Path, Range,
+  BaseElement, Editor, Element, Operation, Path, Range,
 } from 'slate'
 
 import {
@@ -143,7 +143,7 @@ export function withSelection<T extends Editor>(editor: T) {
       }
 
       const selected: NodeEntryWithContext[][] = []
-      const selectedSet = new WeakSet<Element>()
+      const selectedSet = new WeakSet<BaseElement>()
 
       for (let x = start.x; x <= end.x && x < filled.length; x += 1) {
         if (!filled[x]) { continue }

--- a/packages/yjs/src/applyToYjs/node/insertNode.ts
+++ b/packages/yjs/src/applyToYjs/node/insertNode.ts
@@ -1,5 +1,6 @@
-import { CustomElement } from 'packages/custom-types'
-import { InsertNodeOperation, Node, Text } from 'slate'
+import {
+  Element, InsertNodeOperation, Node, Text,
+} from 'slate'
 import * as Y from 'yjs'
 
 import { slateElementToYText } from '../../utils/convert'
@@ -13,5 +14,5 @@ export function insertNode(sharedRoot: Y.XmlText, slateRoot: Node, op: InsertNod
     return yParent.insert(textRange.start, op.node.text, getProperties(op.node))
   }
 
-  yParent.insertEmbed(textRange.start, slateElementToYText(op.node as CustomElement))
+  yParent.insertEmbed(textRange.start, slateElementToYText(op.node as Element))
 }

--- a/packages/yjs/src/applyToYjs/node/mergeNode.ts
+++ b/packages/yjs/src/applyToYjs/node/mergeNode.ts
@@ -1,6 +1,5 @@
-import { BaseElement } from 'packages/custom-types'
 import {
-  MergeNodeOperation, Node, Path, Text,
+  Element, MergeNodeOperation, Node, Path, Text,
 } from 'slate'
 import * as Y from 'yjs'
 
@@ -35,7 +34,7 @@ export function mergeNode(sharedRoot: Y.XmlText, slateRoot: Node, op: MergeNodeO
       throw new Error('Path points to Y.Text but not a Slate text node.')
     }
 
-    const targetProps = getProperties(slateTarget as BaseElement)
+    const targetProps = getProperties(slateTarget as Element)
     const prevSiblingProps = getProperties(prevSibling)
     const unsetProps = Object.keys(targetProps).reduce((acc, key) => {
       const prevSiblingHasProp = key in prevSiblingProps

--- a/packages/yjs/src/utils/convert.ts
+++ b/packages/yjs/src/utils/convert.ts
@@ -1,4 +1,3 @@
-import { BaseElement } from 'packages/custom-types'
 import { Element, Node, Text } from 'slate'
 import * as Y from 'yjs'
 
@@ -31,7 +30,7 @@ export function slateNodesToInsertDelta(nodes: Node[]): InsertDelta {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    return { insert: slateElementToYText(node as BaseElement) }
+    return { insert: slateElementToYText(node as Element) }
   })
 }
 

--- a/scripts/check-published-types.js
+++ b/scripts/check-published-types.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs')
+const path = require('node:path')
+
+const rootDir = path.resolve(__dirname, '..')
+const packageDir = path.join(rootDir, 'packages')
+const declarationFiles = []
+const failures = []
+const forbiddenSpecifiers = [
+  {
+    pattern: /(?:from\s+|import\()['"]packages\//g,
+    reason: 'monorepo-only packages/ import',
+  },
+  {
+    pattern: /(?:from\s+|import\()['"]@wangeditor-next\/[^'"]+\/src\//g,
+    reason: 'package-internal src/ import',
+  },
+]
+
+function collectDeclarations(dir) {
+  if (!fs.existsSync(dir)) {
+    return
+  }
+
+  fs.readdirSync(dir, { withFileTypes: true }).forEach(entry => {
+    const fullPath = path.join(dir, entry.name)
+
+    if (entry.isDirectory()) {
+      collectDeclarations(fullPath)
+      return
+    }
+
+    if (entry.isFile() && entry.name.endsWith('.d.ts')) {
+      declarationFiles.push(fullPath)
+    }
+  })
+}
+
+fs.readdirSync(packageDir, { withFileTypes: true }).forEach(entry => {
+  if (!entry.isDirectory()) {
+    return
+  }
+  collectDeclarations(path.join(packageDir, entry.name, 'dist'))
+})
+
+if (declarationFiles.length === 0) {
+  throw new Error('No built declaration files found. Run package builds before this check.')
+}
+
+declarationFiles.forEach(filePath => {
+  const content = fs.readFileSync(filePath, 'utf8')
+
+  forbiddenSpecifiers.forEach(({ pattern, reason }) => {
+    pattern.lastIndex = 0
+    if (pattern.test(content)) {
+      failures.push(`${path.relative(rootDir, filePath)}: ${reason}`)
+    }
+  })
+})
+
+if (failures.length > 0) {
+  console.error('Published declaration check failed:')
+  failures.forEach(failure => console.error(`- ${failure}`))
+  process.exit(1)
+}
+
+console.log(`Published declaration check passed (${declarationFiles.length} files).`)


### PR DESCRIPTION
## 问题

v6.0.0 发布产物的声明文件包含 monorepo 内部 packages 路径和包内 src 路径，外部 TypeScript 项目无法解析这些类型。

## 修改

- 为公开 API 增加显式类型，消除推断出的内部路径
- 补齐 core/upload、editor/core、editor/upload 的 typesVersions
- 新增发布声明扫描并接入根构建
- 添加 core、editor、list-module、table-module、yjs patch Changeset

## 验证

- 受影响 5 个包顺序构建通过
- 受影响 5 个包 TypeScript 检查通过
- core: 302 tests passed
- editor: 23 tests passed
- list-module: 56 tests passed
- table-module: 260 tests passed
- yjs: 5 tests passed
- 扫描 785 个声明文件，无内部路径引用
- 外部 TypeScript 4.9 项目验证主入口及子路径导入通过

## 风险与回滚

风险集中在公开声明类型和子路径 types 映射，不改变运行时行为。若下游出现类型兼容问题，可回滚本 PR；声明扫描脚本也可独立移除。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved TypeScript type resolution for published packages and subpath imports.
  - Enhanced compatibility with projects using classic Node module resolution.
  - Removed internal references from published declaration files, making package types cleaner and more reliable.
  - Added clearer public typings for editor table selections, media elements, menus, and table-related APIs.
  - Expanded available exported types for package consumers.

- **Quality**
  - Added automated validation to ensure published declaration files remain consumable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->