### PR TITLE
ci(release): add package source tags

### DIFF
--- a/.github/scripts/__tests__/derive-release-packages.test.js
+++ b/.github/scripts/__tests__/derive-release-packages.test.js
@@ -48,6 +48,7 @@ test('derives all package versions changed by a release commit', () => {
       { name: '@wangeditor-next/editor', version: '1.1.0' },
       { name: '@wangeditor-next/table-module', version: '1.0.0' },
     ])
+    assert.equal(result.stderr, '')
   } finally {
     fs.rmSync(rootDir, { recursive: true, force: true })
   }

--- a/.github/scripts/__tests__/derive-release-packages.test.js
+++ b/.github/scripts/__tests__/derive-release-packages.test.js
@@ -1,0 +1,81 @@
+const assert = require('node:assert/strict')
+const { execFileSync, spawnSync } = require('node:child_process')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const test = require('node:test')
+
+const scriptPath = path.resolve(__dirname, '../derive-release-packages.js')
+
+function git(rootDir, args) {
+  return execFileSync('git', args, { cwd: rootDir, encoding: 'utf8' }).trim()
+}
+
+function writePackage(rootDir, directory, name, version) {
+  const packageDir = path.join(rootDir, 'packages', directory)
+  fs.mkdirSync(packageDir, { recursive: true })
+  fs.writeFileSync(
+    path.join(packageDir, 'package.json'),
+    `${JSON.stringify({ name, version }, null, 2)}\n`
+  )
+}
+
+test('derives all package versions changed by a release commit', () => {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wangeditor-release-source-'))
+
+  try {
+    git(rootDir, ['init', '-q'])
+    git(rootDir, ['config', 'user.name', 'Test User'])
+    git(rootDir, ['config', 'user.email', 'test@example.com'])
+    writePackage(rootDir, 'editor', '@wangeditor-next/editor', '1.0.0')
+    writePackage(rootDir, 'core', '@wangeditor-next/core', '1.0.0')
+    git(rootDir, ['add', '.'])
+    git(rootDir, ['commit', '-m', 'chore: initial packages'])
+
+    writePackage(rootDir, 'editor', '@wangeditor-next/editor', '1.1.0')
+    writePackage(rootDir, 'table-module', '@wangeditor-next/table-module', '1.0.0')
+    git(rootDir, ['add', '.'])
+    git(rootDir, ['commit', '-m', 'chore: release packages'])
+    const releaseSha = git(rootDir, ['rev-parse', 'HEAD'])
+
+    const result = spawnSync(process.execPath, [scriptPath, releaseSha], {
+      cwd: rootDir,
+      encoding: 'utf8',
+    })
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.deepEqual(JSON.parse(result.stdout), [
+      { name: '@wangeditor-next/editor', version: '1.1.0' },
+      { name: '@wangeditor-next/table-module', version: '1.0.0' },
+    ])
+  } finally {
+    fs.rmSync(rootDir, { recursive: true, force: true })
+  }
+})
+
+test('rejects a commit without package version changes', () => {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wangeditor-release-source-'))
+
+  try {
+    git(rootDir, ['init', '-q'])
+    git(rootDir, ['config', 'user.name', 'Test User'])
+    git(rootDir, ['config', 'user.email', 'test@example.com'])
+    writePackage(rootDir, 'editor', '@wangeditor-next/editor', '1.0.0')
+    git(rootDir, ['add', '.'])
+    git(rootDir, ['commit', '-m', 'chore: initial package'])
+    fs.writeFileSync(path.join(rootDir, 'README.md'), 'no package version change\n')
+    git(rootDir, ['add', 'README.md'])
+    git(rootDir, ['commit', '-m', 'docs: update readme'])
+    const releaseSha = git(rootDir, ['rev-parse', 'HEAD'])
+
+    const result = spawnSync(process.execPath, [scriptPath, releaseSha], {
+      cwd: rootDir,
+      encoding: 'utf8',
+    })
+
+    assert.notEqual(result.status, 0)
+    assert.match(result.stderr, /does not declare any package version changes/)
+  } finally {
+    fs.rmSync(rootDir, { recursive: true, force: true })
+  }
+})

--- a/.github/scripts/__tests__/push-package-release-tags.test.js
+++ b/.github/scripts/__tests__/push-package-release-tags.test.js
@@ -4,6 +4,7 @@ const { spawnSync } = require('node:child_process')
 const fs = require('node:fs')
 const os = require('node:os')
 const path = require('node:path')
+const editorVersion = require('../../../packages/editor/package.json').version
 
 const { getPackageTag, parsePublishedPackages } = require('../push-package-release-tags')
 
@@ -51,11 +52,7 @@ exit 1
   try {
     const result = spawnSync(
       process.execPath,
-      [
-        scriptPath,
-        '[{"name":"@wangeditor-next/editor","version":"6.0.2"}]',
-        '--dry-run',
-      ],
+      [scriptPath, '[{"name":"@wangeditor-next/editor","version":"6.0.2"}]', '--dry-run'],
       {
         cwd: rootDir,
         encoding: 'utf8',
@@ -65,6 +62,60 @@ exit 1
 
     assert.notEqual(result.status, 0)
     assert.match(result.stderr, /git ls-remote/)
+  } finally {
+    fs.rmSync(temporaryBin, { recursive: true, force: true })
+  }
+})
+
+test('continues after pushing a newly created package tag', () => {
+  const temporaryBin = fs.mkdtempSync(path.join(os.tmpdir(), 'wangeditor-fake-git-'))
+  const fakeGit = path.join(temporaryBin, 'git')
+  const gitLog = path.join(temporaryBin, 'git.log')
+  const scriptPath = path.resolve(__dirname, '../push-package-release-tags.js')
+  const rootDir = path.resolve(__dirname, '../../..')
+
+  fs.writeFileSync(
+    fakeGit,
+    `#!/bin/sh
+if [ "$1" = "rev-parse" ] && [ "$2" = "HEAD" ]; then
+  printf '%s\\n' '${'a'.repeat(40)}'
+  exit 0
+fi
+
+if [ "$1" = "tag" ]; then
+  printf '%s\\n' "$*" >> "\${FAKE_GIT_LOG}"
+  exit 0
+fi
+
+if [ "$1" = "rev-parse" ] || [ "$1" = "ls-remote" ] || [ "$1" = "push" ]; then
+  exit 0
+fi
+
+exit 1
+`
+  )
+  fs.chmodSync(fakeGit, 0o755)
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [scriptPath, JSON.stringify([{ name: '@wangeditor-next/editor', version: editorVersion }])],
+      {
+        cwd: rootDir,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          FAKE_GIT_LOG: gitLog,
+          GITHUB_SHA: 'b'.repeat(40),
+          PATH: `${temporaryBin}:${process.env.PATH}`,
+        },
+      }
+    )
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /created=true\tpushed=true/)
+    assert.match(fs.readFileSync(gitLog, 'utf8'), new RegExp(`${'a'.repeat(40)}`))
+    assert.doesNotMatch(fs.readFileSync(gitLog, 'utf8'), new RegExp(`${'b'.repeat(40)}`))
   } finally {
     fs.rmSync(temporaryBin, { recursive: true, force: true })
   }

--- a/.github/scripts/__tests__/push-package-release-tags.test.js
+++ b/.github/scripts/__tests__/push-package-release-tags.test.js
@@ -1,0 +1,71 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const { spawnSync } = require('node:child_process')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+const { getPackageTag, parsePublishedPackages } = require('../push-package-release-tags')
+
+test('formats package source tags with the exact npm package version', () => {
+  assert.equal(
+    getPackageTag('@wangeditor-next/table-module', '3.0.2'),
+    '@wangeditor-next/table-module@3.0.2'
+  )
+})
+
+test('parses the publishedPackages output from changesets', () => {
+  assert.deepEqual(
+    parsePublishedPackages('[{"name":"@wangeditor-next/editor","version":"5.7.11"}]'),
+    [{ name: '@wangeditor-next/editor', version: '5.7.11' }]
+  )
+})
+
+test('rejects malformed publishedPackages output', () => {
+  assert.throws(() => parsePublishedPackages('{'), /JSON array/)
+  assert.throws(
+    () => parsePublishedPackages('[{"name":"@wangeditor-next/editor"}]'),
+    /non-empty name and version/
+  )
+})
+
+test('refuses to treat an unverifiable remote tag as absent', () => {
+  const temporaryBin = fs.mkdtempSync(path.join(os.tmpdir(), 'wangeditor-fake-git-'))
+  const fakeGit = path.join(temporaryBin, 'git')
+  const scriptPath = path.resolve(__dirname, '../push-package-release-tags.js')
+  const rootDir = path.resolve(__dirname, '../../..')
+
+  fs.writeFileSync(
+    fakeGit,
+    `#!/bin/sh
+if [ "$1" = "rev-parse" ] && [ "$2" = "HEAD" ]; then
+  printf '%s\\n' '${'a'.repeat(40)}'
+  exit 0
+fi
+
+exit 1
+`
+  )
+  fs.chmodSync(fakeGit, 0o755)
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        scriptPath,
+        '[{"name":"@wangeditor-next/editor","version":"6.0.2"}]',
+        '--dry-run',
+      ],
+      {
+        cwd: rootDir,
+        encoding: 'utf8',
+        env: { ...process.env, PATH: `${temporaryBin}:${process.env.PATH}` },
+      }
+    )
+
+    assert.notEqual(result.status, 0)
+    assert.match(result.stderr, /git ls-remote/)
+  } finally {
+    fs.rmSync(temporaryBin, { recursive: true, force: true })
+  }
+})

--- a/.github/scripts/__tests__/release-utils.test.js
+++ b/.github/scripts/__tests__/release-utils.test.js
@@ -3,6 +3,7 @@ const { spawnSync } = require('node:child_process')
 const fs = require('node:fs')
 const os = require('node:os')
 const path = require('node:path')
+const editorVersion = require('../../../packages/editor/package.json').version
 const test = require('node:test')
 
 const { getEditorRelease, parsePublishedPackages } = require('../release-utils')
@@ -51,6 +52,100 @@ test('leaf-only publishes explicitly mark the product release as skipped', () =>
     assert.equal(result.status, 0, result.stderr)
     assert.match(result.stdout, /No editor package was published/)
     assert.equal(fs.readFileSync(outputPath, 'utf8'), 'editor_published=false\ntag=\nversion=\n')
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  }
+})
+
+test('reads published packages from the environment', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wangeditor-release-test-'))
+  const outputPath = path.join(tempDir, 'github-output')
+  const scriptPath = path.resolve(__dirname, '../create-consolidated-release.js')
+
+  try {
+    const result = spawnSync(process.execPath, [scriptPath], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        GITHUB_OUTPUT: outputPath,
+        PUBLISHED_PACKAGES: '[{"name":"@wangeditor-next/core","version":"1.9.8"}]',
+      },
+    })
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /No editor package was published/)
+    assert.equal(fs.readFileSync(outputPath, 'utf8'), 'editor_published=false\ntag=\nversion=\n')
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  }
+})
+
+test('creates a product release from the checked-out commit', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wangeditor-release-test-'))
+  const temporaryBin = path.join(tempDir, 'bin')
+  const fakeGit = path.join(temporaryBin, 'git')
+  const fakeGh = path.join(temporaryBin, 'gh')
+  const ghLog = path.join(tempDir, 'gh.log')
+  const outputPath = path.join(tempDir, 'github-output')
+  const scriptPath = path.resolve(__dirname, '../create-consolidated-release.js')
+  const rootDir = path.resolve(__dirname, '../../..')
+
+  fs.mkdirSync(temporaryBin)
+  fs.writeFileSync(
+    fakeGit,
+    `#!/bin/sh
+if [ "$1" = "rev-parse" ] && [ "$2" = "HEAD" ]; then
+  printf '%s\\n' '${'a'.repeat(40)}'
+  exit 0
+fi
+
+if [ "$1" = "ls-remote" ]; then
+  exit 0
+fi
+
+exit 1
+`
+  )
+  fs.writeFileSync(
+    fakeGh,
+    `#!/bin/sh
+if [ "$1" = "release" ] && [ "$2" = "view" ]; then
+  echo 'release not found' >&2
+  exit 1
+fi
+
+if [ "$1" = "release" ] && [ "$2" = "create" ]; then
+  printf '%s\\n' "$*" >> "\${FAKE_GH_LOG}"
+  exit 0
+fi
+
+exit 1
+`
+  )
+  fs.chmodSync(fakeGit, 0o755)
+  fs.chmodSync(fakeGh, 0o755)
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [scriptPath, JSON.stringify([{ name: '@wangeditor-next/editor', version: editorVersion }])],
+      {
+        cwd: rootDir,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          FAKE_GH_LOG: ghLog,
+          GITHUB_OUTPUT: outputPath,
+          GITHUB_SHA: 'b'.repeat(40),
+          PATH: `${temporaryBin}:${process.env.PATH}`,
+        },
+      }
+    )
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(fs.readFileSync(ghLog, 'utf8'), new RegExp(`--target ${'a'.repeat(40)}`))
+    assert.doesNotMatch(fs.readFileSync(ghLog, 'utf8'), new RegExp(`${'b'.repeat(40)}`))
+    assert.match(fs.readFileSync(outputPath, 'utf8'), /editor_published=true/)
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true })
   }

