### PR TITLE
feat(style-presets): add semantic custom styles

### DIFF
--- a/.changeset/modern-styles-flow.md
+++ b/.changeset/modern-styles-flow.md
@@ -1,0 +1,6 @@
+---
+'@wangeditor-next/plugin-style-presets': patch
+---
+
+Add an opt-in semantic style presets plugin with text and block scopes, stable HTML round trips,
+toolbar integration, command APIs, and business class mapping.

--- a/packages/editor/demo/custom-styles.html
+++ b/packages/editor/demo/custom-styles.html
@@ -107,7 +107,9 @@
     </div>
 
     <script src="https://unpkg.com/@wangeditor-next/editor@latest/dist/index.js"></script>
-    <script src="https://unpkg.com/@wangeditor-next/plugin-style-presets@latest/dist/index.js"></script>
+    <script
+      src="https://unpkg.com/@wangeditor-next/plugin-style-presets@latest/dist/index.js"
+    ></script>
     <script>
       const LANG = location.href.indexOf('lang=en') > 0 ? 'en' : 'zh-CN'
       const E = window.wangEditor
@@ -122,8 +124,7 @@
               callout: 'Callout',
               highlight: 'Highlight',
               lead: 'Lead paragraph',
-              missing:
-                'The style presets package is not published yet. Reload this page after its release.',
+              missing: 'The style presets package is not published yet. Reload after its release.',
               muted: 'Muted text',
               preview: 'Rendered content',
             }
@@ -157,9 +158,11 @@
             className: 'article-highlight',
           },
         ]
-        const initialHtml = `<p class="article-lead">Semantic styles keep content stable while themes change.</p>
-        <p>Select text or place the caret in a block, then choose a preset from the toolbar.</p>
-        <p><span class="article-muted">This text is rendered from a configured business class.</span></p>`
+        const initialHtml = [
+          '<p class="article-lead">Semantic styles stay stable across themes.</p>',
+          '<p>Select text or place the caret in a block, then choose a preset.</p>',
+          '<p><span class="article-muted">Imported from a configured business class.</span></p>',
+        ].join('\n')
         const htmlOutput = document.getElementById('editor-content-html')
         const contentView = document.getElementById('editor-content-view')
 

--- a/packages/editor/demo/custom-styles.html
+++ b/packages/editor/demo/custom-styles.html
@@ -1,0 +1,201 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>wangEditor custom styles</title>
+    <link
+      href="https://cdn.bootcdn.net/ajax/libs/normalize/8.0.1/normalize.min.css"
+      rel="stylesheet"
+    />
+    <link
+      href="https://unpkg.com/@wangeditor-next/editor@latest/dist/css/style.css"
+      rel="stylesheet"
+    />
+    <link href="./css/layout.css" rel="stylesheet" />
+    <style>
+      .article-lead {
+        color: #344054;
+        font-size: 20px;
+        line-height: 1.75;
+      }
+      .article-callout {
+        background: #f2f4f7;
+        border-left: 4px solid #175cd3;
+        color: #101828;
+        margin: 16px 0;
+        padding: 10px 14px;
+      }
+      .article-muted {
+        color: #667085;
+        font-size: 14px;
+      }
+      .article-highlight {
+        background: #fef0c7;
+        color: #93370d;
+        padding: 1px 3px;
+      }
+      .demo-section {
+        margin-top: 20px;
+      }
+      .demo-section h2 {
+        font-size: 16px;
+        margin: 0 0 8px;
+      }
+      #editor-content-html {
+        box-sizing: border-box;
+        font-family: monospace;
+        height: 140px;
+        resize: vertical;
+        width: 100%;
+      }
+      #editor-content-view {
+        border-top: 1px solid #e4e7ec;
+        min-height: 100px;
+        padding: 8px 0;
+      }
+      #plugin-status {
+        background: #fef3f2;
+        border-left: 4px solid #d92d20;
+        color: #912018;
+        padding: 10px 14px;
+      }
+      @media (max-width: 720px) {
+        .page-container {
+          display: block;
+        }
+        .page-left,
+        .page-right {
+          box-sizing: border-box;
+          width: 100%;
+        }
+        .page-left {
+          padding-bottom: 12px;
+        }
+        #editor-text-area {
+          height: 360px !important;
+        }
+      }
+    </style>
+    <script src="./js/custom-elem.js"></script>
+  </head>
+
+  <body>
+    <demo-nav title="wangEditor custom styles"></demo-nav>
+    <div class="page-container">
+      <div class="page-left">
+        <demo-menu></demo-menu>
+      </div>
+      <div class="page-right">
+        <p id="plugin-status" hidden></p>
+        <div style="border: 1px solid #ccc">
+          <div id="editor-toolbar" style="border-bottom: 1px solid #ccc"></div>
+          <div id="editor-text-area" style="height: 420px"></div>
+        </div>
+
+        <section class="demo-section">
+          <h2 id="html-title">HTML</h2>
+          <textarea id="editor-content-html" readonly></textarea>
+        </section>
+
+        <section class="demo-section">
+          <h2 id="preview-title">Rendered content</h2>
+          <div id="editor-content-view"></div>
+        </section>
+      </div>
+    </div>
+
+    <script src="https://unpkg.com/@wangeditor-next/editor@latest/dist/index.js"></script>
+    <script src="https://unpkg.com/@wangeditor-next/plugin-style-presets@latest/dist/index.js"></script>
+    <script>
+      const LANG = location.href.indexOf('lang=en') > 0 ? 'en' : 'zh-CN'
+      const E = window.wangEditor
+      const pluginExport = window.WangEditorStylePresetsPlugin
+      const stylePresetsModule = pluginExport?.default || pluginExport
+
+      E.i18nChangeLanguage(LANG)
+
+      const labels =
+        LANG === 'en'
+          ? {
+              callout: 'Callout',
+              highlight: 'Highlight',
+              lead: 'Lead paragraph',
+              missing:
+                'The style presets package is not published yet. Reload this page after its release.',
+              muted: 'Muted text',
+              preview: 'Rendered content',
+            }
+          : {
+              callout: '提示块',
+              highlight: '重点文字',
+              lead: '导语',
+              missing: '样式预设插件尚未发布，发布后刷新页面即可使用。',
+              muted: '辅助文字',
+              preview: '独立渲染效果',
+            }
+
+      document.getElementById('preview-title').textContent = labels.preview
+
+      if (!stylePresetsModule?.menus) {
+        const status = document.getElementById('plugin-status')
+
+        status.hidden = false
+        status.textContent = labels.missing
+      } else {
+        E.Boot.registerModule(stylePresetsModule)
+
+        const presets = [
+          { key: 'lead-paragraph', title: labels.lead, scope: 'block', className: 'article-lead' },
+          { key: 'callout', title: labels.callout, scope: 'block', className: 'article-callout' },
+          { key: 'muted-text', title: labels.muted, scope: 'text', className: 'article-muted' },
+          {
+            key: 'highlight',
+            title: labels.highlight,
+            scope: 'text',
+            className: 'article-highlight',
+          },
+        ]
+        const initialHtml = `<p class="article-lead">Semantic styles keep content stable while themes change.</p>
+        <p>Select text or place the caret in a block, then choose a preset from the toolbar.</p>
+        <p><span class="article-muted">This text is rendered from a configured business class.</span></p>`
+        const htmlOutput = document.getElementById('editor-content-html')
+        const contentView = document.getElementById('editor-content-view')
+
+        const editor = E.createEditor({
+          selector: '#editor-text-area',
+          html: initialHtml,
+          config: {
+            MENU_CONF: {
+              stylePreset: { presets },
+            },
+            onChange(editor) {
+              const html = editor.getHtml()
+
+              htmlOutput.value = html
+              contentView.innerHTML = html
+            },
+          },
+        })
+
+        E.createToolbar({
+          editor,
+          selector: '#editor-toolbar',
+          config: {
+            insertKeys: {
+              index: 4,
+              keys: ['stylePreset'],
+            },
+          },
+        })
+
+        const html = editor.getHtml()
+
+        htmlOutput.value = html
+        contentView.innerHTML = html
+        window.editor = editor
+      }
+    </script>
+  </body>
+</html>

