### PR TITLE
docs(v6): define compatibility cleanup boundaries

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Check compatibility inventory
+        run: pnpm run check:compatibility
+
       # Full lint gate
       - name: Lint
         run: pnpm lint

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,5 +3,6 @@
 - [开发文档](./dev.md)
 - [plugin 包统一规范](./plugin-package-spec.md)
 - [class 模式与 CSP 配置](./class-style-mode.md)
+- [v6 兼容策略与清理边界](./v6-compatibility-policy.md)
 - [发布到 npm](./publish.md)
 - [加入研发团队](./join.md)

--- a/docs/v6-compatibility-inventory.json
+++ b/docs/v6-compatibility-inventory.json
@@ -1,0 +1,123 @@
+{
+  "schemaVersion": 1,
+  "entries": [
+    {
+      "id": "core-root-upload-exports",
+      "category": "public-api",
+      "package": "@wangeditor-next/core",
+      "paths": [
+        "packages/core/src/index.ts",
+        "packages/core/__tests__/upload/deprecated-export.test.ts"
+      ],
+      "behavior": "Keeps createUploader and createUppyUploader available from the core root entry.",
+      "status": "deprecated",
+      "removalMajor": 2,
+      "migration": "Import the functions from @wangeditor-next/core/upload."
+    },
+    {
+      "id": "core-toolbar-insert-keys-shapes",
+      "category": "public-api",
+      "package": "@wangeditor-next/core",
+      "paths": ["packages/core/src/config/interface.ts", "packages/core/src/menus/bar/Toolbar.ts"],
+      "behavior": "Accepts one insertKeys object or an array, with keys as a string or an array.",
+      "status": "retained",
+      "removalMajor": 2,
+      "migration": "Use an array of insertKeys entries and an array for each keys value."
+    },
+    {
+      "id": "core-editor-move-overload",
+      "category": "public-api",
+      "package": "@wangeditor-next/core",
+      "paths": [
+        "packages/core/src/editor/interface.ts",
+        "packages/core/src/editor/plugins/with-selection.ts"
+      ],
+      "behavior": "Accepts move(distance, reverse) in addition to Slate MoveOptions.",
+      "status": "retained",
+      "removalMajor": 2,
+      "migration": "Use editor.move({ distance, reverse })."
+    },
+    {
+      "id": "builtin-v4-v5-html-preparse",
+      "category": "stored-data",
+      "package": "@wangeditor-next/basic-modules",
+      "paths": [
+        "packages/basic-modules/src/modules/color/pre-parse-html.ts",
+        "packages/basic-modules/src/modules/font-size-family/pre-parse-html.ts",
+        "packages/basic-modules/src/modules/code-block/pre-parse-html.ts",
+        "packages/basic-modules/src/modules/todo/pre-parse-html.ts",
+        "packages/basic-modules/src/modules/indent/pre-parse-html.ts"
+      ],
+      "behavior": "Normalizes historical font, code, todo and indent HTML before parsing.",
+      "status": "retained",
+      "migration": "Keep historical HTML readable and preserve values through round trips."
+    },
+    {
+      "id": "list-legacy-json-types",
+      "category": "stored-data",
+      "package": "@wangeditor-next/list-module",
+      "paths": ["packages/list-module/src/module/plugin.ts"],
+      "behavior": "Normalizes numbered-list and bulleted-list nodes created by older editors.",
+      "status": "retained",
+      "migration": "Normalize loaded documents to the current list-item model without losing content."
+    },
+    {
+      "id": "upload-image-legacy-response-array",
+      "category": "stored-data",
+      "package": "@wangeditor-next/upload-image-module",
+      "paths": ["packages/upload-image-module/src/module/upload-images.ts"],
+      "behavior": "Accepts the historical array form of a successful upload response.",
+      "status": "retained",
+      "migration": "Backends should return one data object; existing array responses remain supported."
+    },
+    {
+      "id": "video-legacy-html",
+      "category": "stored-data",
+      "package": "@wangeditor-next/video-module",
+      "paths": ["packages/video-module/src/module/pre-parse-html.ts"],
+      "behavior": "Normalizes historical iframe and video attributes before parsing.",
+      "status": "retained",
+      "migration": "Keep historical video HTML readable and preserve media attributes."
+    },
+    {
+      "id": "table-legacy-html",
+      "category": "stored-data",
+      "package": "@wangeditor-next/table-module",
+      "paths": ["packages/table-module/src/module/pre-parse-html.ts"],
+      "behavior": "Normalizes historical table structure, widths and alignment before parsing.",
+      "status": "retained",
+      "migration": "Keep historical table HTML readable and verify width and alignment round trips."
+    },
+    {
+      "id": "editor-browser-polyfills",
+      "category": "runtime-environment",
+      "package": "@wangeditor-next/editor",
+      "paths": ["packages/editor/src/utils/browser-polyfill.ts"],
+      "behavior": "Provides globalThis and AggregateError fallbacks for supported browser environments.",
+      "status": "retained",
+      "migration": "Raise and publish the browser support baseline before removing fallbacks."
+    },
+    {
+      "id": "editor-node-ssr-polyfills",
+      "category": "runtime-environment",
+      "package": "@wangeditor-next/editor",
+      "paths": ["packages/editor/src/utils/node-polyfill.ts"],
+      "behavior": "Provides minimal browser globals when the editor is imported in Node or SSR.",
+      "status": "retained",
+      "migration": "Define the SSR import contract and verify supported frameworks before removal."
+    },
+    {
+      "id": "core-beforeinput-fallback",
+      "category": "runtime-environment",
+      "package": "@wangeditor-next/core",
+      "paths": [
+        "packages/core/src/text-area/event-handlers/beforeInput.ts",
+        "packages/core/src/text-area/event-handlers/keydown.ts",
+        "packages/core/src/text-area/event-handlers/keypress.ts"
+      ],
+      "behavior": "Uses keydown and keypress when beforeinput is absent or incomplete.",
+      "status": "retained",
+      "migration": "Raise the browser support baseline and verify IME behavior before removal."
+    }
+  ]
+}