--- a/.github/scripts/__tests__/release-utils.test.js
+++ b/.github/scripts/__tests__/release-utils.test.js
@@ -1,0 +1,57 @@
+const assert = require('node:assert/strict')
+const { spawnSync } = require('node:child_process')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const test = require('node:test')
+
+const { getEditorRelease, parsePublishedPackages } = require('../release-utils')
+
+test('identifies an editor product release only when editor was published', () => {
+  const leafPackages = parsePublishedPackages(
+    '[{"name":"@wangeditor-next/core","version":"1.9.8"}]'
+  )
+  const editorPackages = parsePublishedPackages(
+    '[{"name":"@wangeditor-next/core","version":"1.9.8"},{"name":"@wangeditor-next/editor","version":"6.0.2"}]'
+  )
+
+  assert.equal(getEditorRelease(leafPackages), null)
+  assert.deepEqual(getEditorRelease(editorPackages), {
+    name: '@wangeditor-next/editor',
+    version: '6.0.2',
+    tag: 'v6.0.2',
+  })
+})
+
+test('rejects duplicate package entries from a publish result', () => {
+  assert.throws(
+    () =>
+      parsePublishedPackages(
+        '[{"name":"@wangeditor-next/editor","version":"6.0.2"},{"name":"@wangeditor-next/editor","version":"6.0.2"}]'
+      ),
+    /appears more than once/
+  )
+})
+
+test('leaf-only publishes explicitly mark the product release as skipped', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wangeditor-release-test-'))
+  const outputPath = path.join(tempDir, 'github-output')
+  const scriptPath = path.resolve(__dirname, '../create-consolidated-release.js')
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [scriptPath, '[{"name":"@wangeditor-next/core","version":"1.9.8"}]'],
+      {
+        encoding: 'utf8',
+        env: { ...process.env, GITHUB_OUTPUT: outputPath },
+      }
+    )
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /No editor package was published/)
+    assert.equal(fs.readFileSync(outputPath, 'utf8'), 'editor_published=false\ntag=\nversion=\n')
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  }
+})

--- a/.github/scripts/__tests__/release-workflow-policy.test.js
+++ b/.github/scripts/__tests__/release-workflow-policy.test.js
@@ -1,0 +1,41 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const test = require('node:test')
+
+const rootDir = path.resolve(__dirname, '../../..')
+const releaseWorkflow = fs.readFileSync(path.join(rootDir, '.github/workflows/release.yml'), 'utf8')
+const repairWorkflow = fs.readFileSync(
+  path.join(rootDir, '.github/workflows/repair-release-provenance.yml'),
+  'utf8'
+)
+
+test('release only publishes from master through the protected automation environment', () => {
+  assert.match(releaseWorkflow, /push:\n\s+branches:\n\s+- master\n/)
+  assert.doesNotMatch(releaseWorkflow, /workflow_dispatch:/)
+  assert.match(releaseWorkflow, /id: release_work/)
+  assert.match(releaseWorkflow, /needs: validate/)
+  assert.match(releaseWorkflow, /if: needs\.validate\.outputs\.requires_release == 'true'/)
+  assert.match(releaseWorkflow, /environment: release-automation/)
+  assert.match(releaseWorkflow, /contents: read/)
+  assert.match(releaseWorkflow, /pull-requests: read/)
+  assert.doesNotMatch(releaseWorkflow, /id-token: write/)
+  assert.match(releaseWorkflow, /secrets\.NPM_RELEASE_TOKEN/)
+  assert.match(releaseWorkflow, /secrets\.RELEASE_AUTOMATION_TOKEN/)
+  assert.doesNotMatch(releaseWorkflow, /secrets\.NPM_TOKEN/)
+  assert.doesNotMatch(releaseWorkflow, /secrets\.DOCS_REPO_DISPATCH_TOKEN/)
+  assert.doesNotMatch(releaseWorkflow, /secrets\.GITHUB_TOKEN/)
+})
+
+test(
+  'repair only trusts master release runs and uses the protected automation token to write',
+  () => {
+    assert.match(repairWorkflow, /workflow_dispatch:/)
+    assert.match(repairWorkflow, /if: github\.ref == 'refs\/heads\/master'/)
+    assert.match(repairWorkflow, /\[ "\$\{run_branch\}" != 'master' \]/)
+    assert.match(repairWorkflow, /environment: release-automation/)
+    assert.match(repairWorkflow, /contents: read/)
+    assert.match(repairWorkflow, /GH_TOKEN: \$\{\{ secrets\.RELEASE_AUTOMATION_TOKEN \}\}/)
+    assert.doesNotMatch(repairWorkflow, /secrets\.DOCS_REPO_DISPATCH_TOKEN/)
+  }
+)

--- a/.github/scripts/__tests__/release-workflow-policy.test.js
+++ b/.github/scripts/__tests__/release-workflow-policy.test.js
@@ -10,6 +10,15 @@ const repairWorkflow = fs.readFileSync(
   'utf8'
 )
 
+function getReleaseSubjectPattern(workflow) {
+  const match = workflow.match(
+    /release_subject_pattern='([^']+)'\n\s+release_subject_pattern\+='([^']+)'/
+  )
+
+  assert.ok(match, 'workflow must define a release subject pattern')
+  return new RegExp(`${match[1]}${match[2]}`)
+}
+
 test('release only publishes from master through the protected automation environment', () => {
   assert.match(releaseWorkflow, /push:\n\s+branches:\n\s+- master\n/)
   assert.doesNotMatch(releaseWorkflow, /workflow_dispatch:/)
@@ -27,15 +36,22 @@ test('release only publishes from master through the protected automation enviro
   assert.doesNotMatch(releaseWorkflow, /secrets\.GITHUB_TOKEN/)
 })
 
-test(
-  'repair only trusts master release runs and uses the protected automation token to write',
-  () => {
-    assert.match(repairWorkflow, /workflow_dispatch:/)
-    assert.match(repairWorkflow, /if: github\.ref == 'refs\/heads\/master'/)
-    assert.match(repairWorkflow, /\[ "\$\{run_branch\}" != 'master' \]/)
-    assert.match(repairWorkflow, /environment: release-automation/)
-    assert.match(repairWorkflow, /contents: read/)
-    assert.match(repairWorkflow, /GH_TOKEN: \$\{\{ secrets\.RELEASE_AUTOMATION_TOKEN \}\}/)
-    assert.doesNotMatch(repairWorkflow, /secrets\.DOCS_REPO_DISPATCH_TOKEN/)
-  }
-)
+test('release detection recognizes the Changesets merge commit subject', () => {
+  const pattern = getReleaseSubjectPattern(releaseWorkflow)
+
+  assert.match('chore(release): publish a new release version (#949)', pattern)
+  assert.doesNotMatch('chore(release): publish a new release version forged', pattern)
+})
+
+test('repair trusts master runs and uses the protected automation token', () => {
+  assert.match(repairWorkflow, /workflow_dispatch:/)
+  assert.match(repairWorkflow, /if: github\.ref == 'refs\/heads\/master'/)
+  assert.match(repairWorkflow, /\[ "\$\{run_branch\}" != 'master' \]/)
+  assert.match(repairWorkflow, /environment: release-automation/)
+  assert.match(repairWorkflow, /contents: read/)
+  assert.match(repairWorkflow, /GH_TOKEN: \$\{\{ secrets\.RELEASE_AUTOMATION_TOKEN \}\}/)
+  assert.doesNotMatch(repairWorkflow, /secrets\.DOCS_REPO_DISPATCH_TOKEN/)
+  const pattern = getReleaseSubjectPattern(repairWorkflow)
+
+  assert.match('chore(release): publish a new release version (#949)', pattern)
+})

--- a/.github/scripts/__tests__/verify-published-packages.test.js
+++ b/.github/scripts/__tests__/verify-published-packages.test.js
@@ -1,0 +1,81 @@
+const assert = require('node:assert/strict')
+const { spawnSync } = require('node:child_process')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const test = require('node:test')
+
+const editorVersion = require('../../../packages/editor/package.json').version
+
+test('verifies the package version in both the workspace and npm', () => {
+  const temporaryBin = fs.mkdtempSync(path.join(os.tmpdir(), 'wangeditor-fake-npm-'))
+  const fakeNpm = path.join(temporaryBin, 'npm')
+  const scriptPath = path.resolve(__dirname, '../verify-published-packages.js')
+  const rootDir = path.resolve(__dirname, '../../..')
+
+  fs.writeFileSync(
+    fakeNpm,
+    `#!/bin/sh
+if [ "$1" = "view" ]; then
+  printf '"%s"\\n' "$FAKE_NPM_VERSION"
+  exit 0
+fi
+
+exit 1
+`
+  )
+  fs.chmodSync(fakeNpm, 0o755)
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [scriptPath, JSON.stringify([{ name: '@wangeditor-next/editor', version: editorVersion }])],
+      {
+        cwd: rootDir,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          FAKE_NPM_VERSION: editorVersion,
+          PATH: `${temporaryBin}:${process.env.PATH}`,
+        },
+      }
+    )
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, new RegExp(`${editorVersion}\\tverified=true`))
+  } finally {
+    fs.rmSync(temporaryBin, { recursive: true, force: true })
+  }
+})
+
+test('rejects an npm version that does not match the release input', () => {
+  const temporaryBin = fs.mkdtempSync(path.join(os.tmpdir(), 'wangeditor-fake-npm-'))
+  const fakeNpm = path.join(temporaryBin, 'npm')
+  const scriptPath = path.resolve(__dirname, '../verify-published-packages.js')
+  const rootDir = path.resolve(__dirname, '../../..')
+
+  fs.writeFileSync(
+    fakeNpm,
+    `#!/bin/sh
+printf '"0.0.0"\\n'
+`
+  )
+  fs.chmodSync(fakeNpm, 0o755)
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [scriptPath, JSON.stringify([{ name: '@wangeditor-next/editor', version: editorVersion }])],
+      {
+        cwd: rootDir,
+        encoding: 'utf8',
+        env: { ...process.env, PATH: `${temporaryBin}:${process.env.PATH}` },
+      }
+    )
+
+    assert.notEqual(result.status, 0)
+    assert.match(result.stderr, /npm registry reports/)
+  } finally {
+    fs.rmSync(temporaryBin, { recursive: true, force: true })
+  }
+})

--- a/.github/scripts/create-consolidated-release.js
+++ b/.github/scripts/create-consolidated-release.js
@@ -9,7 +9,7 @@ const os = require('os')
 const path = require('path')
 const { getEditorRelease, parsePublishedPackages, writeGitHubOutput } = require('./release-utils')
 
