### PR TITLE
fix(core): preserve caret when IME replaces a selection

### DIFF
--- a/.changeset/steady-ime-caret.md
+++ b/.changeset/steady-ime-caret.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/core': patch
+---
+
+Preserve the caret when IME composition replaces selected editor content.

--- a/packages/core/__tests__/text-area/event-handlers/composition.test.ts
+++ b/packages/core/__tests__/text-area/event-handlers/composition.test.ts
@@ -47,24 +47,62 @@ const createSelection = (expanded: boolean) => ({
 
 describe('composition handlers', () => {
   it('handles composition start on expanded selection', async () => {
+    const callOrder: string[] = []
     const editor = {
       selection: createSelection(true),
     } as any
-    const textarea = { isComposing: false } as any
+    const textarea = {
+      isComposing: false,
+      changeViewState: vi.fn(() => callOrder.push('view')),
+    } as any
     const event = { target: {} } as any
-    const startContainer = { textContent: 'old' }
+
+    vi.spyOn(helpers, 'hasEditableTarget').mockReturnValue(true)
+    vi.spyOn(Editor, 'deleteFragment').mockImplementation(() => {
+      expect(textarea.isComposing).toBe(true)
+      callOrder.push('delete')
+    })
+    vi.mocked(editorSelectionToDOM).mockImplementation(() => {
+      callOrder.push('selection')
+    })
+
+    handleCompositionStart(event, textarea, editor)
+
+    expect(callOrder).toEqual(['delete', 'view'])
+    await flushPromises()
+
+    expect(callOrder).toEqual(['delete', 'view', 'selection'])
+    expect(Editor.deleteFragment).toHaveBeenCalledWith(editor)
+    expect(textarea.changeViewState).toHaveBeenCalledOnce()
+    expect(textarea.isComposing).toBe(true)
+    expect(hidePlaceholder).toHaveBeenCalledWith(textarea, editor)
+    expect(editorSelectionToDOM).toHaveBeenCalledWith(textarea, editor, true)
+  })
+
+  it('does not force a view refresh when composition starts on a collapsed selection', async () => {
+    const editor = {
+      selection: createSelection(false),
+    } as any
+    const textarea = { isComposing: false, changeViewState: vi.fn() } as any
+    const event = { target: {} } as any
+    const startContainer = document.createTextNode('old')
 
     vi.spyOn(helpers, 'hasEditableTarget').mockReturnValue(true)
     vi.spyOn(Editor, 'deleteFragment').mockImplementation(() => {})
-    vi.spyOn(DomEditor, 'toDOMRange').mockReturnValue({ startContainer } as any)
+    vi.spyOn(DomEditor, 'findDocumentOrShadowRoot').mockReturnValue({
+      getSelection: () => ({
+        rangeCount: 1,
+        getRangeAt: () => ({ startContainer }),
+      }),
+    } as any)
 
     handleCompositionStart(event, textarea, editor)
     await flushPromises()
 
-    expect(Editor.deleteFragment).toHaveBeenCalledWith(editor)
+    expect(Editor.deleteFragment).not.toHaveBeenCalled()
+    expect(textarea.changeViewState).not.toHaveBeenCalled()
+    expect(editorSelectionToDOM).not.toHaveBeenCalled()
     expect(textarea.isComposing).toBe(true)
-    expect(hidePlaceholder).toHaveBeenCalledWith(textarea, editor)
-    expect(editorSelectionToDOM).toHaveBeenCalledWith(textarea, editor, true)
   })
 
   it('marks composing state on update', () => {

--- a/packages/core/src/text-area/event-handlers/composition.ts
+++ b/packages/core/src/text-area/event-handlers/composition.ts
@@ -128,6 +128,7 @@ export function handleCompositionStart(e: Event, textarea: TextArea, editor: IDo
 
   if (!hasEditableTarget(editor, event.target)) { return }
   EDITOR_TO_PENDING_SELECTION.delete(editor)
+  textarea.isComposing = true
 
   const { selection } = editor
 
@@ -146,16 +147,14 @@ export function handleCompositionStart(e: Event, textarea: TextArea, editor: IDo
 
   if (selection && Range.isExpanded(selection)) {
     Editor.deleteFragment(editor)
-
+    // Flush the deletion before the browser mutates the native composition range.
+    // This also queues the new Slate-to-DOM mappings ahead of the caret restore.
+    textarea.changeViewState()
     Promise.resolve().then(() => {
-      // deleteFragment 会在一个 Promise 后更新 dom，导致浏览器选区不正确
-      // 因此这里延迟一下再设置选区，使选区在正确位置
-      // 这里 model 选区没有发生变化，不能使用 editor.restoreSelection
-      // restoreSelection 会对比前后 model 选区是否相同，相同就不更新了
+      // Restore the collapsed caret after the new mappings point at connected nodes.
       editorSelectionToDOM(textarea, editor, true)
     })
   }
-  textarea.isComposing = true
 
   // 隐藏 placeholder
   hidePlaceholder(textarea, editor)

--- a/tests/e2e/editor.smoke.spec.ts
+++ b/tests/e2e/editor.smoke.spec.ts
@@ -53,7 +53,19 @@ const runDividerUndoImeScenario = async (page: Page) => {
     pageErrors.push(err?.stack || err?.message || String(err))
   })
 
-  await focusEditor(page)
+  await setEditorHtml(page, '<p>ime anchor</p>')
+  await page.evaluate(() => {
+    const editor = (window as any).wangEditorExampleBridge?.editor
+
+    if (!editor) {
+      throw new Error('[smoke] editor instance is not ready')
+    }
+    editor.focus()
+    editor.select({
+      anchor: { path: [0, 0], offset: 10 },
+      focus: { path: [0, 0], offset: 10 },
+    })
+  })
   await waitForMenuEnabled(page, 'divider')
   await getToolbarMenu(page, 'divider').click()
 
@@ -125,6 +137,98 @@ const runDividerUndoImeScenario = async (page: Page) => {
   expect(fatalErrors).toEqual([])
 }
 
+const runSelectedTextImeScenario = async (page: Page) => {
+  const pageErrors: string[] = []
+
+  page.on('pageerror', err => {
+    pageErrors.push(err?.stack || err?.message || String(err))
+  })
+
+  await setEditorHtml(page, '<p>abc</p>')
+  await page.evaluate(() => {
+    const editor = (window as any).wangEditorExampleBridge?.editor
+    const editable = document.querySelector(
+      '[data-testid="editor-textarea"] [contenteditable="true"]',
+    )
+
+    if (!editor || !editable) {
+      throw new Error('[smoke] editor is not ready')
+    }
+    editor.focus()
+    editor.select({
+      anchor: { path: [0, 0], offset: 0 },
+      focus: { path: [0, 0], offset: 3 },
+    })
+    editable.dispatchEvent(new CompositionEvent('compositionstart', {
+      data: '',
+      bubbles: true,
+    }))
+  })
+
+  await expect.poll(() => page.evaluate(() => {
+    const editor = (window as any).wangEditorExampleBridge?.editor
+    const editable = document.querySelector(
+      '[data-testid="editor-textarea"] [contenteditable="true"]',
+    )
+    const selection = window.getSelection()
+
+    return {
+      anchorConnected: selection?.anchorNode?.isConnected ?? false,
+      collapsed: selection?.isCollapsed ?? false,
+      html: editor?.getHtml() || '',
+      rangeCount: selection?.rangeCount || 0,
+      selectionInside: !!selection?.anchorNode && !!editable?.contains(selection.anchorNode),
+    }
+  })).toEqual({
+    anchorConnected: true,
+    collapsed: true,
+    html: '<p><br></p>',
+    rangeCount: 1,
+    selectionInside: true,
+  })
+
+  await page.evaluate(() => {
+    const editable = document.querySelector(
+      '[data-testid="editor-textarea"] [contenteditable="true"]',
+    )
+
+    if (!editable) {
+      throw new Error('[smoke] editable not found')
+    }
+    editable.dispatchEvent(new CompositionEvent('compositionend', {
+      data: '你',
+      bubbles: true,
+    }))
+  })
+  await expect.poll(() => page.evaluate(() => {
+    const editor = (window as any).wangEditorExampleBridge?.editor
+    const editable = document.querySelector(
+      '[data-testid="editor-textarea"] [contenteditable="true"]',
+    )
+
+    return {
+      domText: (editable?.textContent || '').replace(/\uFEFF/g, ''),
+      html: editor?.getHtml() || '',
+      modelText: editor?.getText() || '',
+    }
+  })).toEqual({
+    domText: '你',
+    html: '<p>你</p>',
+    modelText: '你',
+  })
+
+  await page.keyboard.type('x')
+  await expect.poll(() => page.evaluate(() => {
+    return (window as any).wangEditorExampleBridge?.editor?.getHtml() || ''
+  })).toBe('<p>你x</p>')
+
+  await page.keyboard.press('Backspace')
+  await expect.poll(() => page.evaluate(() => {
+    return (window as any).wangEditorExampleBridge?.editor?.getHtml() || ''
+  })).toBe('<p>你</p>')
+  expect(pageErrors).toEqual([])
+}
+
 test.describe('Cross Browser Smoke', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/examples/default-mode.html')
@@ -188,5 +292,9 @@ test.describe('Cross Browser Smoke', () => {
 
   test('regression #892: divider -> undo -> composition should stay stable', async ({ page }) => {
     await runDividerUndoImeScenario(page)
+  })
+
+  test('regression #947: selected text composition keeps the caret connected', async ({ page }) => {
+    await runSelectedTextImeScenario(page)
   })
 })

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -27,6 +27,206 @@ const selectAll = async (page: Page) => {
   await page.keyboard.press('Control+A')
 }
 
+type NativeImeSelection = {
+  anchor: { path: number[], offset: number }
+  focus: { path: number[], offset: number }
+}
+
+type NativeImeSelectionCase = {
+  name: string
+  html: string
+  selection: NativeImeSelection | null
+  selectedText: string
+  composingText: string
+  committedHtml: string
+  committedText: string
+}
+
+const nativeImeSelectionCases: NativeImeSelectionCase[] = [
+  {
+    name: 'full selection',
+    html: '<p>abc</p>',
+    selection: null,
+    selectedText: 'abc',
+    composingText: 's',
+    committedHtml: '<p>是</p>',
+    committedText: '是',
+  },
+  {
+    name: 'backward partial selection',
+    html: '<p>abcdef</p>',
+    selection: {
+      anchor: { path: [0, 0], offset: 4 },
+      focus: { path: [0, 0], offset: 1 },
+    },
+    selectedText: 'bcd',
+    composingText: 'asef',
+    committedHtml: '<p>a是ef</p>',
+    committedText: 'a是ef',
+  },
+  {
+    name: 'cross-block formatted selection',
+    html: '<p>A<strong>BC</strong></p><p><em>DE</em>F</p>',
+    selection: {
+      anchor: { path: [0, 0], offset: 1 },
+      focus: { path: [1, 1], offset: 0 },
+    },
+    selectedText: 'BCDE',
+    composingText: 'AsF',
+    committedHtml: '<p>A是F</p>',
+    committedText: 'A是F',
+  },
+]
+
+const runNativeImeSelectionScenario = async (
+  page: Page,
+  scenario: NativeImeSelectionCase,
+) => {
+  const pageErrors: string[] = []
+
+  page.on('pageerror', err => {
+    pageErrors.push(err?.stack || err?.message || String(err))
+  })
+
+  await page.evaluate(html => {
+    const editor = (window as any).wangEditorExampleBridge?.editor
+
+    if (!editor) {
+      throw new Error('editor not ready')
+    }
+    editor.setHtml(html)
+  }, scenario.html)
+  await expect.poll(() => page.evaluate(() => {
+    return (window as any).wangEditorExampleBridge?.editor?.getHtml() || ''
+  })).toBe(scenario.html)
+
+  if (scenario.selection) {
+    await page.evaluate(selection => {
+      const editor = (window as any).wangEditorExampleBridge?.editor
+
+      if (!editor) {
+        throw new Error('editor not ready')
+      }
+      editor.focus()
+      editor.select(selection)
+    }, scenario.selection)
+  } else {
+    await selectAll(page)
+  }
+
+  await expect.poll(() => page.evaluate(() => {
+    const editor = (window as any).wangEditorExampleBridge?.editor
+    const domText = window.getSelection()?.toString().replace(/\s/g, '') || ''
+
+    return {
+      domText,
+      modelText: editor?.getSelectionText() || '',
+    }
+  })).toEqual({
+    domText: scenario.selectedText,
+    modelText: scenario.selectedText,
+  })
+
+  await page.evaluate(() => {
+    const editable = document.querySelector(
+      '[data-testid="editor-textarea"] [contenteditable="true"]',
+    )
+
+    if (!editable) {
+      throw new Error('editable not found')
+    }
+    const eventStore = window as any
+
+    eventStore.__nativeImeEvents = []
+    for (const type of ['compositionstart', 'compositionend']) {
+      editable.addEventListener(type, () => {
+        eventStore.__nativeImeEvents.push(type)
+      })
+    }
+  })
+
+  const cdp = await page.context().newCDPSession(page)
+
+  await cdp.send('Input.imeSetComposition', {
+    text: 's',
+    selectionStart: 1,
+    selectionEnd: 1,
+  })
+
+  await expect.poll(() => page.evaluate(() => {
+    const editable = document.querySelector(
+      '[data-testid="editor-textarea"] [contenteditable="true"]',
+    )
+    const selection = window.getSelection()
+
+    return {
+      active: document.activeElement === editable,
+      anchorConnected: selection?.anchorNode?.isConnected ?? false,
+      collapsed: selection?.isCollapsed ?? false,
+      domText: (editable?.textContent || '').replace(/\uFEFF/g, ''),
+      focusConnected: selection?.focusNode?.isConnected ?? false,
+      rangeCount: selection?.rangeCount || 0,
+      selectionInside: !!selection?.anchorNode && !!editable?.contains(selection.anchorNode),
+    }
+  })).toEqual({
+    active: true,
+    anchorConnected: true,
+    collapsed: true,
+    domText: scenario.composingText,
+    focusConnected: true,
+    rangeCount: 1,
+    selectionInside: true,
+  })
+
+  await cdp.send('Input.insertText', { text: '是' })
+
+  await expect.poll(() => page.evaluate(() => {
+    const editor = (window as any).wangEditorExampleBridge?.editor
+    const editable = document.querySelector(
+      '[data-testid="editor-textarea"] [contenteditable="true"]',
+    )
+    const selection = window.getSelection()
+    const modelSelection = editor?.selection
+
+    return {
+      anchorConnected: selection?.anchorNode?.isConnected ?? false,
+      collapsed: selection?.isCollapsed ?? false,
+      domText: (editable?.textContent || '').replace(/\uFEFF/g, ''),
+      html: editor?.getHtml() || '',
+      modelSelectionCollapsed: !!modelSelection
+        && JSON.stringify(modelSelection.anchor) === JSON.stringify(modelSelection.focus),
+      modelText: editor?.getText() || '',
+      rangeCount: selection?.rangeCount || 0,
+    }
+  })).toEqual({
+    anchorConnected: true,
+    collapsed: true,
+    domText: scenario.committedText,
+    html: scenario.committedHtml,
+    modelSelectionCollapsed: true,
+    modelText: scenario.committedText,
+    rangeCount: 1,
+  })
+
+  const typedHtml = scenario.committedHtml.replace('是', '是x')
+
+  await page.keyboard.type('x')
+  await expect.poll(() => page.evaluate(() => {
+    return (window as any).wangEditorExampleBridge?.editor?.getHtml() || ''
+  })).toBe(typedHtml)
+
+  await page.keyboard.press('Backspace')
+  await expect.poll(() => page.evaluate(() => {
+    return (window as any).wangEditorExampleBridge?.editor?.getHtml() || ''
+  })).toBe(scenario.committedHtml)
+
+  const imeEvents = await page.evaluate(() => (window as any).__nativeImeEvents) as string[]
+
+  expect(imeEvents.filter(type => type === 'compositionstart')).toHaveLength(1)
+  expect(imeEvents.filter(type => type === 'compositionend')).toHaveLength(1)
+  expect(pageErrors).toEqual([])
+}
+
 const waitForMenuEnabled = async (page: Page, menuKey: string) => {
   const menu = getToolbarMenu(page, menuKey)
 
@@ -225,6 +425,13 @@ test.describe('Basic Editor', () => {
     await expect(page.getByTestId('editor-html')).toContainText('<p>你</p>')
     expect(pageErrors).toEqual([])
   })
+
+  for (const scenario of nativeImeSelectionCases) {
+    test(`regression #947: native IME replaces ${scenario.name}`, async ({ page, browserName }) => {
+      test.skip(browserName !== 'chromium', 'CDP IME input is only available in Chromium')
+      await runNativeImeSelectionScenario(page, scenario)
+    })
+  }
 
   test('regression #793: repeated composition on long text should not throw DOM point error', async ({ page }) => {
     const pageErrors: string[] = []


### PR DESCRIPTION
## Changes Overview

Fix IME replacement of an expanded selection losing its native caret or throwing
`removeChild` `NotFoundError` after Chrome starts mutating the contenteditable DOM.

Add regression coverage for full selection, backward partial selection, and a
cross-block selection spanning formatted text.

## Implementation Approach

- Mark the textarea as composing before deleting an expanded Slate selection.
- Flush the deletion to the view before the browser mutates the native composition range.
- Restore the forced DOM caret in the next microtask, after new Slate-to-DOM mappings exist.
- Keep collapsed-selection composition behavior unchanged.

## Testing Done

- `pnpm build` (23/23 tasks; published declaration check passed for 5448 files)
- Core composition unit tests: 13/13 passed
- Core full test suite: 303/303 passed
- Editor full test suite: 23/23 passed
- Chromium IME regressions #793, #813, #861, #892, and #947: 8/8 passed
- Chromium/Firefox/WebKit smoke matrix: 24/24 passed
- Chrome for Testing 150.0.7871.124 native CDP matrix: 3/3 passed
- ESLint for all changed TypeScript files and `git diff --check`

## Verification Steps

1. Enter text in the editor and select all of it.
2. Start Chinese IME composition by entering `s`.
3. Confirm the composition text and caret remain visible, then commit a candidate.
4. Repeat with a partial selection and a selection spanning blocks/formatted text.
5. Confirm typing and Backspace continue to work without page errors.

## Additional Notes

- Native IME DOM mutation is covered with Chromium CDP. Firefox and WebKit cover the
  expanded-selection handler using cross-browser composition smoke tests.
- Risk is limited to one additional synchronous view refresh when composition starts with
  an expanded selection. A collapsed caret follows the existing path.
- Rollback: revert commit `e00ed70d`.

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Fixes #947


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IME composition behavior when replacing selected editor content.
  * Preserved the caret and selection state during composition, including formatted and cross-block selections.
  * Ensured subsequent typing and deletion continue to work correctly after IME input.

* **Tests**
  * Added regression coverage for native IME input across multiple selection scenarios and browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->