--- a/packages/editor/demo/js/custom-elem.js
+++ b/packages/editor/demo/js/custom-elem.js
@@ -162,6 +162,10 @@ const MENU_CONF = [
     en: { text: 'Set HTML', link: './set-html.html?lang=en' },
   },
   {
+    'zh-CN': { text: '自定义样式', link: './custom-styles.html' },
+    en: { text: 'Custom styles', link: './custom-styles.html?lang=en' },
+  },
+  {
     'zh-CN': { text: '模拟腾讯文档', link: './like-qq-doc.html' },
     en: { text: 'Like QQ doc', link: './like-qq-doc.html?lang=en' },
   },

--- a/packages/plugin-style-presets/CHANGELOG.md
+++ b/packages/plugin-style-presets/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @wangeditor-next/plugin-style-presets

--- a/packages/plugin-style-presets/README-en.md
+++ b/packages/plugin-style-presets/README-en.md
@@ -1,0 +1,127 @@
+# wangEditor semantic style presets plugin
+
+[中文文档](./README.md)
+
+## Introduction
+
+`@wangeditor-next/plugin-style-presets` adds semantic text and block style presets to wangEditor v6.
+Documents persist stable preset keys while application CSS controls presentation, so themes can
+change without rewriting stored content.
+
+The plugin is opt-in. It does not change the existing toolbar, nodes, or HTML output by default.
+
+## Installation
+
+```shell
+pnpm add @wangeditor-next/plugin-style-presets
+```
+
+## Registration
+
+```ts
+import { Boot } from '@wangeditor-next/editor'
+import stylePresetsModule from '@wangeditor-next/plugin-style-presets'
+
+// Register once before creating any editor.
+Boot.registerModule(stylePresetsModule)
+```
+
+## Configuration
+
+```ts
+const editorConfig = {
+  MENU_CONF: {
+    stylePreset: {
+      presets: [
+        {
+          key: 'muted-text',
+          title: 'Muted text',
+          scope: 'text',
+          className: 'article-muted',
+        },
+        {
+          key: 'lead-paragraph',
+          title: 'Lead paragraph',
+          scope: 'block',
+          className: 'article-lead',
+        },
+      ],
+    },
+  },
+}
+
+const toolbarConfig = {
+  insertKeys: {
+    index: 4,
+    keys: ['stylePreset'],
+  },
+}
+```
+
+- `key`: Stable kebab-case identifier persisted in JSON and HTML. Keep it independent of themes.
+- `title`: Label displayed in the toolbar menu.
+- `scope: 'text'`: Applies to selected text or subsequent input.
+- `scope: 'block'`: Applies to selected paragraphs, headings, list items, and other blocks.
+- `className`: Optional whitespace-separated business class names.
+
+The plugin always emits `w-e-style-preset-${key}`, so CSS can target a preset without `className`.
+
+## CSS
+
+```css
+.article-muted {
+  color: var(--article-muted-color, #667085);
+  font-size: 0.875rem;
+}
+
+.article-lead {
+  color: var(--article-lead-color, #344054);
+  font-size: 1.125rem;
+  line-height: 1.75;
+}
+```
+
+Load the same business CSS in the editor and in standalone HTML viewers.
+
+## HTML
+
+Text preset:
+
+```html
+<span class="w-e-style-preset-muted-text article-muted" data-w-e-style-preset="muted-text"
+  >Muted content</span
+>
+```
+
+Block preset:
+
+```html
+<p class="w-e-style-preset-lead-paragraph article-lead" data-w-e-style-preset="lead-paragraph">
+  Article lead
+</p>
+```
+
+Import prefers `data-w-e-style-preset`. When data is absent, configured business classes are also
+recognized. Unknown data keys remain in the document so adding configuration later restores their
+presentation.
+
+## Command API
+
+```ts
+import {
+  applyStylePreset,
+  getActiveStylePreset,
+  removeStylePreset,
+} from '@wangeditor-next/plugin-style-presets'
+
+applyStylePreset(editor, 'muted-text')
+getActiveStylePreset(editor) // 'muted-text' | null
+removeStylePreset(editor, 'text') // 'text' | 'block' | 'all'
+```
+
+## Compatibility
+
+- Supports `@wangeditor-next/editor >= 6.0.0`.
+- Does not change the existing inline/class style modes.
+- Does not enter the default toolbar automatically.
+- Covers `Slate -> HTML -> Slate`, `HTML -> Slate -> HTML`, and `setHtml(getHtml())` round trips.