-const publishedPackages = parsePublishedPackages(process.argv[2])
+const publishedPackages = parsePublishedPackages(process.argv[2] || process.env.PUBLISHED_PACKAGES)
 
 if (publishedPackages.length === 0) {
   console.log('No packages published, skipping release creation.')
@@ -35,7 +35,7 @@ function git(args) {
   return execFileSync('git', args, { encoding: 'utf8' }).trim()
 }
 
-const target = process.env.GITHUB_SHA || git(['rev-parse', 'HEAD'])
+const target = git(['rev-parse', 'HEAD'])
 
 function resolveLocalTag(tagName) {
   try {

--- a/.github/scripts/create-consolidated-release.js
+++ b/.github/scripts/create-consolidated-release.js
@@ -1,45 +1,80 @@
 #!/usr/bin/env node
-// Creates a single consolidated GitHub Release from all published packages.
+// Creates the product-level GitHub Release when the editor package is published.
 // Usage: node create-consolidated-release.js '<publishedPackagesJSON>'
 //   publishedPackagesJSON: JSON array of { name, version } objects (from changesets/action output)
 
-const { execSync } = require('child_process')
+const { execFileSync } = require('child_process')
 const fs = require('fs')
+const os = require('os')
 const path = require('path')
+const { getEditorRelease, parsePublishedPackages, writeGitHubOutput } = require('./release-utils')
 
-const publishedPackages = JSON.parse(process.argv[2] || '[]')
+const publishedPackages = parsePublishedPackages(process.argv[2])
 
 if (publishedPackages.length === 0) {
   console.log('No packages published, skipping release creation.')
+  writeGitHubOutput({ editor_published: 'false', tag: '', version: '' })
   process.exit(0)
 }
 
-// ── Tag ────────────────────────────────────────────────────────────────────
-// Prefer @wangeditor-next/editor version as the release tag.
-function resolveTag(packages) {
-  const priority = ['@wangeditor-next/editor', '@wangeditor-next/core']
-  for (const name of priority) {
-    const pkg = packages.find(p => p.name === name)
-    if (pkg) return `v${pkg.version}`
-  }
-  return `release/${new Date().toISOString().slice(0, 10)}`
+// ── Product release ────────────────────────────────────────────────────────
+// Leaf packages have their own @scope/package@version source tags. A product
+// release only exists when the public editor package itself is published.
+const editorRelease = getEditorRelease(publishedPackages)
+
+if (!editorRelease) {
+  console.log('No editor package was published; skip the product-level GitHub Release.')
+  writeGitHubOutput({ editor_published: 'false', tag: '', version: '' })
+  process.exit(0)
 }
 
-let tag = resolveTag(publishedPackages)
+const editorPkg = editorRelease
+const { tag } = editorRelease
 
-function tagExists(t) {
+function git(args) {
+  return execFileSync('git', args, { encoding: 'utf8' }).trim()
+}
+
+const target = process.env.GITHUB_SHA || git(['rev-parse', 'HEAD'])
+
+function resolveLocalTag(tagName) {
   try {
-    execSync(`gh release view "${t}"`, { stdio: 'pipe' })
-    return true
+    return git(['rev-parse', `${tagName}^{}`])
   } catch {
-    return false
+    return null
   }
 }
 
-if (tagExists(tag)) {
-  let i = 2
-  while (tagExists(`${tag}-${i}`)) i++
-  tag = `${tag}-${i}`
+function resolveRemoteTag(tagName) {
+  const output = git([
+    'ls-remote',
+    '--tags',
+    'origin',
+    `refs/tags/${tagName}`,
+    `refs/tags/${tagName}^{}`,
+  ])
+
+  if (!output) return null
+
+  const entries = output
+    .split('\n')
+    .map(line => line.split('\t'))
+    .filter(parts => parts.length === 2)
+  const dereferenced = entries.find(([, ref]) => ref === `refs/tags/${tagName}^{}`)
+
+  return (dereferenced || entries[0])[0]
+}
+
+const existingLocalTagTarget = resolveLocalTag(tag)
+if (existingLocalTagTarget && existingLocalTagTarget !== target) {
+  throw new Error(
+    `Local product tag ${tag} points to ${existingLocalTagTarget}, expected ${target}`
+  )
+}
+
+const existingTagTarget = resolveRemoteTag(tag)
+if (existingTagTarget && existingTagTarget !== target) {
+  throw new Error(`Product tag ${tag} points to ${existingTagTarget}, expected ${target}`)
 }
 
 // ── CHANGELOG helpers ──────────────────────────────────────────────────────
@@ -66,7 +101,11 @@ function parseChangelogSection(changelogPath, version, pkgName) {
 
   for (const line of lines) {
     if (/^## /.test(line)) {
-      if (line.includes(version)) { inSection = true; continue }
+      const headerVersion = line.match(/^##\s+\[?([^\]\s]+)\]?/)?.[1]
+      if (headerVersion === version) {
+        inSection = true
+        continue
+      }
       if (inSection) break
     }
     if (!inSection) continue
@@ -153,18 +192,21 @@ if (allChanges.length === 0) {
 }
 
 // ── Build package versions table ──────────────────────────────────────────
+const repository = process.env.GITHUB_REPOSITORY || 'wangeditor-next/wangEditor-next'
 const versionRows = publishedPackages
-  .map(({ name, version }) => `| \`${name}\` | \`${version}\` |`)
+  .map(({ name, version }) => {
+    const packageTag = `${name}@${version}`
+    const encodedTag = encodeURIComponent(packageTag)
+    const sourceUrl = `https://github.com/${repository}/tree/${encodedTag}`
+    const archiveUrl = `https://github.com/${repository}/archive/refs/tags/${encodedTag}.tar.gz`
+    return `| \`${name}\` | \`${version}\` | [Source](${sourceUrl}) ([tar.gz](${archiveUrl})) |`
+  })
   .join('\n')
 
-const versionsTable =
-  `| Package | Version |\n` +
-  `| --- | --- |\n` +
-  versionRows
+const versionsTable = `| Package | Version | Source |\n` + `| --- | --- | --- |\n` + versionRows
 
 // ── Compose full release body ──────────────────────────────────────────────
-const editorPkg = publishedPackages.find(p => p.name === '@wangeditor-next/editor')
-const title = editorPkg ? `v${editorPkg.version}` : tag
+const title = `v${editorPkg.version}`
 
 const body = `## What's Changed
 
@@ -177,17 +219,42 @@ ${versionsTable}
 
 </details>`
 
-const bodyFile = path.join(require('os').tmpdir(), 'release-body.md')
+const bodyFile = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'wangeditor-release-')), 'body.md')
 fs.writeFileSync(bodyFile, body)
 
-// ── Create GitHub Release ──────────────────────────────────────────────────
-execSync(
-  `gh release create "${tag}" --title "${title}" --notes-file "${bodyFile}"`,
-  { stdio: 'inherit' },
-)
-
-console.log(`\nConsolidated GitHub release created: ${tag}`)
-
-if (process.env.GITHUB_OUTPUT) {
-  fs.appendFileSync(process.env.GITHUB_OUTPUT, `tag=${tag}\n`)
+// ── Create or update GitHub Release ────────────────────────────────────────
+function isMissingReleaseError(error) {
+  const message = `${error.stdout || ''}\n${error.stderr || ''}`
+  return /release not found|could not resolve to a release|http 404/i.test(message)
 }
+
+function releaseExists(tagName) {
+  try {
+    execFileSync('gh', ['release', 'view', tagName, '--json', 'id'], { stdio: 'pipe' })
+    return true
+  } catch (error) {
+    if (isMissingReleaseError(error)) return false
+    throw error
+  }
+}
+
+const releaseArgs = ['--title', title, '--notes-file', bodyFile]
+if (editorPkg.version.includes('-')) {
+  releaseArgs.push('--prerelease')
+}
+
+if (releaseExists(tag)) {
+  execFileSync('gh', ['release', 'edit', tag, ...releaseArgs], { stdio: 'inherit' })
+  console.log(`\nProduct GitHub release updated: ${tag}`)
+} else {
+  const createArgs = ['release', 'create', tag]
+  if (!existingTagTarget) {
+    createArgs.push('--target', target)
+  }
+  createArgs.push(...releaseArgs)
+
+  execFileSync('gh', createArgs, { stdio: 'inherit' })
+  console.log(`\nProduct GitHub release created: ${tag}`)
+}
+
+writeGitHubOutput({ editor_published: 'true', tag, version: editorPkg.version })

--- a/.github/scripts/create-consolidated-release.js
+++ b/.github/scripts/create-consolidated-release.js
@@ -9,6 +9,8 @@ const os = require('os')
 const path = require('path')
 const { getEditorRelease, parsePublishedPackages, writeGitHubOutput } = require('./release-utils')
 
+const GIT_TIMEOUT_MS = 60_000
+
 const publishedPackages = parsePublishedPackages(process.argv[2] || process.env.PUBLISHED_PACKAGES)
 
 if (publishedPackages.length === 0) {
@@ -32,7 +34,7 @@ const editorPkg = editorRelease
 const { tag } = editorRelease
 
 function git(args) {
-  return execFileSync('git', args, { encoding: 'utf8' }).trim()
+  return execFileSync('git', args, { encoding: 'utf8', timeout: GIT_TIMEOUT_MS }).trim()
 }
 
 const target = git(['rev-parse', 'HEAD'])

--- a/.github/scripts/derive-release-packages.js
+++ b/.github/scripts/derive-release-packages.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+
+const { execFileSync } = require('child_process')
+const fs = require('fs')
+const path = require('path')
+
+function git(args) {
+  return execFileSync('git', args, { encoding: 'utf8' }).trim()
+}
+
+function readPackageJsonAtCommit(commit, packageDir) {
+  const packageJsonPath = `packages/${packageDir}/package.json`
+  try {
+    return JSON.parse(git(['show', `${commit}:${packageJsonPath}`]))
+  } catch {
+    return null
+  }
+}
+
+function deriveReleasePackages(releaseSha) {
+  if (!/^[a-f0-9]{40}$/.test(releaseSha)) {
+    throw new Error('release SHA must be a lowercase 40-character commit SHA')
+  }
+
+  const target = git(['rev-parse', `${releaseSha}^{commit}`])
+  if (target !== releaseSha) {
+    throw new Error(`release SHA resolved to ${target}, expected ${releaseSha}`)
+  }
+
+  const parent = git(['rev-parse', `${target}^`])
+  const packagesDir = path.join(process.cwd(), 'packages')
+  const packages = []
+
+  for (const entry of fs.readdirSync(packagesDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+
+    const packageJsonPath = path.join(packagesDir, entry.name, 'package.json')
+    if (!fs.existsSync(packageJsonPath)) continue
+
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+    const parentPackageJson = readPackageJsonAtCommit(parent, entry.name)
+    if (parentPackageJson?.version === packageJson.version) continue
+
+    packages.push({ name: packageJson.name, version: packageJson.version })
+  }
+
+  if (packages.length === 0) {
+    throw new Error(`Release commit ${releaseSha} does not declare any package version changes`)
+  }
+
+  return packages.sort((left, right) => left.name.localeCompare(right.name))
+}
+
+function main() {
+  const releaseSha = process.argv[2] || process.env.RELEASE_SHA
+  process.stdout.write(JSON.stringify(deriveReleasePackages(releaseSha)))
+}
+
+if (require.main === module) {
+  main()
+}
+
+module.exports = {
+  deriveReleasePackages,
+}

--- a/.github/scripts/derive-release-packages.js
+++ b/.github/scripts/derive-release-packages.js
@@ -5,7 +5,10 @@ const fs = require('fs')
 const path = require('path')
 
 function git(args) {
-  return execFileSync('git', args, { encoding: 'utf8' }).trim()
+  return execFileSync('git', args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim()
 }
 
 function readPackageJsonAtCommit(commit, packageDir) {

--- a/.github/scripts/push-package-release-tags.js
+++ b/.github/scripts/push-package-release-tags.js
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+const { execFileSync } = require('child_process')
+const fs = require('fs')
+const path = require('path')
+const { getPackageTag, parsePublishedPackages } = require('./release-utils')
+
+function getWorkspacePackage(rootDir, packageName) {
+  const packagesDir = path.join(rootDir, 'packages')
+
+  for (const entry of fs.readdirSync(packagesDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+
+    const packageJsonPath = path.join(packagesDir, entry.name, 'package.json')
+    if (!fs.existsSync(packageJsonPath)) continue
+
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+    if (packageJson.name === packageName) {
+      return { packageJson, packageJsonPath }
+    }
+  }
+
+  throw new Error(`Published package ${packageName} does not exist in packages/`)
+}
+
+function git(args, options = {}) {
+  return execFileSync('git', args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    ...options,
+  }).trim()
+}
+
+function resolveLocalTag(tag) {
+  try {
+    return git(['rev-parse', `${tag}^{}`]) || null
+  } catch {
+    return null
+  }
+}
+
+function resolveRemoteTag(tag) {
+  const output = git([
+    'ls-remote',
+    '--tags',
+    'origin',
+    `refs/tags/${tag}`,
+    `refs/tags/${tag}^{}`,
+  ])
+  if (!output) return null
+
+  const entries = output
+    .split('\n')
+    .map(line => line.split('\t'))
+    .filter(parts => parts.length === 2)
+
+  const dereferenced = entries.find(([, ref]) => ref === `refs/tags/${tag}^{}`)
+  return (dereferenced || entries[0])[0]
+}
+
+function ensurePackageTag({ tag, target, dryRun }) {
+  const localTarget = resolveLocalTag(tag)
+  if (localTarget && localTarget !== target) {
+    throw new Error(`Local tag ${tag} points to ${localTarget}, expected ${target}`)
+  }
+
+  const remoteTarget = resolveRemoteTag(tag)
+  if (remoteTarget && remoteTarget !== target) {
+    throw new Error(`Remote tag ${tag} points to ${remoteTarget}, expected ${target}`)
+  }
+
+  if (dryRun) {
+    return { created: !localTarget && !remoteTarget, pushed: !remoteTarget }
+  }
+
+  if (!localTarget && !remoteTarget) {
+    git(['tag', '-a', tag, target, '-m', `chore(release): ${tag}`])
+  }
+
+  if (!remoteTarget) {
+    git(['push', 'origin', `refs/tags/${tag}:refs/tags/${tag}`], { stdio: 'inherit' })
+  }
+
+  return { created: !localTarget && !remoteTarget, pushed: !remoteTarget }
+}
+
+function main() {
+  const args = process.argv.slice(2)
+  const dryRun = args.includes('--dry-run')
+  const packagesInput = args.find(arg => arg !== '--dry-run') || process.env.PUBLISHED_PACKAGES
+  const packages = parsePublishedPackages(packagesInput)
+  if (packages.length === 0) {
+    throw new Error('Changesets reported a publish, but no published packages were provided')
+  }
+
+  const rootDir = process.cwd()
+  const target = process.env.GITHUB_SHA || git(['rev-parse', 'HEAD'])
+
+  for (const publishedPackage of packages) {
+    const { packageJson, packageJsonPath } = getWorkspacePackage(rootDir, publishedPackage.name)
+    if (packageJson.version !== publishedPackage.version) {
+      throw new Error(
+        `${publishedPackage.name} is ${packageJson.version} in ${packageJsonPath}, expected ${publishedPackage.version}`
+      )
+    }
+
+    const tag = getPackageTag(publishedPackage.name, publishedPackage.version)
+    const result = ensurePackageTag({ tag, target, dryRun })
+    console.log(`${tag}\tcreated=${result.created}\tpushed=${result.pushed}`)
+  }
+}
+
+if (require.main === module) {
+  main()
+}
+
+module.exports = {
+  getPackageTag,
+  parsePublishedPackages,
+}

--- a/.github/scripts/push-package-release-tags.js
+++ b/.github/scripts/push-package-release-tags.js
@@ -24,11 +24,13 @@ function getWorkspacePackage(rootDir, packageName) {
 }
 
 function git(args, options = {}) {
-  return execFileSync('git', args, {
+  const output = execFileSync('git', args, {
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
     ...options,
-  }).trim()
+  })
+
+  return typeof output === 'string' ? output.trim() : ''
 }
 
 function resolveLocalTag(tag) {
@@ -40,13 +42,7 @@ function resolveLocalTag(tag) {
 }
 
 function resolveRemoteTag(tag) {
-  const output = git([
-    'ls-remote',
-    '--tags',
-    'origin',
-    `refs/tags/${tag}`,
-    `refs/tags/${tag}^{}`,
-  ])
+  const output = git(['ls-remote', '--tags', 'origin', `refs/tags/${tag}`, `refs/tags/${tag}^{}`])
   if (!output) return null
 
   const entries = output
@@ -94,7 +90,7 @@ function main() {
   }
 
   const rootDir = process.cwd()
-  const target = process.env.GITHUB_SHA || git(['rev-parse', 'HEAD'])
+  const target = git(['rev-parse', 'HEAD'])
 
   for (const publishedPackage of packages) {
     const { packageJson, packageJsonPath } = getWorkspacePackage(rootDir, publishedPackage.name)

--- a/.github/scripts/push-package-release-tags.js
+++ b/.github/scripts/push-package-release-tags.js
@@ -5,6 +5,8 @@ const fs = require('fs')
 const path = require('path')
 const { getPackageTag, parsePublishedPackages } = require('./release-utils')
 
+const NETWORK_TIMEOUT_MS = 60_000
+
 function getWorkspacePackage(rootDir, packageName) {
   const packagesDir = path.join(rootDir, 'packages')
 
@@ -27,6 +29,7 @@ function git(args, options = {}) {
   const output = execFileSync('git', args, {
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: NETWORK_TIMEOUT_MS,
     ...options,
   })
 

--- a/.github/scripts/release-utils.js
+++ b/.github/scripts/release-utils.js
@@ -1,0 +1,71 @@
+const fs = require('fs')
+
+const EDITOR_PACKAGE_NAME = '@wangeditor-next/editor'
+
+function parsePublishedPackages(value) {
+  let packages
+
+  try {
+    packages = JSON.parse(value || '[]')
+  } catch {
+    throw new Error('Published packages must be a JSON array')
+  }
+
+  if (!Array.isArray(packages)) {
+    throw new Error('Published packages must be a JSON array')
+  }
+
+  const names = new Set()
+
+  return packages.map(pkg => {
+    if (
+      typeof pkg?.name !== 'string' ||
+      typeof pkg?.version !== 'string' ||
+      !pkg.name ||
+      !pkg.version ||
+      /[\r\n]/.test(pkg.name) ||
+      /[\r\n]/.test(pkg.version)
+    ) {
+      throw new Error('Each published package must include a non-empty name and version')
+    }
+
+    if (names.has(pkg.name)) {
+      throw new Error(`Published package ${pkg.name} appears more than once`)
+    }
+    names.add(pkg.name)
+
+    return { name: pkg.name, version: pkg.version }
+  })
+}
+
+function getPackageTag(name, version) {
+  return `${name}@${version}`
+}
+
+function getEditorRelease(packages) {
+  const editorPkg = packages.find(pkg => pkg.name === EDITOR_PACKAGE_NAME)
+  if (!editorPkg) return null
+
+  return {
+    ...editorPkg,
+    tag: `v${editorPkg.version}`,
+  }
+}
+
+function writeGitHubOutput(values) {
+  if (!process.env.GITHUB_OUTPUT) return
+
+  const output = Object.entries(values)
+    .map(([name, value]) => `${name}=${value ?? ''}`)
+    .join('\n')
+
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, `${output}\n`)
+}
+
+module.exports = {
+  EDITOR_PACKAGE_NAME,
+  getEditorRelease,
+  getPackageTag,
+  parsePublishedPackages,
+  writeGitHubOutput,
+}

--- a/.github/scripts/verify-published-packages.js
+++ b/.github/scripts/verify-published-packages.js
@@ -5,6 +5,8 @@ const fs = require('fs')
 const path = require('path')
 const { parsePublishedPackages } = require('./release-utils')
 
+const NPM_TIMEOUT_MS = 60_000
+
 function getWorkspacePackage(rootDir, packageName) {
   const packagesDir = path.join(rootDir, 'packages')
 
@@ -25,6 +27,7 @@ function getNpmVersion(packageName, version) {
   const output = execFileSync('npm', ['view', `${packageName}@${version}`, 'version', '--json'], {
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: NPM_TIMEOUT_MS,
   }).trim()
 
   let reportedVersion

--- a/.github/scripts/verify-published-packages.js
+++ b/.github/scripts/verify-published-packages.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+
+const { execFileSync } = require('child_process')
+const fs = require('fs')
+const path = require('path')
+const { parsePublishedPackages } = require('./release-utils')
+
+function getWorkspacePackage(rootDir, packageName) {
+  const packagesDir = path.join(rootDir, 'packages')
+
+  for (const entry of fs.readdirSync(packagesDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+
+    const packageJsonPath = path.join(packagesDir, entry.name, 'package.json')
+    if (!fs.existsSync(packageJsonPath)) continue
+
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+    if (packageJson.name === packageName) return { packageJson, packageJsonPath }
+  }
+
+  throw new Error(`Published package ${packageName} does not exist in packages/`)
+}
+
+function getNpmVersion(packageName, version) {
+  const output = execFileSync('npm', ['view', `${packageName}@${version}`, 'version', '--json'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim()
+
+  let reportedVersion
+  try {
+    reportedVersion = JSON.parse(output)
+  } catch {
+    throw new Error(`npm returned an invalid version response for ${packageName}@${version}`)
+  }
+
+  if (Array.isArray(reportedVersion)) [reportedVersion] = reportedVersion
+  if (reportedVersion !== version) {
+    throw new Error(
+      `npm registry reports ${packageName}@${reportedVersion || 'missing'}, expected ${version}`
+    )
+  }
+}
+
+function main() {
+  const packagesInput = process.argv[2] || process.env.PUBLISHED_PACKAGES
+  const packages = parsePublishedPackages(packagesInput)
+  if (packages.length === 0) {
+    throw new Error('At least one published package is required')
+  }
+
+  const rootDir = process.cwd()
+  for (const { name, version } of packages) {
+    const { packageJson, packageJsonPath } = getWorkspacePackage(rootDir, name)
+    if (packageJson.version !== version) {
+      throw new Error(
+        `${name} is ${packageJson.version} in ${packageJsonPath}, expected ${version}`
+      )
+    }
+
+    getNpmVersion(name, version)
+    console.log(`${name}@${version}\tverified=true`)
+  }
+}
+
+if (require.main === module) {
+  main()
+}
+
+module.exports = {
+  getNpmVersion,
+  getWorkspacePackage,
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,6 @@ jobs:
     strategy:
       matrix:
         node-version: ['22.13.0']
-    env:
-      DOCS_REPO_DISPATCH_TOKEN: ${{ secrets.DOCS_REPO_DISPATCH_TOKEN }}
 
     steps:
       # 检出代码库
@@ -37,6 +35,17 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+
+      - name: Verify release branch
+        env:
+          RELEASE_BRANCH: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "${RELEASE_BRANCH}" =~ ^(master|dev|develop|dev-[^/]*|dev/.+)$ ]]; then
+            echo "Release runs are limited to master, dev, develop, dev-*, and dev/**." >&2
+            exit 1
+          fi
 
       # 安装 pnpm
       - name: Install pnpm
@@ -152,16 +161,30 @@ jobs:
           gh release upload "${RELEASE_TAG}" "${asset_name}" --clobber
 
       - name: Trigger docs site deployment for released editor version
-        if: steps.consolidated_release.outputs.editor_published == 'true' && github.ref_name == 'master' && env.DOCS_REPO_DISPATCH_TOKEN != ''
+        if: >-
+          steps.consolidated_release.outputs.editor_published == 'true' &&
+          github.ref_name == 'master' &&
+          env.DOCS_REPO_DISPATCH_TOKEN != ''
+        env:
+          DOCS_REPO_DISPATCH_TOKEN: ${{ secrets.DOCS_REPO_DISPATCH_TOKEN }}
         uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ env.DOCS_REPO_DISPATCH_TOKEN }}
           repository: wangeditor-next/docs
           event-type: editor-release-published
           client-payload: >-
-            {"version":"${{ steps.consolidated_release.outputs.version }}","sourceRepo":"${{ github.repository }}","sourceSha":"${{ github.sha }}","sourceRunId":"${{ github.run_id }}"}
+            {"version":"${{ steps.consolidated_release.outputs.version }}",
+            "sourceRepo":"${{ github.repository }}","sourceSha":"${{ github.sha }}",
+            "sourceRunId":"${{ github.run_id }}"}
 
       - name: Warn when docs dispatch token is missing
-        if: steps.consolidated_release.outputs.editor_published == 'true' && github.ref_name == 'master' && env.DOCS_REPO_DISPATCH_TOKEN == ''
+        if: >-
+          steps.consolidated_release.outputs.editor_published == 'true' &&
+          github.ref_name == 'master' &&
+          env.DOCS_REPO_DISPATCH_TOKEN == ''
+        env:
+          DOCS_REPO_DISPATCH_TOKEN: ${{ secrets.DOCS_REPO_DISPATCH_TOKEN }}
         run: |
-          echo "::warning::DOCS_REPO_DISPATCH_TOKEN is not set. Skip triggering wangeditor-next/docs deployment."
+          printf '::warning::%s%s\n' \
+            'DOCS_REPO_DISPATCH_TOKEN is not set. Skip triggering ' \
+            'wangeditor-next/docs deployment.'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       matrix:
         node-version: ['22.13.0']

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,7 @@ on:
   push:
     branches:
       - master
-      - dev
       - develop
-      - 'dev-*'
-      - 'dev/**'
   workflow_dispatch:
 
 permissions:
@@ -17,8 +14,8 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Ensure release jobs on master are not interrupted by subsequent pushes.
-  cancel-in-progress: ${{ github.ref_name != 'master' }}
+  # npm publishes are immutable, so provenance steps must never be cancelled mid-release.
+  cancel-in-progress: false
 
 jobs:
   release:
@@ -39,11 +36,17 @@ jobs:
       - name: Verify release branch
         env:
           RELEASE_BRANCH: ${{ github.ref_name }}
+          RELEASE_REF_TYPE: ${{ github.ref_type }}
         run: |
           set -euo pipefail
 
-          if [[ ! "${RELEASE_BRANCH}" =~ ^(master|dev|develop|dev-[^/]*|dev/.+)$ ]]; then
-            echo "Release runs are limited to master, dev, develop, dev-*, and dev/**." >&2
+          if [ "${RELEASE_REF_TYPE}" != 'branch' ]; then
+            echo 'Release runs must use a branch ref.' >&2
+            exit 1
+          fi
+
+          if [ "${RELEASE_BRANCH}" != 'master' ] && [ "${RELEASE_BRANCH}" != 'develop' ]; then
+            echo 'Release runs are limited to master and the protected develop branch.' >&2
             exit 1
           fi
 
@@ -87,7 +90,7 @@ jobs:
 
       # 创建测试版本或稳定版本的 Release PR
       - name: Manage Changeset Pre-release Mode
-        if: startsWith(github.ref_name, 'dev') || github.ref_name == 'develop'
+        if: github.ref_name == 'develop'
         run: pnpm changeset pre enter alpha || true
 
       - name: Exit Changeset Pre-release Mode

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,12 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Verify published npm packages
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+        run: node .github/scripts/verify-published-packages.js
+
       - name: Push package source tags
         if: steps.changesets.outputs.published == 'true'
         env:
@@ -116,9 +122,8 @@ jobs:
         if: steps.changesets.outputs.published == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: >-
-          node .github/scripts/create-consolidated-release.js
-          '${{ steps.changesets.outputs.publishedPackages }}'
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+        run: node .github/scripts/create-consolidated-release.js
 
       - name: Upload editor sourcemaps to GitHub Release assets
         if: steps.consolidated_release.outputs.editor_published == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,8 @@ jobs:
           set -euo pipefail
 
           release_subject="$(git log -1 --format=%s)"
-          release_subject_pattern='^chore\(release\): publish (a new )?release version$'
+          release_subject_pattern='^chore\(release\): publish (a new )?release version'
+          release_subject_pattern+='( \(#[0-9]+\))?$'
           changeset_file=''
           requires_release=false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,10 @@ on:
   push:
     branches:
       - master
-      - develop
-  workflow_dispatch:
 
 permissions:
-  id-token: write
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -18,8 +15,10 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  release:
-    name: Release
+  validate:
+    name: Validate release source
+    outputs:
+      requires_release: ${{ steps.release_work.outputs.requires_release }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -32,6 +31,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Verify release branch
         env:
@@ -40,13 +40,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ "${RELEASE_REF_TYPE}" != 'branch' ]; then
-            echo 'Release runs must use a branch ref.' >&2
-            exit 1
-          fi
-
-          if [ "${RELEASE_BRANCH}" != 'master' ] && [ "${RELEASE_BRANCH}" != 'develop' ]; then
-            echo 'Release runs are limited to master and the protected develop branch.' >&2
+          if [ "${RELEASE_REF_TYPE}" != 'branch' ] || [ "${RELEASE_BRANCH}" != 'master' ]; then
+            echo 'Release runs are limited to pushes on the protected master branch.' >&2
             exit 1
           fi
 
@@ -88,14 +83,89 @@ jobs:
           pnpm exec playwright install --with-deps chromium
           pnpm e2e
 
-      # 创建测试版本或稳定版本的 Release PR
-      - name: Manage Changeset Pre-release Mode
-        if: github.ref_name == 'develop'
-        run: pnpm changeset pre enter alpha || true
+      - name: Determine whether release work is needed
+        id: release_work
+        run: |
+          set -euo pipefail
+
+          release_subject="$(git log -1 --format=%s)"
+          release_subject_pattern='^chore\(release\): publish (a new )?release version$'
+          changeset_file=''
+          requires_release=false
+
+          if [ -d .changeset ]; then
+            changeset_file="$(find .changeset -maxdepth 1 -type f -name '*.md' ! -name 'README.md' \
+              -print -quit)"
+          fi
+
+          if [ -n "${changeset_file}" ]; then
+            requires_release=true
+          elif [[ "${release_subject}" =~ ${release_subject_pattern} ]]; then
+            requires_release=true
+          fi
+
+          echo "requires_release=${requires_release}" >> "$GITHUB_OUTPUT"
+
+  release:
+    name: Release
+    needs: validate
+    if: needs.validate.outputs.requires_release == 'true'
+    environment: release-automation
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify release branch
+        env:
+          RELEASE_BRANCH: ${{ github.ref_name }}
+          RELEASE_REF_TYPE: ${{ github.ref_type }}
+        run: |
+          set -euo pipefail
+
+          if [ "${RELEASE_REF_TYPE}" != 'branch' ] || [ "${RELEASE_BRANCH}" != 'master' ]; then
+            echo 'Release runs are limited to pushes on the protected master branch.' >&2
+            exit 1
+          fi
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 9.15.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22.13.0
+          registry-url: https://registry.npmjs.org/
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm build
 
       - name: Exit Changeset Pre-release Mode
-        if: github.ref_name == 'master'
         run: pnpm changeset pre exit || true
+
+      - name: Verify release credentials
+        env:
+          NPM_RELEASE_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}
+          RELEASE_AUTOMATION_TOKEN: ${{ secrets.RELEASE_AUTOMATION_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${NPM_RELEASE_TOKEN}" ] || [ -z "${RELEASE_AUTOMATION_TOKEN}" ]; then
+            echo 'Configure NPM_RELEASE_TOKEN and RELEASE_AUTOMATION_TOKEN' >&2
+            echo 'in release-automation.' >&2
+            exit 1
+          fi
 
       - name: Create Release PR or publish version to npm
         id: changesets
@@ -107,14 +177,13 @@ jobs:
           createGithubReleases: false
           version: pnpm run version:release
           publish: pnpm changeset publish --access=public
-          title: >-
-            ${{ github.ref_name == 'master' && 'Publish a new stable version' || 'Publish a new pre-release version' }}
+          title: Publish a new stable version
           commit: >-
-            ${{ github.ref_name == 'master' && 'chore(release): publish a new release version' || 'chore(release): publish a new pre-release version' }}
+            chore(release): publish a new release version
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_AUTOMATION_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}
 
       - name: Verify published npm packages
         if: steps.changesets.outputs.published == 'true'
@@ -125,8 +194,11 @@ jobs:
       - name: Push package source tags
         if: steps.changesets.outputs.published == 'true'
         env:
+          GH_TOKEN: ${{ secrets.RELEASE_AUTOMATION_TOKEN }}
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
-        run: node .github/scripts/push-package-release-tags.js
+        run: |
+          gh auth setup-git
+          node .github/scripts/push-package-release-tags.js
 
       # The editor gets a product-level Release. Leaf packages remain
       # discoverable through their @scope/package@version source tags.
@@ -134,14 +206,14 @@ jobs:
         id: consolidated_release
         if: steps.changesets.outputs.published == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_AUTOMATION_TOKEN }}
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
         run: node .github/scripts/create-consolidated-release.js
 
       - name: Upload editor sourcemaps to GitHub Release assets
         if: steps.consolidated_release.outputs.editor_published == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_AUTOMATION_TOKEN }}
           RELEASE_TAG: ${{ steps.consolidated_release.outputs.tag }}
         run: |
           set -euo pipefail
@@ -167,12 +239,12 @@ jobs:
         if: >-
           steps.consolidated_release.outputs.editor_published == 'true' &&
           github.ref_name == 'master' &&
-          env.DOCS_REPO_DISPATCH_TOKEN != ''
+          env.DOCS_RELEASE_DISPATCH_TOKEN != ''
         env:
-          DOCS_REPO_DISPATCH_TOKEN: ${{ secrets.DOCS_REPO_DISPATCH_TOKEN }}
+          DOCS_RELEASE_DISPATCH_TOKEN: ${{ secrets.DOCS_RELEASE_DISPATCH_TOKEN }}
         uses: peter-evans/repository-dispatch@v4
         with:
-          token: ${{ env.DOCS_REPO_DISPATCH_TOKEN }}
+          token: ${{ env.DOCS_RELEASE_DISPATCH_TOKEN }}
           repository: wangeditor-next/docs
           event-type: editor-release-published
           client-payload: >-
@@ -184,10 +256,10 @@ jobs:
         if: >-
           steps.consolidated_release.outputs.editor_published == 'true' &&
           github.ref_name == 'master' &&
-          env.DOCS_REPO_DISPATCH_TOKEN == ''
+          env.DOCS_RELEASE_DISPATCH_TOKEN == ''
         env:
-          DOCS_REPO_DISPATCH_TOKEN: ${{ secrets.DOCS_REPO_DISPATCH_TOKEN }}
+          DOCS_RELEASE_DISPATCH_TOKEN: ${{ secrets.DOCS_RELEASE_DISPATCH_TOKEN }}
         run: |
           printf '::warning::%s%s\n' \
-            'DOCS_REPO_DISPATCH_TOKEN is not set. Skip triggering ' \
+            'DOCS_RELEASE_DISPATCH_TOKEN is not set. Skip triggering ' \
             'wangeditor-next/docs deployment.'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,8 @@ jobs:
         uses: changesets/action@v1
         with:
           # Disable per-package releases; a single consolidated release is
-          # created by the step below instead.
+          # created only for public editor releases below. Source provenance
+          # for every published package is maintained by immutable package tags.
           createGithubReleases: false
           version: pnpm run version:release
           publish: pnpm changeset publish --access=public
@@ -102,8 +103,14 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      # Create one consolidated GitHub Release that aggregates all published
-      # packages into a single entry instead of one release per package.
+      - name: Push package source tags
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+        run: node .github/scripts/push-package-release-tags.js
+
+      # The editor gets a product-level Release. Leaf packages remain
+      # discoverable through their @scope/package@version source tags.
       - name: Create consolidated GitHub Release
         id: consolidated_release
         if: steps.changesets.outputs.published == 'true'
@@ -113,26 +120,8 @@ jobs:
           node .github/scripts/create-consolidated-release.js
           '${{ steps.changesets.outputs.publishedPackages }}'
 
-      - name: Resolve published editor version
-        if: steps.changesets.outputs.published == 'true' && github.ref_name == 'master'
-        id: editor_version
-        env:
-          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
-        run: |
-          set -euo pipefail
-
-          version="$(node -e "const pkgs = JSON.parse(process.env.PUBLISHED_PACKAGES || '[]'); const editor = pkgs.find(p => p.name === '@wangeditor-next/editor'); if (editor?.version) process.stdout.write(editor.version)")"
-          if [ -z "$version" ]; then
-            version="$(node -p "require('./packages/editor/package.json').version")"
-            echo "Fallback to packages/editor/package.json version: $version"
-          else
-            echo "Published @wangeditor-next/editor version: $version"
-          fi
-
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-
       - name: Upload editor sourcemaps to GitHub Release assets
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.consolidated_release.outputs.editor_published == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ steps.consolidated_release.outputs.tag }}
@@ -157,16 +146,16 @@ jobs:
           gh release upload "${RELEASE_TAG}" "${asset_name}" --clobber
 
       - name: Trigger docs site deployment for released editor version
-        if: steps.changesets.outputs.published == 'true' && github.ref_name == 'master' && env.DOCS_REPO_DISPATCH_TOKEN != ''
+        if: steps.consolidated_release.outputs.editor_published == 'true' && github.ref_name == 'master' && env.DOCS_REPO_DISPATCH_TOKEN != ''
         uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ env.DOCS_REPO_DISPATCH_TOKEN }}
           repository: wangeditor-next/docs
           event-type: editor-release-published
           client-payload: >-
-            {"version":"${{ steps.editor_version.outputs.version }}","sourceRepo":"${{ github.repository }}","sourceSha":"${{ github.sha }}","sourceRunId":"${{ github.run_id }}"}
+            {"version":"${{ steps.consolidated_release.outputs.version }}","sourceRepo":"${{ github.repository }}","sourceSha":"${{ github.sha }}","sourceRunId":"${{ github.run_id }}"}
 
       - name: Warn when docs dispatch token is missing
-        if: steps.changesets.outputs.published == 'true' && github.ref_name == 'master' && env.DOCS_REPO_DISPATCH_TOKEN == ''
+        if: steps.consolidated_release.outputs.editor_published == 'true' && github.ref_name == 'master' && env.DOCS_REPO_DISPATCH_TOKEN == ''
         run: |
           echo "::warning::DOCS_REPO_DISPATCH_TOKEN is not set. Skip triggering wangeditor-next/docs deployment."

--- a/.github/workflows/repair-release-provenance.yml
+++ b/.github/workflows/repair-release-provenance.yml
@@ -14,7 +14,7 @@ on:
 
 permissions:
   actions: read
-  contents: write
+  contents: read
 
 concurrency:
   group: repair-release-provenance-${{ inputs.release_sha }}
@@ -24,6 +24,7 @@ jobs:
   repair:
     name: Repair release provenance
     if: github.ref == 'refs/heads/master'
+    environment: release-automation
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -78,7 +79,8 @@ jobs:
               [run.path, run.event, run.status, run.head_sha, run.head_branch].join("\\t")
             )
           ' "${release_run}")"
-          IFS=$'\t' read -r run_path run_event run_status run_sha run_branch <<< "${release_run_fields}"
+          IFS=$'\t' read -r run_path run_event run_status run_sha run_branch \
+            <<< "${release_run_fields}"
 
           if [ "${run_path}" != '.github/workflows/release.yml' ] || \
             [ "${run_status}" != 'completed' ] || [ "${run_sha}" != "${checked_out}" ]; then
@@ -91,8 +93,8 @@ jobs:
             exit 1
           fi
 
-          if [ "${run_branch}" != 'master' ] && [ "${run_branch}" != 'develop' ]; then
-            echo 'release_run_id must come from master or the protected develop branch.' >&2
+          if [ "${run_branch}" != 'master' ]; then
+            echo 'release_run_id must come from the protected master branch.' >&2
             exit 1
           fi
 
@@ -104,7 +106,17 @@ jobs:
           fi
 
           echo "sha=${checked_out}" >> "$GITHUB_OUTPUT"
-          echo "branch=${run_branch}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify release automation credential
+        env:
+          RELEASE_AUTOMATION_TOKEN: ${{ secrets.RELEASE_AUTOMATION_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${RELEASE_AUTOMATION_TOKEN}" ]; then
+            echo 'Configure RELEASE_AUTOMATION_TOKEN in release-automation.' >&2
+            exit 1
+          fi
 
       - name: Install pnpm
         uses: pnpm/action-setup@v5
@@ -146,7 +158,7 @@ jobs:
       - name: Restore package source tags
         working-directory: release-source
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_AUTOMATION_TOKEN }}
           PUBLISHED_PACKAGES: ${{ steps.packages.outputs.published_packages }}
         run: |
           gh auth setup-git
@@ -156,7 +168,7 @@ jobs:
         id: consolidated_release
         working-directory: release-source
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_AUTOMATION_TOKEN }}
           PUBLISHED_PACKAGES: ${{ steps.packages.outputs.published_packages }}
         run: node ../.github/scripts/create-consolidated-release.js
 
@@ -164,7 +176,7 @@ jobs:
         if: steps.consolidated_release.outputs.editor_published == 'true'
         working-directory: release-source
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_AUTOMATION_TOKEN }}
           RELEASE_TAG: ${{ steps.consolidated_release.outputs.tag }}
         run: |
           set -euo pipefail
@@ -204,12 +216,12 @@ jobs:
         if: >-
           steps.consolidated_release.outputs.editor_published == 'true' &&
           steps.docs_source.outputs.dispatch == 'true' &&
-          env.DOCS_REPO_DISPATCH_TOKEN != ''
+          env.DOCS_RELEASE_DISPATCH_TOKEN != ''
         env:
-          DOCS_REPO_DISPATCH_TOKEN: ${{ secrets.DOCS_REPO_DISPATCH_TOKEN }}
+          DOCS_RELEASE_DISPATCH_TOKEN: ${{ secrets.DOCS_RELEASE_DISPATCH_TOKEN }}
         uses: peter-evans/repository-dispatch@v4
         with:
-          token: ${{ env.DOCS_REPO_DISPATCH_TOKEN }}
+          token: ${{ env.DOCS_RELEASE_DISPATCH_TOKEN }}
           repository: wangeditor-next/docs
           event-type: editor-release-published
           client-payload: >-
@@ -220,10 +232,10 @@ jobs:
       - name: Warn when docs dispatch is skipped
         if: >-
           steps.consolidated_release.outputs.editor_published == 'true' &&
-          (steps.docs_source.outputs.dispatch != 'true' || env.DOCS_REPO_DISPATCH_TOKEN == '')
+          (steps.docs_source.outputs.dispatch != 'true' || env.DOCS_RELEASE_DISPATCH_TOKEN == '')
         env:
-          DOCS_REPO_DISPATCH_TOKEN: ${{ secrets.DOCS_REPO_DISPATCH_TOKEN }}
+          DOCS_RELEASE_DISPATCH_TOKEN: ${{ secrets.DOCS_RELEASE_DISPATCH_TOKEN }}
         run: |
           printf '::warning::%s%s\n' \
             'Skip docs dispatch because the version is not npm latest or ' \
-            'DOCS_REPO_DISPATCH_TOKEN is not set.'
+            'DOCS_RELEASE_DISPATCH_TOKEN is not set.'

--- a/.github/workflows/repair-release-provenance.yml
+++ b/.github/workflows/repair-release-provenance.yml
@@ -100,6 +100,7 @@ jobs:
 
           release_subject="$(git log -1 --format=%s "${checked_out}")"
           release_subject_pattern='^chore\(release\): publish (a new )?(pre-)?release version'
+          release_subject_pattern+='( \(#[0-9]+\))?$'
           if [[ ! "${release_subject}" =~ ${release_subject_pattern} ]]; then
             echo "release_sha must point to an automated chore(release) publish commit." >&2
             exit 1

--- a/.github/workflows/repair-release-provenance.yml
+++ b/.github/workflows/repair-release-provenance.yml
@@ -1,0 +1,176 @@
+name: Repair Release Provenance
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_sha:
+        description: Lowercase 40-character SHA of the already-published master release commit
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: repair-release-provenance-${{ inputs.release_sha }}
+  cancel-in-progress: false
+
+jobs:
+  repair:
+    name: Repair release provenance
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout release tooling
+        uses: actions/checkout@v7
+        with:
+          ref: master
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Checkout release source
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.release_sha }}
+          fetch-depth: 0
+          path: release-source
+          persist-credentials: false
+
+      - name: Verify release source
+        id: target
+        working-directory: release-source
+        env:
+          RELEASE_SHA: ${{ inputs.release_sha }}
+        run: |
+          set -euo pipefail
+
+          if ! [[ "${RELEASE_SHA}" =~ ^[a-f0-9]{40}$ ]]; then
+            echo "release_sha must be a lowercase 40-character commit SHA" >&2
+            exit 1
+          fi
+
+          expected="$(git rev-parse --verify "${RELEASE_SHA}^{commit}")"
+          checked_out="$(git rev-parse HEAD)"
+          if [ "${expected}" != "${checked_out}" ]; then
+            echo "Checked-out commit ${checked_out} does not match ${RELEASE_SHA}" >&2
+            exit 1
+          fi
+
+          git fetch --no-tags origin '+refs/heads/master:refs/remotes/origin/master'
+          if ! git merge-base --is-ancestor "${checked_out}" origin/master; then
+            echo "Release source ${checked_out} must be reachable from master" >&2
+            exit 1
+          fi
+
+          echo "sha=${checked_out}" >> "$GITHUB_OUTPUT"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 9.15.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22.13.0
+          registry-url: https://registry.npmjs.org/
+          cache: pnpm
+          cache-dependency-path: release-source/pnpm-lock.yaml
+
+      - name: Derive packages from the release commit
+        id: packages
+        working-directory: release-source
+        env:
+          RELEASE_SHA: ${{ steps.target.outputs.sha }}
+        run: |
+          set -euo pipefail
+          packages="$(node ../.github/scripts/derive-release-packages.js)"
+          echo "published_packages=${packages}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify packages were published to npm
+        working-directory: release-source
+        env:
+          PUBLISHED_PACKAGES: ${{ steps.packages.outputs.published_packages }}
+        run: node ../.github/scripts/verify-published-packages.js
+
+      - name: Install dependencies
+        working-directory: release-source
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        working-directory: release-source
+        run: pnpm build
+
+      - name: Restore package source tags
+        working-directory: release-source
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUBLISHED_PACKAGES: ${{ steps.packages.outputs.published_packages }}
+        run: |
+          gh auth setup-git
+          node ../.github/scripts/push-package-release-tags.js
+
+      - name: Restore product GitHub Release
+        id: consolidated_release
+        working-directory: release-source
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUBLISHED_PACKAGES: ${{ steps.packages.outputs.published_packages }}
+        run: node ../.github/scripts/create-consolidated-release.js
+
+      - name: Upload editor sourcemaps to GitHub Release assets
+        if: steps.consolidated_release.outputs.editor_published == 'true'
+        working-directory: release-source
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.consolidated_release.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          map_count="$(find packages/editor/dist -type f -name '*.map' | wc -l | tr -d ' ')"
+          if [ "${map_count}" = "0" ]; then
+            echo "::warning::No sourcemap files found under packages/editor/dist. Skip upload."
+            exit 0
+          fi
+
+          asset_name="editor-sourcemaps-${RELEASE_TAG}.tar.gz"
+          find packages/editor/dist -type f -name '*.map' -print0 \
+            | tar --null -T - -czf "${asset_name}"
+
+          gh release upload "${RELEASE_TAG}" "${asset_name}" --clobber
+
+      - name: Determine docs dispatch eligibility
+        id: docs_source
+        if: steps.consolidated_release.outputs.editor_published == 'true'
+        working-directory: release-source
+        env:
+          RELEASE_VERSION: ${{ steps.consolidated_release.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          latest_version="$(npm view @wangeditor-next/editor dist-tags.latest)"
+          if [ "${latest_version}" = "${RELEASE_VERSION}" ]; then
+            echo "dispatch=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "dispatch=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skip docs dispatch because ${RELEASE_VERSION} is not npm latest (${latest_version})."
+          fi
+
+      - name: Trigger docs site deployment for repaired editor release
+        if: steps.consolidated_release.outputs.editor_published == 'true' && steps.docs_source.outputs.dispatch == 'true' && env.DOCS_REPO_DISPATCH_TOKEN != ''
+        env:
+          DOCS_REPO_DISPATCH_TOKEN: ${{ secrets.DOCS_REPO_DISPATCH_TOKEN }}
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          token: ${{ env.DOCS_REPO_DISPATCH_TOKEN }}
+          repository: wangeditor-next/docs
+          event-type: editor-release-published
+          client-payload: >-
+            {"version":"${{ steps.consolidated_release.outputs.version }}","sourceRepo":"${{ github.repository }}","sourceSha":"${{ steps.target.outputs.sha }}","sourceRunId":"${{ github.run_id }}"}
+
+      - name: Warn when docs dispatch is skipped
+        if: steps.consolidated_release.outputs.editor_published == 'true' && (steps.docs_source.outputs.dispatch != 'true' || env.DOCS_REPO_DISPATCH_TOKEN == '')
+        env:
+          DOCS_REPO_DISPATCH_TOKEN: ${{ secrets.DOCS_REPO_DISPATCH_TOKEN }}
+        run: |
+          echo "::warning::Skip docs dispatch because the version is not npm latest or DOCS_REPO_DISPATCH_TOKEN is not set."

--- a/.github/workflows/repair-release-provenance.yml
+++ b/.github/workflows/repair-release-provenance.yml
@@ -57,6 +57,13 @@ jobs:
             exit 1
           fi
 
+          release_subject="$(git log -1 --format=%s "${checked_out}")"
+          release_subject_pattern='^chore\(release\): publish (a new )?(pre-)?release version'
+          if [[ ! "${release_subject}" =~ ${release_subject_pattern} ]]; then
+            echo "release_sha must point to an automated chore(release) publish commit." >&2
+            exit 1
+          fi
+
           release_branch_pattern='^(master|dev|develop|dev-[^/]*|dev/.+)$'
           remote_refs="$(timeout 60s git ls-remote --heads origin)"
           release_refspecs=()

--- a/.github/workflows/repair-release-provenance.yml
+++ b/.github/workflows/repair-release-provenance.yml
@@ -57,13 +57,42 @@ jobs:
             exit 1
           fi
 
-          git fetch --no-tags origin '+refs/heads/master:refs/remotes/origin/master'
-          if ! git merge-base --is-ancestor "${checked_out}" origin/master; then
-            echo "Release source ${checked_out} must be reachable from master" >&2
+          release_branch_pattern='^(master|dev|develop|dev-[^/]*|dev/.+)$'
+          remote_refs="$(timeout 60s git ls-remote --heads origin)"
+          release_refspecs=()
+
+          while IFS=$'\t' read -r _remote_sha remote_ref; do
+            branch="${remote_ref#refs/heads/}"
+            if [[ "${branch}" =~ ${release_branch_pattern} ]]; then
+              release_refspecs+=("+${remote_ref}:refs/remotes/origin/${branch}")
+            fi
+          done <<< "${remote_refs}"
+
+          if [ "${#release_refspecs[@]}" -eq 0 ]; then
+            echo "No configured release branches were found on origin." >&2
+            exit 1
+          fi
+
+          timeout 60s git fetch --no-tags origin "${release_refspecs[@]}"
+
+          trusted_ref=''
+          for refspec in "${release_refspecs[@]}"; do
+            remote_ref="${refspec#*:}"
+            if git merge-base --is-ancestor "${checked_out}" "${remote_ref}"; then
+              trusted_ref="${remote_ref}"
+              break
+            fi
+          done
+
+          if [ -z "${trusted_ref}" ]; then
+            message="Release source ${checked_out} must be reachable from"
+            message+=" a configured release branch."
+            echo "${message}" >&2
             exit 1
           fi
 
           echo "sha=${checked_out}" >> "$GITHUB_OUTPUT"
+          echo "branch=${trusted_ref#refs/remotes/origin/}" >> "$GITHUB_OUTPUT"
 
       - name: Install pnpm
         uses: pnpm/action-setup@v5

--- a/.github/workflows/repair-release-provenance.yml
+++ b/.github/workflows/repair-release-provenance.yml
@@ -19,6 +19,7 @@ jobs:
   repair:
     name: Repair release provenance
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - name: Checkout release tooling
@@ -153,11 +154,16 @@ jobs:
             echo "dispatch=true" >> "$GITHUB_OUTPUT"
           else
             echo "dispatch=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Skip docs dispatch because ${RELEASE_VERSION} is not npm latest (${latest_version})."
+            message="Skip docs dispatch because ${RELEASE_VERSION} is not npm latest"
+            message+=" (${latest_version})."
+            echo "::notice::${message}"
           fi
 
       - name: Trigger docs site deployment for repaired editor release
-        if: steps.consolidated_release.outputs.editor_published == 'true' && steps.docs_source.outputs.dispatch == 'true' && env.DOCS_REPO_DISPATCH_TOKEN != ''
+        if: >-
+          steps.consolidated_release.outputs.editor_published == 'true' &&
+          steps.docs_source.outputs.dispatch == 'true' &&
+          env.DOCS_REPO_DISPATCH_TOKEN != ''
         env:
           DOCS_REPO_DISPATCH_TOKEN: ${{ secrets.DOCS_REPO_DISPATCH_TOKEN }}
         uses: peter-evans/repository-dispatch@v4
@@ -166,11 +172,17 @@ jobs:
           repository: wangeditor-next/docs
           event-type: editor-release-published
           client-payload: >-
-            {"version":"${{ steps.consolidated_release.outputs.version }}","sourceRepo":"${{ github.repository }}","sourceSha":"${{ steps.target.outputs.sha }}","sourceRunId":"${{ github.run_id }}"}
+            {"version":"${{ steps.consolidated_release.outputs.version }}",
+            "sourceRepo":"${{ github.repository }}","sourceSha":"${{ steps.target.outputs.sha }}",
+            "sourceRunId":"${{ github.run_id }}"}
 
       - name: Warn when docs dispatch is skipped
-        if: steps.consolidated_release.outputs.editor_published == 'true' && (steps.docs_source.outputs.dispatch != 'true' || env.DOCS_REPO_DISPATCH_TOKEN == '')
+        if: >-
+          steps.consolidated_release.outputs.editor_published == 'true' &&
+          (steps.docs_source.outputs.dispatch != 'true' || env.DOCS_REPO_DISPATCH_TOKEN == '')
         env:
           DOCS_REPO_DISPATCH_TOKEN: ${{ secrets.DOCS_REPO_DISPATCH_TOKEN }}
         run: |
-          echo "::warning::Skip docs dispatch because the version is not npm latest or DOCS_REPO_DISPATCH_TOKEN is not set."
+          printf '::warning::%s%s\n' \
+            'Skip docs dispatch because the version is not npm latest or ' \
+            'DOCS_REPO_DISPATCH_TOKEN is not set.'

--- a/.github/workflows/repair-release-provenance.yml
+++ b/.github/workflows/repair-release-provenance.yml
@@ -4,11 +4,16 @@ on:
   workflow_dispatch:
     inputs:
       release_sha:
-        description: Lowercase 40-character SHA of the already-published master release commit
+        description: Lowercase 40-character SHA of the published automated release commit
+        required: true
+        type: string
+      release_run_id:
+        description: Numeric ID of the original Release workflow run for release_sha
         required: true
         type: string
 
 permissions:
+  actions: read
   contents: write
 
 concurrency:
@@ -18,6 +23,7 @@ concurrency:
 jobs:
   repair:
     name: Repair release provenance
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -42,11 +48,18 @@ jobs:
         working-directory: release-source
         env:
           RELEASE_SHA: ${{ inputs.release_sha }}
+          RELEASE_RUN_ID: ${{ inputs.release_run_id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
           if ! [[ "${RELEASE_SHA}" =~ ^[a-f0-9]{40}$ ]]; then
             echo "release_sha must be a lowercase 40-character commit SHA" >&2
+            exit 1
+          fi
+
+          if ! [[ "${RELEASE_RUN_ID}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "release_run_id must be a positive numeric workflow run ID" >&2
             exit 1
           fi
 
@@ -57,6 +70,32 @@ jobs:
             exit 1
           fi
 
+          release_run="$(timeout 60s gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${RELEASE_RUN_ID}")"
+          release_run_fields="$(node -e '
+            const run = JSON.parse(process.argv[1])
+            process.stdout.write(
+              [run.path, run.event, run.status, run.head_sha, run.head_branch].join("\\t")
+            )
+          ' "${release_run}")"
+          IFS=$'\t' read -r run_path run_event run_status run_sha run_branch <<< "${release_run_fields}"
+
+          if [ "${run_path}" != '.github/workflows/release.yml' ] || \
+            [ "${run_status}" != 'completed' ] || [ "${run_sha}" != "${checked_out}" ]; then
+            echo "release_run_id must identify the completed Release run for release_sha" >&2
+            exit 1
+          fi
+
+          if [ "${run_event}" != 'push' ] && [ "${run_event}" != 'workflow_dispatch' ]; then
+            echo 'release_run_id must identify a push or manual Release run.' >&2
+            exit 1
+          fi
+
+          if [ "${run_branch}" != 'master' ] && [ "${run_branch}" != 'develop' ]; then
+            echo 'release_run_id must come from master or the protected develop branch.' >&2
+            exit 1
+          fi
+
           release_subject="$(git log -1 --format=%s "${checked_out}")"
           release_subject_pattern='^chore\(release\): publish (a new )?(pre-)?release version'
           if [[ ! "${release_subject}" =~ ${release_subject_pattern} ]]; then
@@ -64,42 +103,8 @@ jobs:
             exit 1
           fi
 
-          release_branch_pattern='^(master|dev|develop|dev-[^/]*|dev/.+)$'
-          remote_refs="$(timeout 60s git ls-remote --heads origin)"
-          release_refspecs=()
-
-          while IFS=$'\t' read -r _remote_sha remote_ref; do
-            branch="${remote_ref#refs/heads/}"
-            if [[ "${branch}" =~ ${release_branch_pattern} ]]; then
-              release_refspecs+=("+${remote_ref}:refs/remotes/origin/${branch}")
-            fi
-          done <<< "${remote_refs}"
-
-          if [ "${#release_refspecs[@]}" -eq 0 ]; then
-            echo "No configured release branches were found on origin." >&2
-            exit 1
-          fi
-
-          timeout 60s git fetch --no-tags origin "${release_refspecs[@]}"
-
-          trusted_ref=''
-          for refspec in "${release_refspecs[@]}"; do
-            remote_ref="${refspec#*:}"
-            if git merge-base --is-ancestor "${checked_out}" "${remote_ref}"; then
-              trusted_ref="${remote_ref}"
-              break
-            fi
-          done
-
-          if [ -z "${trusted_ref}" ]; then
-            message="Release source ${checked_out} must be reachable from"
-            message+=" a configured release branch."
-            echo "${message}" >&2
-            exit 1
-          fi
-
           echo "sha=${checked_out}" >> "$GITHUB_OUTPUT"
-          echo "branch=${trusted_ref#refs/remotes/origin/}" >> "$GITHUB_OUTPUT"
+          echo "branch=${run_branch}" >> "$GITHUB_OUTPUT"
 
       - name: Install pnpm
         uses: pnpm/action-setup@v5

--- a/docs/publish.md
+++ b/docs/publish.md
@@ -15,8 +15,8 @@
 如果 npm 已发布，但 source tag、GitHub Release、sourcemap 或文档触发步骤失败，
 不要重新执行 npm publish。到 Actions 运行 `Repair Release Provenance`，填写：
 
-1. `release_sha`：声明该版本的小写 40 位提交 SHA。稳定版必须可达 `master`；
-   alpha 版必须可达 `dev`、`develop`、`dev-*` 或 `dev/**` 发布分支。
+1. `release_sha`：自动发布产生的 `chore(release)` 提交的小写 40 位 SHA。稳定版必须
+   可达 `master`；alpha 版必须可达 `dev`、`develop`、`dev-*` 或 `dev/**` 发布分支。
 
 该工作流会从该提交相对第一父提交的包版本变化自动推导发布列表，再验证 npm 中
 的已发布版本、只创建缺失的源码 tag，并幂等更新产品 Release 与 sourcemap。

--- a/docs/publish.md
+++ b/docs/publish.md
@@ -15,8 +15,12 @@
 如果 npm 已发布，但 source tag、GitHub Release、sourcemap 或文档触发步骤失败，
 不要重新执行 npm publish。到 Actions 运行 `Repair Release Provenance`，填写：
 
-1. `release_sha`：自动发布产生的 `chore(release)` 提交的小写 40 位 SHA。稳定版必须
-   可达 `master`；alpha 版必须可达 `dev`、`develop`、`dev-*` 或 `dev/**` 发布分支。
+1. 从 `master` 分支启动该工作流。
+2. `release_sha`：自动发布产生的 `chore(release)` 提交的小写 40 位 SHA。
+3. `release_run_id`：该提交原始 `Release` workflow 的数字 run ID（Actions URL 中的数字）。
+
+稳定版只能来自受保护的 `master`，alpha 版只能来自受保护的 `develop`。恢复会校验
+run ID、workflow 路径、源码 SHA、分支和 npm 已发布版本，不能用普通版本提交伪造。
 
 该工作流会从该提交相对第一父提交的包版本变化自动推导发布列表，再验证 npm 中
 的已发布版本、只创建缺失的源码 tag，并幂等更新产品 Release 与 sourcemap。
@@ -25,8 +29,8 @@ editor 版本仍为 npm `latest` 时触发，避免修复历史 Release 时回�
 
 ## 发布一个测试版本
 
-1. 进入预发布模式：`npx changeset pre enter beta`
-2. 添加 `changeset`：`npx changeset`
-3. 更新版本号：`npx changeset version`
-4. 发布测试包：`npx changeset publish`
-5. 退出预发布模式（可选）：`npx changeset pre exit`
+1. 从 `master` 创建并保护 `develop` 分支，使用与 `master` 相同的审批和必需检查。
+2. 将包含 changeset 的预发布改动合入 `develop`。
+3. `Release` workflow 自动进入 alpha 模式并完成发布、source tag 和 Release 归档。
+
+不要直接执行 `pnpm changeset publish`，否则会绕过 npm 校验、不可变 source tag 和失败补偿。

--- a/docs/publish.md
+++ b/docs/publish.md
@@ -1,5 +1,20 @@
 # 发布到 NPM
 
+## 发布凭证（合并前配置）
+
+Release 与 `Repair Release Provenance` 都只能使用 GitHub Environment
+`release-automation` 中的凭证。该 Environment 必须限制为受保护的分支，并要求另一名
+维护者批准部署。不要把以下凭证保留为仓库级 secret：
+
+1. `NPM_RELEASE_TOKEN`：将现有 npm 发布 token 的值迁入该 Environment。
+2. `RELEASE_AUTOMATION_TOKEN`：机器人账号的 fine-grained PAT（或 GitHub App token），至少
+   授予本仓库 Contents 和 Pull requests 的读写权限。
+3. `DOCS_RELEASE_DISPATCH_TOKEN`：可选；用于触发 `wangeditor-next/docs` 的发布。
+
+在合并本流程后、批准首个 `release-automation` job 前，删除仓库级的 `NPM_TOKEN` 和
+`DOCS_REPO_DISPATCH_TOKEN`。缺少前两个 secret 时工作流会停止，绝不会回退使用仓库级
+`NPM_TOKEN`。
+
 ## 发布一个正式版本
 
 1. 添加 `changeset`：`npx changeset`
@@ -19,18 +34,24 @@
 2. `release_sha`：自动发布产生的 `chore(release)` 提交的小写 40 位 SHA。
 3. `release_run_id`：该提交原始 `Release` workflow 的数字 run ID（Actions URL 中的数字）。
 
-稳定版只能来自受保护的 `master`，alpha 版只能来自受保护的 `develop`。恢复会校验
-run ID、workflow 路径、源码 SHA、分支和 npm 已发布版本，不能用普通版本提交伪造。
+恢复只接受受保护 `master` 的新流程发布。它会校验 run ID、workflow 路径、源码 SHA、
+分支和 npm 已发布版本，不能用普通版本提交伪造。
 
 该工作流会从该提交相对第一父提交的包版本变化自动推导发布列表，再验证 npm 中
 的已发布版本、只创建缺失的源码 tag，并幂等更新产品 Release 与 sourcemap。
 它不会发布或重新发布 npm 包；已有 tag 若指向其他提交会直接失败。文档只会在该
 editor 版本仍为 npm `latest` 时触发，避免修复历史 Release 时回退站点。
 
+这个工作流只处理本流程启用后产生的发布。历史版本若没有可查询的 Actions run，不要
+放宽输入校验；应在单独 PR 中提交包含 npm、源码提交和 Release 链接证据的补档清单，
+由两名维护者核对后手工创建不可变 source tag 与 Release。见
+[`release-provenance-backfill.md`](./release-provenance-backfill.md)。
+
 ## 发布一个测试版本
 
-1. 从 `master` 创建并保护 `develop` 分支，使用与 `master` 相同的审批和必需检查。
-2. 将包含 changeset 的预发布改动合入 `develop`。
-3. `Release` workflow 自动进入 alpha 模式并完成发布、source tag 和 Release 归档。
+当前自动流程只发布 `master` 稳定版。启用 alpha 前，必须先从已合并的 `master` 创建
+精确的 `develop` 分支，并应用与 `master` 相同的审批和必需检查；随后通过一个单独审查
+的 PR 将 `develop` 加入 Release 与 Repair 的允许分支。不要将未受保护的临时分支作为
+发布源。
 
 不要直接执行 `pnpm changeset publish`，否则会绕过 npm 校验、不可变 source tag 和失败补偿。

--- a/docs/publish.md
+++ b/docs/publish.md
@@ -5,6 +5,23 @@
 1. 添加 `changeset`：`npx changeset`
 2. 提交代码合并 master，线上会自动发版到 `npm`。
 
+发布完成后，每个包都有一个不可变的源码 tag：
+`@wangeditor-next/<package>@<version>`。仅当
+`@wangeditor-next/editor` 发布时，才会创建对应的产品级 GitHub Release
+`v<version>`；Release 中会列出所有本次发布包的源码与 tarball 链接。
+
+## 发布失败后的补偿
+
+如果 npm 已发布，但 source tag、GitHub Release、sourcemap 或文档触发步骤失败，
+不要重新执行 npm publish。到 Actions 运行 `Repair Release Provenance`，填写：
+
+1. `release_sha`：声明该版本、且已进入 `master` 的小写 40 位提交 SHA。
+
+该工作流会从该提交相对第一父提交的包版本变化自动推导发布列表，再验证 npm 中
+的已发布版本、只创建缺失的源码 tag，并幂等更新产品 Release 与 sourcemap。
+它不会发布或重新发布 npm 包；已有 tag 若指向其他提交会直接失败。文档只会在该
+editor 版本仍为 npm `latest` 时触发，避免修复历史 Release 时回退站点。
+
 ## 发布一个测试版本
 
 1. 进入预发布模式：`npx changeset pre enter beta`

--- a/docs/publish.md
+++ b/docs/publish.md
@@ -15,7 +15,8 @@
 如果 npm 已发布，但 source tag、GitHub Release、sourcemap 或文档触发步骤失败，
 不要重新执行 npm publish。到 Actions 运行 `Repair Release Provenance`，填写：
 
-1. `release_sha`：声明该版本、且已进入 `master` 的小写 40 位提交 SHA。
+1. `release_sha`：声明该版本的小写 40 位提交 SHA。稳定版必须可达 `master`；
+   alpha 版必须可达 `dev`、`develop`、`dev-*` 或 `dev/**` 发布分支。
 
 该工作流会从该提交相对第一父提交的包版本变化自动推导发布列表，再验证 npm 中
 的已发布版本、只创建缺失的源码 tag，并幂等更新产品 Release 与 sourcemap。

--- a/docs/release-provenance-backfill.md
+++ b/docs/release-provenance-backfill.md
@@ -1,0 +1,36 @@
+# Historical Release Provenance Backfill
+
+Use this process only for packages published before the current release workflow, or when the
+original GitHub Actions run is no longer available. Do not weaken `Repair Release Provenance` to
+accept these releases.
+
+Create one reviewed PR per historical release and include the following manifest in the PR body or
+an attached Markdown file:
+
+```md
+## Release Provenance Backfill
+
+- Source repository: `owner/repository`
+- Source commit: `<full 40-character SHA>`
+- Package: `@scope/package@<version>`
+- npm evidence: `https://www.npmjs.com/package/@scope/package/v/<version>`
+- Immutable source tag: `@scope/package@<version>`
+- Product Release: `v<version>` or `not applicable`
+- Reason the automated recovery workflow cannot be used: `<missing run / pre-workflow release>`
+- Reviewer evidence: `<two maintainer approvals>`
+```
+
+Before creating a source tag or GitHub Release, both reviewers must independently verify that:
+
+1. `npm view @scope/package@<version> version` returns the recorded version.
+2. The package manifest at the recorded source commit has the exact package name and version.
+3. An existing source tag, if present, resolves to that exact commit.
+4. The proposed product Release is only created for `@wangeditor-next/editor`; leaf packages use
+   their immutable package source tag instead.
+
+The tag creator must use an annotated tag at the recorded commit. Tag update or deletion is not a
+repair mechanism: a mismatched immutable tag is a stop condition that requires a new review.
+
+Issue #950 was handled through this path for
+`@wangeditor-next/editor-for-vue@5.1.14`: its npm tarball, source commit, immutable tag, and
+historical GitHub Release were recorded before the issue was closed.


### PR DESCRIPTION
## Summary

- create immutable `@wangeditor-next/<package>@<version>` source tags for every package published by Changesets
- create a product GitHub Release only when `@wangeditor-next/editor` is published; leaf packages remain discoverable through their source tags
- verify each reported npm version before creating provenance records, and link package source archives from the product Release
- add `Repair Release Provenance`: it derives the exact package-version diff from an already-published release commit, verifies npm, then idempotently restores tags, the product Release, and sourcemaps without republishing npm

## Privilege Boundary

- `Release` has no `workflow_dispatch` entry point and only observes pushes to protected `master`
- an unprivileged validation job runs install, lint, build, unit tests, and E2E; it requests a release only for a changeset or an automated release commit
- the credential-bearing release job runs only after validation and only through `release-automation`
- the job-level `GITHUB_TOKEN` is read-only; package tags, Releases, and Changesets PRs use `RELEASE_AUTOMATION_TOKEN` from the protected Environment
- `Repair Release Provenance` keeps its original run-ID/SHA/workflow-path validation, is limited to `master`, has a read-only default token, and uses the same protected automation token only for tag/Release writes
- package and product tags are protected from update/deletion; an existing tag must resolve to the expected source commit
- release jobs never cancel in progress after npm publish starts, because an npm version is immutable while its provenance steps remain pending

## Environment Rollout

`release-automation` is now configured in GitHub with protected-branch-only access, both maintainers as required reviewers, self-review blocked, and administrator bypass disabled.

Before merging this PR, configure these Environment secrets:

- `NPM_RELEASE_TOKEN`: the current npm publish token
- `RELEASE_AUTOMATION_TOKEN`: a bot-owned fine-grained PAT or GitHub App credential with Contents and Pull requests read/write for this repository
- `DOCS_RELEASE_DISPATCH_TOKEN`: optional token for the docs repository dispatch

After merge and before approving the first environment-gated release job, remove the old repository-level `NPM_TOKEN` and `DOCS_REPO_DISPATCH_TOKEN`. The workflows never fall back to those names.

Alpha release support is intentionally deferred: create and protect the exact `develop` branch from merged `master` first, then add it in a separately reviewed PR. The existing `develop-refactor` branch is not a release source.

## Historical Recovery

- Repair is intentionally for releases produced by this workflow and requires the original Release run ID
- releases without a surviving Actions run use the reviewed manifest process in `docs/release-provenance-backfill.md`; do not weaken the automatic repair checks
- issue #950's missing Vue package provenance was backfilled with its npm tarball, source commit, immutable tag, and historical Release before closing the issue

## Rollback

- this PR cannot publish npm by itself and it does not alter published packages
- reverting the workflow commits restores prior automation; protected source tags and repaired historical Releases remain intact
- the first real release must be observed through npm verification, package tag creation, product Release creation, sourcemap upload, and docs dispatch

## Validation

- `node --test .github/scripts/__tests__/*.test.js` (17 passing tests, including release-policy coverage)
- real npm registry verification and a real `v6.0.2` release-commit recovery dry run
- real GitHub Actions API validation for Release run `29888613104` and SHA `f5155400309596374a7ed5159c424538fab19cde`
- `node --check`, `actionlint` for both workflows, `bash -n` for all 15 embedded workflow scripts, line-width checks, and `git diff --check`