--- a/docs/v6-compatibility-policy.md
+++ b/docs/v6-compatibility-policy.md
@@ -1,0 +1,49 @@
+# v6 兼容策略与清理边界
+
+`@wangeditor-next/editor@6` 的发布不代表 monorepo 内所有包都进入了同一个主版本。
+兼容代码由实际提供该行为的包负责，只有该包进入下一个主版本，才能删除已公开的旧 API。
+
+仓库使用 [`v6-compatibility-inventory.json`](./v6-compatibility-inventory.json) 记录已确认的兼容入口。
+修改清单后运行：
+
+```bash
+pnpm check:compatibility
+```
+
+## 分类
+
+| 分类                  | 含义                                       | 删除条件                                           |
+| --------------------- | ------------------------------------------ | -------------------------------------------------- |
+| `public-api`          | 仍在类型或运行时导出中公开的旧调用方式     | 已弃用、有迁移路径，且所属包进入清单指定的主版本   |
+| `stored-data`         | 读取历史 HTML、JSON 或服务端响应的转换逻辑 | 有数据迁移方案，并完成导入、导出和 round-trip 验证 |
+| `runtime-environment` | 浏览器、SSR 或事件能力差异的兜底           | 仓库先提高并公布运行环境基线，再完成目标环境验证   |
+
+`stored-data` 兼容不是待删除的普通技术债。即使编辑器 API 升级，用户已有内容仍可能长期包含旧格式。
+这类逻辑原则上保留；如果迁移到独立 legacy parser，也必须保持默认可读且不丢失。
+
+## 当前结论
+
+- `@wangeditor-next/core` 根入口的 `createUploader` 和 `createUppyUploader` 已弃用。新代码应从
+  `@wangeditor-next/core/upload` 导入，根入口最早在 `core@2` 删除。
+- `IToolbarConfig.insertKeys` 的单对象/字符串形式和 `IDomEditor.move(distance, reverse)` 仍是
+  `core@1` 的公开类型，不能在 `core@1.x` 静默删除。
+- v4/v5 HTML 预解析、旧 list JSON、旧上传响应和历史媒体/表格属性属于持久化数据兼容，
+  不能仅因为 `editor@6` 发布而删除。
+- 浏览器与 Node/SSR polyfill 的删除需要单独确定 browserslist 和 SSR 支持基线。
+
+完整路径和状态见兼容清单。
+
+## 变更流程
+
+1. 修改兼容代码前，先在清单中确认所有者包、分类和删除条件。
+2. 删除 `public-api` 前提供弃用周期、迁移说明和对应包的 major changeset。
+3. 修改 `stored-data` 时覆盖 `HTML -> Slate -> HTML`、`Slate -> HTML -> Slate`、
+   `setHtml(getHtml())` 和 `toHtml(parseHtml(html))` 中受影响的路径。
+4. 修改 `runtime-environment` 前更新支持基线，并在对应浏览器或 SSR 环境实测。
+5. PR 中运行 `pnpm check:compatibility`；新增兼容分支时同步更新清单。
+
+## 不应执行的清理
+
+- 不依据注释中出现“兼容”“旧版”等文字直接删除代码。
+- 不把 `editor` 的主版本当作所有 workspace 包的破坏性变更许可。
+- 不用一次性的 HTML 转换替代默认可读的历史数据支持，除非已提供可验证的数据迁移工具。

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "smoke:demo:yjs:vue3": "pnpm --filter @wangeditor-next/demo-yjs-vue3 run smoke",
     "smoke:demos": "pnpm exec turbo build --filter=@wangeditor-next/demo-react --filter=@wangeditor-next/demo-vue3 --filter=@wangeditor-next/demo-yjs-react --filter=@wangeditor-next/demo-yjs-vue3",
     "check:editor:pack-size": "node scripts/check-editor-pack-size.js",