--- a/packages/plugin-style-presets/README.md
+++ b/packages/plugin-style-presets/README.md
@@ -1,0 +1,125 @@
+# wangEditor 命名样式预设插件
+
+[English Documentation](./README-en.md)
+
+## 介绍
+
+`@wangeditor-next/plugin-style-presets` 为 wangEditor v6 提供语义化的文本和块级样式预设。
+内容保存稳定的 preset key，实际视觉样式由业务 CSS 控制，因此切换主题时无需修改历史内容。
+
+插件默认不注册到编辑器，不会改变现有工具栏、节点或 HTML 输出。
+
+## 安装
+
+```shell
+pnpm add @wangeditor-next/plugin-style-presets
+```
+
+## 注册
+
+```ts
+import { Boot } from '@wangeditor-next/editor'
+import stylePresetsModule from '@wangeditor-next/plugin-style-presets'
+
+// 创建编辑器之前注册，且只能注册一次。
+Boot.registerModule(stylePresetsModule)
+```
+
+## 配置
+
+```ts
+const editorConfig = {
+  MENU_CONF: {
+    stylePreset: {
+      presets: [
+        {
+          key: 'muted-text',
+          title: '提示文字',
+          scope: 'text',
+          className: 'article-muted',
+        },
+        {
+          key: 'lead-paragraph',
+          title: '导语',
+          scope: 'block',
+          className: 'article-lead',
+        },
+      ],
+    },
+  },
+}
+
+const toolbarConfig = {
+  insertKeys: {
+    index: 4,
+    keys: ['stylePreset'],
+  },
+}
+```
+
+- `key`：持久化到 JSON 和 HTML 的稳定 kebab-case 标识，不应随主题变化。
+- `title`：工具栏菜单展示名称。
+- `scope: 'text'`：应用到所选文字或后续输入文字。
+- `scope: 'block'`：应用到选区内的段落、标题、列表项等块节点。
+- `className`：可选业务 class，支持空格分隔的多个 class。
+
+插件始终额外输出 `w-e-style-preset-${key}`，即使不配置 `className` 也可直接编写 CSS。
+
+## CSS
+
+```css
+.article-muted {
+  color: var(--article-muted-color, #667085);
+  font-size: 0.875rem;
+}
+
+.article-lead {
+  color: var(--article-lead-color, #344054);
+  font-size: 1.125rem;
+  line-height: 1.75;
+}
+```
+
+编辑器区域和独立 HTML 展示区域都需要加载相同的业务 CSS。
+
+## HTML
+
+文本预设：
+
+```html
+<span class="w-e-style-preset-muted-text article-muted" data-w-e-style-preset="muted-text"
+  >提示内容</span
+>
+```
+
+块级预设：
+
+```html
+<p class="w-e-style-preset-lead-paragraph article-lead" data-w-e-style-preset="lead-paragraph">
+  文章导语
+</p>
+```
+
+导入时优先读取 `data-w-e-style-preset`。没有 data 属性时，也会根据已配置的业务 class
+恢复 preset。遇到尚未配置的 data key 时保留数据，后续补回配置即可恢复显示。
+
+## 命令 API
+
+```ts
+import {
+  applyStylePreset,
+  getActiveStylePreset,
+  removeStylePreset,
+} from '@wangeditor-next/plugin-style-presets'
+
+applyStylePreset(editor, 'muted-text')
+getActiveStylePreset(editor) // 'muted-text' | null
+removeStylePreset(editor, 'text') // 'text' | 'block' | 'all'
+```
+
+## 兼容性
+
+- 支持 `@wangeditor-next/editor >= 6.0.0`。
+- 不改变现有 inline/class 样式模式。
+- 不会自动加入默认工具栏。
+- 支持 `Slate -> HTML -> Slate`、`HTML -> Slate -> HTML` 和 `setHtml(getHtml())` 回环。

--- a/packages/plugin-style-presets/__tests__/config.test.ts
+++ b/packages/plugin-style-presets/__tests__/config.test.ts
@@ -1,0 +1,57 @@
+import { IDomEditor } from '@wangeditor-next/editor'
+
+import { getStylePresetConfig } from '../src/module/config'
+
+function createEditorWithConfig(config: unknown): IDomEditor {
+  return {
+    getMenuConfig: () => config,
+  } as unknown as IDomEditor
+}
+
+describe('style preset config', () => {
+  it('defaults to an empty preset list', () => {
+    expect(getStylePresetConfig(createEditorWithConfig({}))).toEqual({ presets: [] })
+  })
+
+  it('accepts valid text and block presets', () => {
+    const presets = [
+      { key: 'muted-text', title: 'Muted text', scope: 'text' as const },
+      {
+        key: 'lead-paragraph',
+        title: 'Lead paragraph',
+        scope: 'block' as const,
+        className: 'article-lead theme-readable',
+      },
+    ]
+
+    expect(getStylePresetConfig(createEditorWithConfig({ presets }))).toEqual({ presets })
+  })
+
+  it.each([
+    [{ key: 'Invalid Key', title: 'Bad', scope: 'text' }],
+    [{ key: 'valid', title: '', scope: 'text' }],
+    [{ key: 'valid', title: '   ', scope: 'text' }],
+    [{ key: 'valid', title: 'Bad', scope: 'other' }],
+    [
+      { key: 'valid', title: 'One', scope: 'text' },
+      { key: 'valid', title: 'Two', scope: 'block' },
+    ],
+    [{ key: 'valid', title: 'Bad class', scope: 'text', className: 'bad.class' }],
+    [
+      { key: 'one', title: 'One', scope: 'text', className: 'same-class' },
+      { key: 'two', title: 'Two', scope: 'text', className: 'same-class' },
+    ],
+    [
+      { key: 'one', title: 'One', scope: 'block', className: 'article-style' },
+      { key: 'two', title: 'Two', scope: 'block', className: 'article-style article-lead' },
+    ],
+  ])('rejects invalid presets %#', presets => {
+    expect(() => getStylePresetConfig(createEditorWithConfig({ presets }))).toThrow()
+  })
+
+  it('rejects a non-array preset value', () => {
+    expect(() => getStylePresetConfig(createEditorWithConfig({ presets: 'invalid' }))).toThrow(
+      'must be an array'
+    )
+  })
+})

--- a/packages/plugin-style-presets/__tests__/config.test.ts
+++ b/packages/plugin-style-presets/__tests__/config.test.ts
@@ -27,6 +27,33 @@ describe('style preset config', () => {
     expect(getStylePresetConfig(createEditorWithConfig({ presets }))).toEqual({ presets })
   })
 
