### PR TITLE
ci: add stable unit test required check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  unit-tests:
     name: Unit Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     strategy:
@@ -96,3 +96,12 @@ jobs:
           files: coverage/lcov.info
           disable_search: true
           verbose: true
+
+  test:
+    name: test
+    if: always()
+    needs: unit-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require all unit test jobs to pass
+        run: test "${{ needs.unit-tests.result }}" = 'success'


### PR DESCRIPTION
## Summary

- keep the Node 20 and Node 22 unit-test matrix unchanged
- add a stable check named test that depends on the complete matrix
- make the aggregate check run after failures or cancellations and report failure explicitly

## Why

The master branch protection requires a check named test. The matrix job currently publishes checks named Unit Test (Node 20.19.0) and Unit Test (Node 22.13.0), so release PR #938 remains blocked while waiting for a check that can never be created.

Using a stable aggregate check keeps branch protection independent from future Node matrix changes.

## Validation

- Prettier YAML check passed
- YAML parse passed with js-yaml
- git diff --check passed

No package is changed, so no Changeset is required.

## Risk

Low. Existing matrix jobs still execute the same commands. The new job only reports their aggregate result.

## Rollback

Revert this PR and update branch protection to require each matrix check name directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI test workflow reliability by ensuring the overall workflow fails when unit tests do not complete successfully.
  * Preserved matrix-based test execution and coverage reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->