+    "check:compatibility": "node scripts/check-compatibility-inventory.js",
     "check:published-types": "node scripts/check-published-types.js"
   },
   "workspaces": [

--- a/scripts/check-compatibility-inventory.js
+++ b/scripts/check-compatibility-inventory.js
@@ -1,0 +1,69 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+const rootDir = path.resolve(__dirname, '..')
+const inventoryPath = path.join(rootDir, 'docs/v6-compatibility-inventory.json')
+const inventory = JSON.parse(fs.readFileSync(inventoryPath, 'utf8'))
+const categories = new Set(['public-api', 'stored-data', 'runtime-environment'])
+const statuses = new Set(['deprecated', 'retained'])
+const errors = []
+const ids = new Set()
+
+if (inventory.schemaVersion !== 1) {
+  errors.push('schemaVersion must be 1')
+}
+
+if (!Array.isArray(inventory.entries) || inventory.entries.length === 0) {
+  errors.push('entries must be a non-empty array')
+}
+
+for (const [index, entry] of (inventory.entries || []).entries()) {
+  const label = entry.id || `entry #${index + 1}`
+
+  for (const field of ['id', 'category', 'package', 'behavior', 'status', 'migration']) {
+    if (typeof entry[field] !== 'string' || entry[field].trim() === '') {
+      errors.push(`${label}: ${field} must be a non-empty string`)
+    }
+  }
+
+  if (ids.has(entry.id)) {
+    errors.push(`${label}: id must be unique`)
+  }
+  ids.add(entry.id)
+
+  if (!categories.has(entry.category)) {
+    errors.push(`${label}: unsupported category ${entry.category}`)
+  }
+  if (!statuses.has(entry.status)) {
+    errors.push(`${label}: unsupported status ${entry.status}`)
+  }
+  if (
+    entry.category === 'public-api' &&
+    (!Number.isInteger(entry.removalMajor) || entry.removalMajor < 1)
+  ) {
+    errors.push(`${label}: public-api entries require a positive removalMajor`)
+  }
+  if (!Array.isArray(entry.paths) || entry.paths.length === 0) {
+    errors.push(`${label}: paths must be a non-empty array`)
+    continue
+  }
+
+  for (const relativePath of entry.paths) {
+    if (typeof relativePath !== 'string' || path.isAbsolute(relativePath)) {
+      errors.push(`${label}: paths must be relative strings`)
+      continue
+    }
+    if (!fs.existsSync(path.join(rootDir, relativePath))) {
+      errors.push(`${label}: missing path ${relativePath}`)
+    }
+  }
+}
+
+if (errors.length > 0) {
+  console.error(`Compatibility inventory check failed:\n- ${errors.join('\n- ')}`)
+  process.exitCode = 1
+} else {
+  process.stdout.write(
+    `Compatibility inventory check passed (${inventory.entries.length} entries).\n`
+  )
+}


### PR DESCRIPTION
## Summary

- define public API, stored-data, and runtime-environment compatibility boundaries after editor v6
- inventory 11 confirmed compatibility paths with owners, migration paths, and removal requirements
- validate the inventory in the existing unit-test workflow

## Why

The monorepo packages do not share one major version. editor@6 does not authorize removing public compatibility from core@1 or historical HTML/JSON readers from their owning packages. This PR records those boundaries so future cleanup is deliberate and verifiable.

No runtime compatibility path is removed. Historical content parsing remains unchanged.

## Validation

- pnpm check:compatibility
- pnpm exec eslint scripts/check-compatibility-inventory.js
- pnpm --filter @wangeditor-next/core test (41 files, 302 tests)
- pnpm exec turbo build --concurrency=1 (23/23 tasks)
- pnpm check:published-types (5,448 files)
- pnpm changeset status --since=origin/master (no packages to bump)

## Risk

Low. The only executable change validates a static JSON inventory and runs in CI. Runtime packages and published output are unchanged.

## Rollback

Revert this PR to remove the policy, inventory, package script, and CI step. No package or stored-data migration is required.

## Merge recommendation

可合并发版。This PR does not itself publish package changes and needs no changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on v6 compatibility strategy, cleanup boundaries, migration requirements, and validation procedures.
  * Added a compatibility inventory covering public APIs, stored data, and runtime environments.

* **Quality Improvements**
  * Added compatibility inventory validation, including required fields, valid categories, unique entries, and referenced paths.
  * Integrated the compatibility check into the unit test workflow for automated verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->