+  it('treats a whitespace-only class name as an omitted class mapping', () => {
+    const presets = [
+      {
+        key: 'generated-class',
+        title: 'Generated class',
+        scope: 'text' as const,
+        className: '   ',
+      },
+      {
+        key: 'business-class',
+        title: 'Business class',
+        scope: 'text' as const,
+        className: 'article-text',
+      },
+    ]
+
+    expect(getStylePresetConfig(createEditorWithConfig({ presets }))).toEqual({ presets })
+  })
+
+  it('caches validated config for the same preset array', () => {
+    const presets = [{ key: 'muted-text', title: 'Muted text', scope: 'text' as const }]
+    const editor = createEditorWithConfig({ presets })
+    const firstConfig = getStylePresetConfig(editor)
+
+    expect(getStylePresetConfig(editor)).toBe(firstConfig)
+  })
+
   it.each([
     [{ key: 'Invalid Key', title: 'Bad', scope: 'text' }],
     [{ key: 'valid', title: '', scope: 'text' }],

--- a/packages/plugin-style-presets/__tests__/module.test.ts
+++ b/packages/plugin-style-presets/__tests__/module.test.ts
@@ -1,0 +1,10 @@
+import module from '../src'
+
+describe('plugin-style-presets module', () => {
+  it('exposes the complete style pipeline', () => {
+    expect(module.menus?.length).toBe(1)
+    expect(typeof module.renderStyle).toBe('function')
+    expect(typeof module.styleToHtml).toBe('function')
+    expect(typeof module.parseStyleHtml).toBe('function')
+  })
+})

--- a/packages/plugin-style-presets/__tests__/style-pipeline.test.ts
+++ b/packages/plugin-style-presets/__tests__/style-pipeline.test.ts
@@ -1,0 +1,208 @@
+import {
+  Boot,
+  createEditor,
+  IDomEditor,
+  ISelectMenu,
+  SlateTransforms,
+} from '@wangeditor-next/editor'
+
+import stylePresetModule, {
+  applyStylePreset,
+  getActiveStylePreset,
+  removeStylePreset,
+} from '../src'
+import { IStylePreset } from '../src/module/types'
+
+const presets: IStylePreset[] = [
+  {
+    key: 'muted-text',
+    title: 'Muted text',
+    scope: 'text',
+    className: 'article-muted',
+  },
+  {
+    key: 'lead-paragraph',
+    title: 'Lead paragraph',
+    scope: 'block',
+    className: 'article-lead',
+  },
+]
+
+Boot.registerModule(stylePresetModule)
+
+function createPresetEditor(
+  content?: unknown[],
+  textStyleMode: 'inline' | 'class' = 'inline'
+): IDomEditor {
+  const selector = document.createElement('div')
+
+  document.body.appendChild(selector)
+  const editor = createEditor({
+    selector,
+    content: content as never,
+    config: {
+      textStyleMode,
+      MENU_CONF: {
+        stylePreset: { presets },
+      },
+    },
+  })
+  const globalScope = globalThis as typeof globalThis & { testEditors?: Set<IDomEditor> }
+
+  globalScope.testEditors ||= new Set()
+  globalScope.testEditors.add(editor)
+  return editor
+}
+
+describe('style preset pipeline', () => {
+  it.each(['inline', 'class'] as const)(
+    'round-trips rendered text and block presets in %s mode',
+    textStyleMode => {
+      const editor = createPresetEditor(
+        [
+          {
+            type: 'paragraph',
+            stylePreset: 'lead-paragraph',
+            children: [{ text: 'Lead ' }, { text: 'note', stylePreset: 'muted-text' }],
+          },
+        ],
+        textStyleMode
+      )
+      const blockNode = editor.children[0]
+      const textNode = blockNode.children[1]
+      const renderedBlock = stylePresetModule.renderStyle!(blockNode, { data: {} } as never, editor)
+      const renderedText = stylePresetModule.renderStyle!(textNode, { data: {} } as never, editor)
+      const html = editor.getHtml()
+
+      expect(renderedBlock).toMatchObject({
+        data: {
+          class: {
+            'article-lead': true,
+            'w-e-style-preset-lead-paragraph': true,
+          },
+          dataset: { wEStylePreset: 'lead-paragraph' },
+        },
+      })
+      expect(renderedText).toMatchObject({
+        data: {
+          class: {
+            'article-muted': true,
+            'w-e-style-preset-muted-text': true,
+          },
+          dataset: { wEStylePreset: 'muted-text' },
+        },
+      })
+      expect(html).toContain('data-w-e-style-preset="lead-paragraph"')
+      expect(html).toContain('class="w-e-style-preset-lead-paragraph article-lead"')
+      expect(html).toContain('data-w-e-style-preset="muted-text"')
+      expect(html).toContain('w-e-style-preset-muted-text article-muted')
+
+      editor.setHtml(html)
+      expect(editor.children).toEqual([
+        {
+          type: 'paragraph',
+          stylePreset: 'lead-paragraph',
+          children: [{ text: 'Lead ' }, { text: 'note', stylePreset: 'muted-text' }],
+        },
+      ])
+      expect(editor.getHtml()).toBe(html)
+    }
+  )
+
+  it.each(['inline', 'class'] as const)(
+    'parses configured business classes and exports stable data in %s mode',
+    textStyleMode => {
+      const editor = createPresetEditor(undefined, textStyleMode)
+
+      editor.setHtml('<p class="article-lead">Lead <span class="article-muted">note</span></p>')
+      expect(editor.children).toEqual([
+        {
+          type: 'paragraph',
+          stylePreset: 'lead-paragraph',
+          children: [{ text: 'Lead ' }, { text: 'note', stylePreset: 'muted-text' }],
+        },
+      ])
+
+      const html = editor.getHtml()
+
+      expect(html).toContain('data-w-e-style-preset="lead-paragraph"')
+      expect(html).toContain('data-w-e-style-preset="muted-text"')
+
+      editor.setHtml(html)
+      expect(editor.getHtml()).toBe(html)
+    }
+  )
+
+  it('preserves unknown data keys for future configuration', () => {
+    const editor = createPresetEditor()
+
+    editor.setHtml(
+      '<p data-w-e-style-preset="future-block">Future <span data-w-e-style-preset="future-text">text</span></p>'
+    )
+    expect(editor.children).toEqual([
+      {
+        type: 'paragraph',
+        stylePreset: 'future-block',
+        children: [{ text: 'Future ' }, { text: 'text', stylePreset: 'future-text' }],
+      },
+    ])
+    const html = editor.getHtml()
+
+    expect(html).toContain('data-w-e-style-preset="future-block"')
+    expect(html).toContain('data-w-e-style-preset="future-text"')
+    editor.setHtml(html)
+    expect(editor.getHtml()).toBe(html)
+  })
+
+  it('applies and removes text and block presets with commands', () => {
+    const editor = createPresetEditor([{ type: 'paragraph', children: [{ text: 'hello' }] }])
+
+    SlateTransforms.select(editor, {
+      anchor: { path: [0, 0], offset: 0 },
+      focus: { path: [0, 0], offset: 5 },
+    })
+
+    applyStylePreset(editor, 'muted-text')
+    expect(getActiveStylePreset(editor)).toBe('muted-text')
+    expect(editor.children[0]).toMatchObject({
+      children: [{ text: 'hello', stylePreset: 'muted-text' }],
+    })
+
+    removeStylePreset(editor, 'text')
+    expect(editor.children[0]).toMatchObject({ children: [{ text: 'hello' }] })
+
+    applyStylePreset(editor, 'lead-paragraph')
+    expect(editor.children[0]).toMatchObject({ stylePreset: 'lead-paragraph' })
+    expect(getActiveStylePreset(editor)).toBe('lead-paragraph')
+
+    removeStylePreset(editor, 'block')
+    expect(editor.children[0]).not.toHaveProperty('stylePreset')
+  })
+
+  it('rejects applying an unknown preset', () => {
+    const editor = createPresetEditor([{ type: 'paragraph', children: [{ text: 'hello' }] }])
+
+    SlateTransforms.select(editor, { path: [0, 0], offset: 0 })
+    expect(() => applyStylePreset(editor, 'missing')).toThrow('Unknown style preset')
+  })
+
+  it('exposes configured presets through the opt-in toolbar menu', () => {
+    const editor = createPresetEditor([{ type: 'paragraph', children: [{ text: 'hello' }] }])
+    const menu = stylePresetModule.menus![0].factory() as ISelectMenu
+
+    SlateTransforms.select(editor, { path: [0, 0], offset: 0 })
+
+    expect(menu.isDisabled(editor)).toBe(false)
+    expect(menu.getOptions(editor).map(option => option.value)).toEqual([
+      '',
+      'muted-text',
+      'lead-paragraph',
+    ])
+
+    menu.exec(editor, 'lead-paragraph')
+    expect(editor.children[0]).toMatchObject({ stylePreset: 'lead-paragraph' })
+
+    menu.exec(editor, '')
+    expect(editor.children[0]).not.toHaveProperty('stylePreset')
+  })
+})

--- a/packages/plugin-style-presets/package.json
+++ b/packages/plugin-style-presets/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@wangeditor-next/plugin-style-presets",
+  "version": "3.0.0",
+  "description": "Semantic style presets for wangEditor",
+  "author": "cycleccc <2991205548@qq.com>",
+  "type": "module",
+  "homepage": "https://github.com/wangeditor-next/wangEditor-next#readme",
+  "license": "MIT",
+  "types": "dist/plugin-style-presets/src/index.d.ts",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "exports": {
+    ".": {
+      "types": "./dist/plugin-style-presets/src/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "directories": {
+    "lib": "dist"
+  },
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wangeditor-next/wangEditor-next.git"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "dev": "cross-env NODE_ENV=development rollup -c rollup.config.js",
+    "dev-watch": "cross-env NODE_ENV=development rollup -c rollup.config.js -w",
+    "build": "cross-env NODE_ENV=production rollup -c rollup.config.js",
+    "dev-size-stats": "cross-env NODE_ENV=development:size_stats rollup -c rollup.config.js",
+    "size-stats": "cross-env NODE_ENV=production:size_stats rollup -c rollup.config.js"
+  },
+  "bugs": {
+    "url": "https://github.com/wangeditor-next/wangEditor-next/issues"
+  },
+  "peerDependencies": {
+    "@wangeditor-next/editor": ">=6.0.0",
+    "snabbdom": "^3.6.0"
+  },
+  "devDependencies": {
+    "@wangeditor-next-shared/rollup-config": "workspace:^"
+  }
+}

--- a/packages/plugin-style-presets/rollup.config.js
+++ b/packages/plugin-style-presets/rollup.config.js
@@ -1,0 +1,31 @@
+import { createRollupConfig } from '@wangeditor-next-shared/rollup-config'
+
+import pkg from './package.json' with { type: 'json' }
+
+const name = 'WangEditorStylePresetsPlugin'
+const configList = []
+
+const esmConf = createRollupConfig({
+  output: {
+    file: pkg.module,
+    format: 'esm',
+    name,
+  },
+})
+
+configList.push(esmConf)
+
+const umdConf = createRollupConfig({
+  output: {
+    file: pkg.main,
+    format: 'umd',
+    globals: {
+      '@wangeditor-next/editor': 'wangEditor',
+    },
+    name,
+  },
+})
+
+configList.push(umdConf)
+
+export default configList

--- a/packages/plugin-style-presets/src/constants/icon-svg.ts
+++ b/packages/plugin-style-presets/src/constants/icon-svg.ts
@@ -1,0 +1,6 @@
+/**
+ * @description style preset menu icon
+ */
+
+export const STYLE_PRESET_SVG =
+  '<svg viewBox="0 0 1024 1024"><path d="M128 160h768v96H128zM224 352h576v96H224zM320 544h384v96H320zM416 736h192v96H416z"></path></svg>'

--- a/packages/plugin-style-presets/src/constants/icon-svg.ts
+++ b/packages/plugin-style-presets/src/constants/icon-svg.ts
@@ -3,4 +3,6 @@
  */
 
 export const STYLE_PRESET_SVG =
-  '<svg viewBox="0 0 1024 1024"><path d="M128 160h768v96H128zM224 352h576v96H224zM320 544h384v96H320zM416 736h192v96H416z"></path></svg>'
+  '<svg viewBox="0 0 1024 1024">' +
+  '<path d="M128 160h768v96H128zM224 352h576v96H224z' +
+  'M320 544h384v96H320zM416 736h192v96H416z"></path></svg>'

--- a/packages/plugin-style-presets/src/index.ts
+++ b/packages/plugin-style-presets/src/index.ts
@@ -1,0 +1,15 @@
+/**
+ * @description style presets plugin entry
+ */
+
+import module from './module/index'
+
+export { applyStylePreset, getActiveStylePreset, removeStylePreset } from './module/commands'
+export {
+  getStylePresetClassNames,
+  STYLE_PRESET_DATA_ATTRIBUTE,
+  STYLE_PRESET_PROPERTY,
+} from './module/helpers'
+export type { IStylePreset, IStylePresetMenuConfig, StylePresetScope } from './module/types'
+
+export default module

--- a/packages/plugin-style-presets/src/module/commands.ts
+++ b/packages/plugin-style-presets/src/module/commands.ts
@@ -2,14 +2,20 @@
  * @description style preset commands
  */
 
-import { IDomEditor, SlateEditor, SlateElement, SlateTransforms } from '@wangeditor-next/editor'
+import {
+  IDomEditor,
+  SlateEditor,
+  SlateElement,
+  SlateNode,
+  SlateTransforms,
+} from '@wangeditor-next/editor'
 
 import { findStylePreset } from './config'
 import { getNodeStylePreset, STYLE_PRESET_PROPERTY } from './helpers'
 import { StylePresetScope } from './types'
 
 function getBlockMatch(editor: IDomEditor) {
-  return node =>
+  return (node: SlateNode) =>
     SlateElement.isElement(node) &&
     SlateEditor.isBlock(editor, node) &&
     !SlateEditor.isVoid(editor, node)

--- a/packages/plugin-style-presets/src/module/commands.ts
+++ b/packages/plugin-style-presets/src/module/commands.ts
@@ -1,0 +1,83 @@
+/**
+ * @description style preset commands
+ */
+
+import { IDomEditor, SlateEditor, SlateElement, SlateTransforms } from '@wangeditor-next/editor'
+
+import { findStylePreset } from './config'
+import { getNodeStylePreset, STYLE_PRESET_PROPERTY } from './helpers'
+import { StylePresetScope } from './types'
+
+function getBlockMatch(editor: IDomEditor) {
+  return node =>
+    SlateElement.isElement(node) &&
+    SlateEditor.isBlock(editor, node) &&
+    !SlateEditor.isVoid(editor, node)
+}
+
+export function applyStylePreset(editor: IDomEditor, key: string): void {
+  const preset = findStylePreset(editor, key)
+
+  if (!preset) {
+    throw new Error(`Unknown style preset "${key}".`)
+  }
+  if (editor.selection == null) {
+    return
+  }
+
+  if (preset.scope === 'text') {
+    editor.addMark(STYLE_PRESET_PROPERTY, key)
+    return
+  }
+
+  SlateTransforms.setNodes(editor, { [STYLE_PRESET_PROPERTY]: key } as never, {
+    at: editor.selection,
+    match: getBlockMatch(editor),
+    mode: 'lowest',
+  })
+}
+
+export function removeStylePreset(
+  editor: IDomEditor,
+  scope: StylePresetScope | 'all' = 'all'
+): void {
+  if (editor.selection == null) {
+    return
+  }
+
+  if (scope === 'text' || scope === 'all') {
+    editor.removeMark(STYLE_PRESET_PROPERTY)
+  }
+
+  if (scope === 'block' || scope === 'all') {
+    SlateTransforms.unsetNodes(editor, STYLE_PRESET_PROPERTY, {
+      at: editor.selection,
+      match: getBlockMatch(editor),
+      mode: 'lowest',
+    })
+  }
+}
+
+export function getActiveStylePreset(editor: IDomEditor): string | null {
+  if (editor.selection == null) {
+    return null
+  }
+
+  const marks = SlateEditor.marks(editor) as Record<string, unknown> | null
+  const textPreset = marks?.[STYLE_PRESET_PROPERTY]
+
+  if (typeof textPreset === 'string' && textPreset) {
+    return textPreset
+  }
+
+  const [blockEntry] = SlateEditor.nodes(editor, {
+    at: editor.selection,
+    match: getBlockMatch(editor),
+    mode: 'lowest',
+  })
+
+  if (!blockEntry) {
+    return null
+  }
+  return getNodeStylePreset(blockEntry[0]) || null
+}

--- a/packages/plugin-style-presets/src/module/config.ts
+++ b/packages/plugin-style-presets/src/module/config.ts
@@ -1,0 +1,102 @@
+/**
+ * @description style preset config
+ */
+
+import { IDomEditor } from '@wangeditor-next/editor'
+
+import { IStylePreset, IStylePresetMenuConfig } from './types'
+
+const PRESET_KEY_REGEXP = /^[a-z][a-z0-9-]{0,63}$/
+const CLASS_NAME_REGEXP = /^-?[_a-zA-Z]+[_a-zA-Z0-9-]*$/
+
+export function genStylePresetMenuConfig(): IStylePresetMenuConfig {
+  return { presets: [] }
+}
+
+function validateClassNames(preset: IStylePreset) {
+  const { className = '', key } = preset
+  const classNames = className.trim().split(/\s+/).filter(Boolean)
+
+  classNames.forEach(name => {
+    if (!CLASS_NAME_REGEXP.test(name)) {
+      throw new Error(`Invalid class name "${name}" for style preset "${key}".`)
+    }
+  })
+}
+
+function validatePresets(presets: IStylePreset[]) {
+  const keys = new Set<string>()
+  const classMappings: Array<{
+    classNames: string[]
+    key: string
+    scope: IStylePreset['scope']
+  }> = []
+
+  presets.forEach(preset => {
+    if (!preset || typeof preset !== 'object') {
+      throw new Error('Style presets must be objects.')
+    }
+    if (!PRESET_KEY_REGEXP.test(preset.key)) {
+      throw new Error(`Invalid style preset key "${preset.key}". Use kebab-case.`)
+    }
+    if (typeof preset.title !== 'string' || !preset.title.trim()) {
+      throw new Error(`Style preset "${preset.key}" requires a title.`)
+    }
+    if (preset.scope !== 'text' && preset.scope !== 'block') {
+      throw new Error(`Style preset "${preset.key}" requires scope "text" or "block".`)
+    }
+    if (keys.has(preset.key)) {
+      throw new Error(`Duplicate style preset key "${preset.key}".`)
+    }
+
+    validateClassNames(preset)
+
+    const classNames = (preset.className || `w-e-style-preset-${preset.key}`)
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean)
+      .sort()
+    const conflictingMapping = classMappings.find(mapping => {
+      if (mapping.scope !== preset.scope) {
+        return false
+      }
+      const previousClassNames = new Set(mapping.classNames)
+      const currentClassNames = new Set(classNames)
+
+      return (
+        classNames.every(name => previousClassNames.has(name)) ||
+        mapping.classNames.every(name => currentClassNames.has(name))
+      )
+    })
+
+    if (conflictingMapping) {
+      throw new Error(
+        `Ambiguous class mapping between style presets "${conflictingMapping.key}" and "${preset.key}".`
+      )
+    }
+
+    keys.add(preset.key)
+    classMappings.push({ classNames, key: preset.key, scope: preset.scope })
+  })
+}
+
+export function getStylePresetConfig(editor: IDomEditor): IStylePresetMenuConfig {
+  const menuConfig = editor.getMenuConfig(
+    'stylePreset'
+  ) as unknown as Partial<IStylePresetMenuConfig>
+  const presets = menuConfig?.presets
+
+  if (presets == null) {
+    return genStylePresetMenuConfig()
+  }
+  if (!Array.isArray(presets)) {
+    throw new Error('Style preset config "presets" must be an array.')
+  }
+
+  validatePresets(presets)
+  return { presets }
+}
+
+export function findStylePreset(editor: IDomEditor, key: string): IStylePreset | undefined {
+  return getStylePresetConfig(editor).presets.find(preset => preset.key === key)
+}

--- a/packages/plugin-style-presets/src/module/config.ts
+++ b/packages/plugin-style-presets/src/module/config.ts
@@ -8,6 +8,7 @@ import { IStylePreset, IStylePresetMenuConfig } from './types'
 
 const PRESET_KEY_REGEXP = /^[a-z][a-z0-9-]{0,63}$/
 const CLASS_NAME_REGEXP = /^-?[_a-zA-Z]+[_a-zA-Z0-9-]*$/
+const validatedConfigCache = new WeakMap<IStylePreset[], IStylePresetMenuConfig>()
 
 export function genStylePresetMenuConfig(): IStylePresetMenuConfig {
   return { presets: [] }
@@ -51,8 +52,8 @@ function validatePresets(presets: IStylePreset[]) {
 
     validateClassNames(preset)
 
-    const classNames = (preset.className || `w-e-style-preset-${preset.key}`)
-      .trim()
+    const trimmedClassName = (preset.className || '').trim()
+    const classNames = (trimmedClassName || `w-e-style-preset-${preset.key}`)
       .split(/\s+/)
       .filter(Boolean)
       .sort()
@@ -70,9 +71,9 @@ function validatePresets(presets: IStylePreset[]) {
     })
 
     if (conflictingMapping) {
-      throw new Error(
-        `Ambiguous class mapping between style presets "${conflictingMapping.key}" and "${preset.key}".`
-      )
+      const conflictingKeys = `"${conflictingMapping.key}" and "${preset.key}"`
+
+      throw new Error(`Ambiguous class mapping between style presets ${conflictingKeys}.`)
     }
 
     keys.add(preset.key)
@@ -93,8 +94,17 @@ export function getStylePresetConfig(editor: IDomEditor): IStylePresetMenuConfig
     throw new Error('Style preset config "presets" must be an array.')
   }
 
+  const cached = validatedConfigCache.get(presets)
+
+  if (cached) {
+    return cached
+  }
+
   validatePresets(presets)
-  return { presets }
+  const config = { presets }
+
+  validatedConfigCache.set(presets, config)
+  return config
 }
 
 export function findStylePreset(editor: IDomEditor, key: string): IStylePreset | undefined {

--- a/packages/plugin-style-presets/src/module/helpers.ts
+++ b/packages/plugin-style-presets/src/module/helpers.ts
@@ -1,0 +1,75 @@
+/**
+ * @description style preset HTML and vnode helpers
+ */
+
+import { IDomEditor } from '@wangeditor-next/editor'
+import { VNode } from 'snabbdom'
+
+import { findStylePreset } from './config'
+import { IStylePreset } from './types'
+
+export const STYLE_PRESET_PROPERTY = 'stylePreset'
+export const STYLE_PRESET_DATA_ATTRIBUTE = 'data-w-e-style-preset'
+const STYLE_PRESET_DATASET_KEY = 'wEStylePreset'
+const SAFE_PRESET_KEY_REGEXP = /^[a-z][a-z0-9-]{0,63}$/
+
+function getGeneratedClassName(key: string): string {
+  return `w-e-style-preset-${key}`
+}
+
+export function getStylePresetClassNames(preset: IStylePreset): string[] {
+  const businessClassNames = (preset.className || '').trim().split(/\s+/).filter(Boolean)
+
+  return [getGeneratedClassName(preset.key), ...businessClassNames]
+}
+
+export function getStylePresetMatchClassNames(preset: IStylePreset): string[] {
+  const businessClassNames = (preset.className || '').trim().split(/\s+/).filter(Boolean)
+
+  return businessClassNames.length > 0 ? businessClassNames : [getGeneratedClassName(preset.key)]
+}
+
+export function getClassNamesForKey(editor: IDomEditor, key: string): string[] {
+  const preset = findStylePreset(editor, key)
+
+  if (preset) {
+    return getStylePresetClassNames(preset)
+  }
+  if (SAFE_PRESET_KEY_REGEXP.test(key)) {
+    return [getGeneratedClassName(key)]
+  }
+  return []
+}
+
+export function getNodeStylePreset(node: unknown): string {
+  if (!node || typeof node !== 'object') {
+    return ''
+  }
+
+  const value = (node as Record<string, unknown>)[STYLE_PRESET_PROPERTY]
+
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+export function addPresetToVnode(vnode: VNode, editor: IDomEditor, key: string): VNode {
+  const data = vnode.data || {}
+  const dataset = data.dataset || {}
+  const classMap = data.class || {}
+
+  dataset[STYLE_PRESET_DATASET_KEY] = key
+  getClassNamesForKey(editor, key).forEach(className => {
+    classMap[className] = true
+  })
+
+  vnode.data = {
+    ...data,
+    class: classMap,
+    dataset,
+  }
+  return vnode
+}
+
+export function addPresetToElement(element: Element, editor: IDomEditor, key: string) {
+  element.setAttribute(STYLE_PRESET_DATA_ATTRIBUTE, key)
+  getClassNamesForKey(editor, key).forEach(className => element.classList.add(className))
+}

--- a/packages/plugin-style-presets/src/module/index.ts
+++ b/packages/plugin-style-presets/src/module/index.ts
@@ -1,0 +1,21 @@
+/**
+ * @description style preset module
+ */
+
+import './local'
+
+import { IModuleConf } from '@wangeditor-next/editor'
+
+import { stylePresetMenuConf } from './menu/index'
+import { parseStyleHtml } from './parse-style-html'
+import { renderStyle } from './render-style'
+import { styleToHtml } from './style-to-html'
+
+const module: Partial<IModuleConf> = {
+  menus: [stylePresetMenuConf],
+  parseStyleHtml,
+  renderStyle,
+  styleToHtml,
+}
+
+export default module

--- a/packages/plugin-style-presets/src/module/local.ts
+++ b/packages/plugin-style-presets/src/module/local.ts
@@ -1,0 +1,19 @@
+/**
+ * @description style preset translations
+ */
+
+import { i18nAddResources } from '@wangeditor-next/editor'
+
+i18nAddResources('en', {
+  stylePreset: {
+    default: 'Default style',
+    title: 'Styles',
+  },
+})
+
+i18nAddResources('zh-CN', {
+  stylePreset: {
+    default: '默认样式',
+    title: '样式',
+  },
+})

--- a/packages/plugin-style-presets/src/module/menu/StylePresetMenu.ts
+++ b/packages/plugin-style-presets/src/module/menu/StylePresetMenu.ts
@@ -1,0 +1,59 @@
+/**
+ * @description style preset select menu
+ */
+
+import { IDomEditor, IOption, ISelectMenu, t } from '@wangeditor-next/editor'
+
+import { STYLE_PRESET_SVG } from '../../constants/icon-svg'
+import { applyStylePreset, getActiveStylePreset, removeStylePreset } from '../commands'
+import { getStylePresetConfig } from '../config'
+
+class StylePresetMenu implements ISelectMenu {
+  readonly title = t('stylePreset.title')
+
+  readonly iconSvg = STYLE_PRESET_SVG
+
+  readonly tag = 'select'
+
+  readonly width = 100
+
+  getOptions(editor: IDomEditor): IOption[] {
+    const { presets } = getStylePresetConfig(editor)
+
+    return [
+      { text: t('stylePreset.default'), value: '' },
+      ...presets.map(preset => ({
+        text: preset.title,
+        value: preset.key,
+      })),
+    ]
+  }
+
+  getValue(editor: IDomEditor): string | boolean {
+    return getActiveStylePreset(editor) || ''
+  }
+
+  isActive(_editor: IDomEditor): boolean {
+    return false
+  }
+
+  isDisabled(editor: IDomEditor): boolean {
+    if (editor.selection == null) {
+      return true
+    }
+    return getStylePresetConfig(editor).presets.length === 0
+  }
+
+  exec(editor: IDomEditor, value: string | boolean): void {
+    const key = typeof value === 'string' ? value : ''
+
+    if (!key) {
+      removeStylePreset(editor)
+      return
+    }
+
+    applyStylePreset(editor, key)
+  }
+}
+
+export default StylePresetMenu

--- a/packages/plugin-style-presets/src/module/menu/index.ts
+++ b/packages/plugin-style-presets/src/module/menu/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @description style preset menu entry
+ */
+
+import { genStylePresetMenuConfig } from '../config'
+import StylePresetMenu from './StylePresetMenu'
+
+export const stylePresetMenuConf = {
+  key: 'stylePreset',
+  factory() {
+    return new StylePresetMenu()
+  },
+  config: genStylePresetMenuConfig(),
+}

--- a/packages/plugin-style-presets/src/module/parse-style-html.ts
+++ b/packages/plugin-style-presets/src/module/parse-style-html.ts
@@ -1,0 +1,49 @@
+/**
+ * @description parse style presets
+ */
+
+import { IDomEditor, SlateDescendant, SlateText } from '@wangeditor-next/editor'
+
+import { getStylePresetConfig } from './config'
+import {
+  getStylePresetMatchClassNames,
+  STYLE_PRESET_DATA_ATTRIBUTE,
+  STYLE_PRESET_PROPERTY,
+} from './helpers'
+import { StylePresetScope } from './types'
+
+function findPresetKeyByClass(
+  element: Element,
+  editor: IDomEditor,
+  scope: StylePresetScope
+): string {
+  const preset = getStylePresetConfig(editor).presets.find(item => {
+    if (item.scope !== scope) {
+      return false
+    }
+    return getStylePresetMatchClassNames(item).every(className =>
+      element.classList.contains(className)
+    )
+  })
+
+  return preset?.key || ''
+}
+
+export function parseStyleHtml(
+  element: Element,
+  node: SlateDescendant,
+  editor: IDomEditor
+): SlateDescendant {
+  const scope: StylePresetScope = SlateText.isText(node) ? 'text' : 'block'
+  const dataKey = element.getAttribute(STYLE_PRESET_DATA_ATTRIBUTE)?.trim() || ''
+  const key = dataKey || findPresetKeyByClass(element, editor, scope)
+
+  if (!key) {
+    return node
+  }
+
+  const styledNode = node as SlateDescendant & Record<string, unknown>
+
+  styledNode[STYLE_PRESET_PROPERTY] = key
+  return styledNode
+}

--- a/packages/plugin-style-presets/src/module/render-style.ts
+++ b/packages/plugin-style-presets/src/module/render-style.ts
@@ -1,0 +1,17 @@
+/**
+ * @description render style presets
+ */
+
+import { IDomEditor, SlateDescendant } from '@wangeditor-next/editor'
+import { VNode } from 'snabbdom'
+
+import { addPresetToVnode, getNodeStylePreset } from './helpers'
+
+export function renderStyle(node: SlateDescendant, vnode: VNode, editor?: IDomEditor): VNode {
+  const key = getNodeStylePreset(node)
+
+  if (!key || !editor) {
+    return vnode
+  }
+  return addPresetToVnode(vnode, editor, key)
+}

--- a/packages/plugin-style-presets/src/module/style-to-html.ts
+++ b/packages/plugin-style-presets/src/module/style-to-html.ts
@@ -1,0 +1,50 @@
+/**
+ * @description serialize style presets
+ */
+
+import { IDomEditor, SlateDescendant, SlateText } from '@wangeditor-next/editor'
+
+import { addPresetToElement, getNodeStylePreset } from './helpers'
+
+function createTextRoot(html: string): HTMLElement {
+  const container = document.createElement('div')
+
+  container.innerHTML = html
+
+  if (container.childNodes.length === 1) {
+    const child = container.firstElementChild
+
+    if (child?.tagName === 'SPAN') {
+      return child as HTMLElement
+    }
+  }
+
+  const span = document.createElement('span')
+
+  span.innerHTML = html
+  return span
+}
+
+function createElementRoot(html: string): HTMLElement | null {
+  const container = document.createElement('div')
+
+  container.innerHTML = html
+  return container.firstElementChild as HTMLElement | null
+}
+
+export function styleToHtml(node: SlateDescendant, html: string, editor?: IDomEditor): string {
+  const key = getNodeStylePreset(node)
+
+  if (!key || !editor || !html) {
+    return html
+  }
+
+  const root = SlateText.isText(node) ? createTextRoot(html) : createElementRoot(html)
+
+  if (!root) {
+    return html
+  }
+
+  addPresetToElement(root, editor, key)
+  return root.outerHTML
+}

--- a/packages/plugin-style-presets/src/module/types.ts
+++ b/packages/plugin-style-presets/src/module/types.ts
@@ -1,0 +1,20 @@
+/**
+ * @description style preset public types
+ */
+
+export type StylePresetScope = 'text' | 'block'
+
+export interface IStylePreset {
+  /** Stable kebab-case identifier persisted in JSON and HTML. */
+  key: string
+  /** Label displayed in the toolbar menu. */
+  title: string
+  /** Apply the preset to text marks or block elements. */
+  scope: StylePresetScope
+  /** Optional business class names added after the stable generated class. */
+  className?: string
+}
+
+export interface IStylePresetMenuConfig {
+  presets: IStylePreset[]
+}

--- a/packages/plugin-style-presets/tsconfig.json
+++ b/packages/plugin-style-presets/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {},
+  "extends": "../../tsconfig.json",
+  "include": ["./src/**/*", "../custom-types.d.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -784,6 +784,19 @@ importers:
         specifier: workspace:^
         version: link:../../shared/rollup-config
 
+  packages/plugin-style-presets:
+    dependencies:
+      '@wangeditor-next/editor':
+        specifier: '>=6.0.0'
+        version: link:../editor
+      snabbdom:
+        specifier: ^3.6.0
+        version: 3.6.3
+    devDependencies:
+      '@wangeditor-next-shared/rollup-config':
+        specifier: workspace:^
+        version: link:../../shared/rollup-config
+
   packages/table-module:
     dependencies:
       '@wangeditor-next/core':

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -16,6 +16,7 @@ const modulePaths = [
   '@wangeditor-next/plugin-link-card',
   '@wangeditor-next/plugin-markdown',
   '@wangeditor-next/plugin-mention',
+  '@wangeditor-next/plugin-style-presets',
   '@wangeditor-next/table-module',
   '@wangeditor-next/upload-image-module',
   '@wangeditor-next/video-module',


### PR DESCRIPTION
## Summary

- add the opt-in `@wangeditor-next/plugin-style-presets` package
- support semantic text and block presets through toolbar and command APIs
- persist stable `stylePreset` keys through render, HTML export, HTML import, and round trips
- emit generated preset classes plus optional business classes
- add bilingual package READMEs and a responsive native HTML demo

## Compatibility and risk

- the plugin is not registered by default, so existing toolbars, JSON, HTML, and inline/class behavior are unchanged
- unknown `data-w-e-style-preset` keys remain preserved for later configuration
- invalid keys, classes, duplicate keys, and ambiguous same-scope class mappings throw when opt-in configuration is read
- consumers must register the module once before editor creation and load the same business CSS in editor and standalone views

## Verification

- `pnpm exec turbo build --concurrency=1`: 24/24 build tasks passed
- `pnpm typecheck`: 20/20 TypeScript projects passed
- `pnpm check:published-types`: 5875 declaration files passed
- focused Vitest: 22/22 tests passed, including inline/class render and round-trip matrices
- affected ESLint, Prettier, and 100-character line checks passed
- Playwright manual demo checks passed on desktop and 390px mobile with no console/page errors or horizontal overflow

## Documentation

Public Chinese and English documentation is in wangeditor-next/docs#17.

## Release

A patch Changeset is included. The first published package version will be `3.0.1`.

## Rollback

The package is isolated and opt-in. Consumers can remove module registration, toolbar insertion, and preset configuration without changing existing editor behavior. The repository change can be reverted as two commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Released an opt-in style presets plugin for semantic text and block styling.
  * Added a style preset toolbar menu with configurable titles/scopes and CSS-class mapping.
  * Added commands to apply, query, and remove active presets, with stable HTML serialization/round-trip behavior (including preservation of unknown preset markers).
* **Documentation**
  * Added Chinese and English READMEs covering configuration, HTML expectations, and API usage.
* **Demo**
  * Added an interactive custom styles page with live rendered preview.
* **Tests**
  * Added test coverage for preset config validation, toolbar/menu behavior, commands, and HTML parse/render pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->