### PR TITLE
feat(list): support semantic heading outline numbering

### DIFF
--- a/.changeset/composable-outline-numbering.md
+++ b/.changeset/composable-outline-numbering.md
@@ -1,0 +1,18 @@
+---
+'@wangeditor-next/core': minor
+'@wangeditor-next/basic-modules': minor
+'@wangeditor-next/list-module': minor
+'@wangeditor-next/editor': minor
+---
+
+feat(list): support semantic heading outline numbering for #912
+
+The numbered-list menu can turn headings into semantic outline items. It keeps the established
+`type: 'list-item'`, `ordered`, `level`, and text-child JSON shape, and adds optional
+`headingType`, `listMode: 'outline'`, and `listRestart` metadata. Headings render with derived
+outline markers, support continue/restart actions, and export as semantic `ol > li > hN` HTML.
+Existing list JSON and ordinary list HTML keep their historical behavior.
+
+`core` adds an optional module-level `htmlTransform` hook for serializers that need neighboring
+top-level blocks. `basic-modules` recognizes an outline item's optional heading metadata in the
+header menu.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,9 @@
   "access": "restricted",
   "baseBranch": "master",
   "updateInternalDependencies": "patch",
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true,
+    "updateInternalDependents": "out-of-range"
+  },
   "ignore": []
 }

--- a/.changeset/relaxed-compatible-peer-ranges.md
+++ b/.changeset/relaxed-compatible-peer-ranges.md
@@ -1,0 +1,11 @@
+---
+'@wangeditor-next/upload-image-module': patch
+'@wangeditor-next/plugin-attachment': patch
+'@wangeditor-next/plugin-ctrl-enter': patch
+---
+
+fix(release): allow compatible minor peer dependency versions
+
+Internal peer dependencies now use bounded compatible ranges instead of exact release versions.
+This prevents an editor or basic-modules minor release from unnecessarily forcing a major release of
+these unaffected packages.

--- a/apps/demo-html/examples/issue-912-outline-numbering.html
+++ b/apps/demo-html/examples/issue-912-outline-numbering.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Issue #912 - Outline numbering</title>
+  <link href="https://cdn.bootcdn.net/ajax/libs/normalize/8.0.1/normalize.min.css" rel="stylesheet">
+  <link href="./css/editor.css" rel="stylesheet">
+  <link href="../dist/css/style.css" rel="stylesheet">
+  <style>
+    body {
+      color: #18212f;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      margin: 0;
+    }
+
+    main {
+      box-sizing: border-box;
+      margin: 0 auto;
+      max-width: 1120px;
+      padding: 32px 24px 48px;
+    }
+
+    h1 {
+      font-size: 24px;
+      font-weight: 600;
+      margin: 0 0 24px;
+    }
+
+    .editor-shell {
+      border: 1px solid #d9e0e8;
+    }
+
+    .editor-toolbar {
+      border-bottom: 1px solid #d9e0e8;
+    }
+
+    .editor-text-area {
+      min-height: 410px;
+    }
+
+    .output {
+      display: grid;
+      gap: 16px;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      margin-top: 24px;
+    }
+
+    .output section {
+      min-width: 0;
+    }
+
+    .output h2 {
+      font-size: 14px;
+      font-weight: 600;
+      margin: 0 0 8px;
+    }
+
+    pre {
+      background: #f6f8fa;
+      border: 1px solid #d9e0e8;
+      box-sizing: border-box;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 12px;
+      line-height: 1.5;
+      margin: 0;
+      max-height: 320px;
+      overflow: auto;
+      padding: 12px;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+
+    @media (max-width: 720px) {
+      main {
+        padding: 20px 12px 32px;
+      }
+
+      .output {
+        grid-template-columns: minmax(0, 1fr);
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Issue #912: 大纲编号与标题语义</h1>
+    <div class="editor-shell">
+      <div id="editor-toolbar" class="editor-toolbar"></div>
+      <div id="editor-text-area" class="editor-text-area"></div>
+    </div>
+
+    <div class="output">
+      <section>
+        <h2>HTML</h2>
+        <pre id="html-output"></pre>
+      </section>
+      <section>
+        <h2>Slate JSON</h2>
+        <pre id="json-output"></pre>
+      </section>
+    </div>
+  </main>
+
+  <script src="../dist/index.js?v=issue-912-baseline-align"></script>
+  <script>
+    const { createEditor, createToolbar } = window.wangEditor
+
+    const content = [
+      {
+        type: 'list-item',
+        ordered: true,
+        level: 0,
+        headingType: 'header1',
+        listMode: 'outline',
+        children: [{ text: '项目概览' }],
+      },
+      {
+        type: 'list-item',
+        ordered: true,
+        level: 1,
+        headingType: 'header2',
+        listMode: 'outline',
+        children: [{ text: '范围' }],
+      },
+      {
+        type: 'list-item',
+        ordered: true,
+        level: 2,
+        headingType: 'header3',
+        listMode: 'outline',
+        children: [{ text: '功能详情' }],
+      },
+      {
+        type: 'list-item',
+        ordered: true,
+        level: 1,
+        headingType: 'header2',
+        listMode: 'outline',
+        children: [{ text: '交付清单' }],
+      },
+      {
+        type: 'list-item',
+        ordered: true,
+        level: 0,
+        headingType: 'header1',
+        listMode: 'outline',
+        children: [{ text: '附录' }],
+      },
+      {
+        type: 'paragraph',
+        children: [{ text: '普通有序列表保持独立编号' }],
+      },
+      {
+        type: 'list-item',
+        ordered: true,
+        level: 0,
+        children: [{ text: '第一项' }],
+      },
+      {
+        type: 'list-item',
+        ordered: true,
+        level: 1,
+        children: [{ text: '子项' }],
+      },
+      {
+        type: 'list-item',
+        ordered: true,
+        level: 0,
+        children: [{ text: '第二项' }],
+      },
+    ]
+
+    const htmlOutput = document.getElementById('html-output')
+    const jsonOutput = document.getElementById('json-output')
+
+    function updateOutputs(editor) {
+      htmlOutput.textContent = editor.getHtml()
+      jsonOutput.textContent = JSON.stringify(editor.children, null, 2)
+    }
+
+    const editor = createEditor({
+      selector: '#editor-text-area',
+      content,
+      config: {
+        onChange: updateOutputs,
+      },
+    })
+
+    createToolbar({
+      editor,
+      selector: '#editor-toolbar',
+    })
+
+    updateOutputs(editor)
+  </script>
+</body>
+</html>

--- a/docs/plugin-package-spec.md
+++ b/docs/plugin-package-spec.md
@@ -77,7 +77,17 @@ packages/plugin-xxx/
 - `elem -> html -> elem`
 - `html -> elem -> html`
 
-### 4.4 菜单（如有）
+### 4.4 文档级 HTML 转换（如有）
+
+当合法 HTML 依赖相邻顶级块时（例如多个块需要组合成一个语义列表），模块可提供
+`htmlTransform`。它在所有节点完成单独序列化后，接收顶级 HTML 片段、Slate 节点、editor
+和导出选项，并返回最终片段列表。
+
+- 只处理模块自己声明的数据契约，保持未识别块的顺序和内容。
+- 同时覆盖 `getHtml()` 和 `getHtmlWithId()`，不得丢失传入的导出选项。
+- 新增的 `data-w-e-*` 属性必须由模块 README 说明，并为 render、parse、toHtml 和回环路径补测试。
+
+### 4.5 菜单（如有）
 
 - 菜单注册通过 `menus` 数组输出
 - 默认配置统一通过 `config` 暴露到 `editorConfig.MENU_CONF[key]`

--- a/docs/publish.md
+++ b/docs/publish.md
@@ -25,6 +25,15 @@ Release 与 `Repair Release Provenance` 都只能使用 GitHub Environment
 `@wangeditor-next/editor` 发布时，才会创建对应的产品级 GitHub Release
 `v<version>`；Release 中会列出所有本次发布包的源码与 tarball 链接。
 
+## 版本关联策略
+
+各 package 独立版本。功能包按自身公开行为选择 patch、minor 或 major；不要因为宿主包
+发布 minor 就把未改动的 peer package 升级为 major。
+
+内部 peer dependency 使用有上界的兼容范围，例如 `>=6.0.2 <7`，而不是精确版本号。
+Changesets 仅在新版本离开该范围时才升级依赖方。提交前执行 `pnpm changeset status`：预期
+之外的 major 必须先解释并消除，不能靠将 feature changeset 误标为 major 来通过发布。
+
 ## 发布失败后的补偿
 
 如果 npm 已发布，但 source tag、GitHub Release、sourcemap 或文档触发步骤失败，

--- a/packages/basic-modules/__tests__/header/helper.test.ts
+++ b/packages/basic-modules/__tests__/header/helper.test.ts
@@ -50,4 +50,41 @@ describe('header helper', () => {
 
     expect(headers.length).toBe(1)
   })
+
+  it('keeps the list-item shape when changing an outline heading level', () => {
+    editor = createEditor({
+      content: [
+        {
+          type: 'list-item',
+          ordered: true,
+          level: 0,
+          headingType: 'header1',
+          listMode: 'outline',
+          children: [{ text: 'Overview' }],
+        },
+      ],
+    })
+    editor.select({ path: [0, 0], offset: 0 })
+
+    expect(getHeaderType(editor)).toBe('header1')
+    expect(isMenuDisabled(editor)).toBeFalsy()
+
+    setHeaderType(editor, 'header3')
+    expect(editor.children[0]).toEqual({
+      type: 'list-item',
+      ordered: true,
+      level: 2,
+      headingType: 'header3',
+      listMode: 'outline',
+      children: [{ text: 'Overview' }],
+    })
+
+    setHeaderType(editor, 'paragraph')
+    expect(editor.children[0]).toEqual({
+      type: 'list-item',
+      ordered: true,
+      level: 2,
+      children: [{ text: 'Overview' }],
+    })
+  })
 })

--- a/packages/basic-modules/src/modules/header/helper.ts
+++ b/packages/basic-modules/src/modules/header/helper.ts
@@ -6,6 +6,12 @@
 import { DomEditor, IDomEditor } from '@wangeditor-next/core'
 import { Editor, Transforms } from 'slate'
 
+type HeadingType = 'header1' | 'header2' | 'header3' | 'header4' | 'header5' | 'header6'
+
+function isHeadingType(type: string): type is HeadingType {
+  return /^header[1-6]$/.test(type)
+}
+
 /**
  * 获取 node type（'header1' 'header2' 等），未匹配则返回 'paragraph'
  */
@@ -13,8 +19,9 @@ export function getHeaderType(editor: IDomEditor): string {
   const [match] = Editor.nodes(editor, {
     match: n => {
       const type = DomEditor.getNodeType(n)
+      const headingType = (n as any).headingType
 
-      return type.startsWith('header') // 匹配 node.type 是 header 开头的 node
+      return type.startsWith('header') || /^header[1-6]$/.test(headingType)
     },
     universal: true,
   })
@@ -25,7 +32,7 @@ export function getHeaderType(editor: IDomEditor): string {
   // 匹配到 header
   const [n] = match
 
-  return DomEditor.getNodeType(n)
+  return (n as any).headingType || DomEditor.getNodeType(n)
 }
 
 export function isMenuDisabled(editor: IDomEditor): boolean {
@@ -35,9 +42,10 @@ export function isMenuDisabled(editor: IDomEditor): boolean {
     match: n => {
       const type = DomEditor.getNodeType(n)
 
-      // 只可用于 p 和 header
+      // 只可用于 p、header 和有序列表中的标题
       if (type === 'paragraph') { return true }
       if (type.startsWith('header')) { return true }
+      if (type === 'list-item' && (n as any).ordered === true) { return true }
 
       return false
     },
@@ -59,8 +67,37 @@ export function isMenuDisabled(editor: IDomEditor): boolean {
 export function setHeaderType(editor: IDomEditor, type: string) {
   if (!type) { return }
 
-  // 执行命令
-  Transforms.setNodes(editor, {
-    type,
+  const entries = Array.from(
+    Editor.nodes(editor, {
+      match: node => {
+        const nodeType = DomEditor.getNodeType(node)
+
+        return nodeType === 'paragraph' || nodeType.startsWith('header') || nodeType === 'list-item'
+      },
+      mode: 'highest',
+    })
+  )
+
+  Editor.withoutNormalizing(editor, () => {
+    entries.forEach(([node, path]) => {
+      if (DomEditor.getNodeType(node) !== 'list-item') {
+        Transforms.setNodes(editor, { type }, { at: path })
+        return
+      }
+
+      const listNode = node as any
+      const heading = isHeadingType(type) ? type : undefined
+      const level = heading ? Number.parseInt(heading.slice('header'.length), 10) - 1 : listNode.level
+
+      Transforms.setNodes(
+        editor,
+        {
+          headingType: heading,
+          listMode: heading && listNode.ordered ? 'outline' : undefined,
+          level,
+        },
+        { at: path }
+      )
+    })
   })
 }

--- a/packages/basic-modules/src/modules/header/parse-elem-html.ts
+++ b/packages/basic-modules/src/modules/header/parse-elem-html.ts
@@ -13,6 +13,7 @@ import {
   Header3Element,
   Header4Element,
   Header5Element,
+  Header6Element,
 } from './custom-types'
 
 function genParser<T>(level: number) {
@@ -67,5 +68,5 @@ export const parseHeader5HtmlConf = {
 
 export const parseHeader6HtmlConf = {
   selector: 'h6:not([data-w-e-type])', // data-w-e-type 属性，留给自定义元素，保证扩展性
-  parseElemHtml: genParser<Header5Element>(6),
+  parseElemHtml: genParser<Header6Element>(6),
 }

--- a/packages/core/__tests__/editor/plugins/with-content.test.ts
+++ b/packages/core/__tests__/editor/plugins/with-content.test.ts
@@ -8,7 +8,12 @@ import {
 } from 'slate'
 
 import { parseHtmlConf } from '../../../../basic-modules/src/modules/link/parse-elem-html'
-import { registerParseElemHtmlConf } from '../../../src'
+import type { HtmlTransformFnType } from '../../../src'
+import {
+  HTML_TRANSFORM_HANDLER_LIST,
+  registerHtmlTransformHandler,
+  registerParseElemHtmlConf,
+} from '../../../src'
 import { IDomEditor } from '../../../src/editor/interface'
 import { withContent } from '../../../src/editor/plugins/with-content'
 import { EDITOR_TO_SELECTION } from '../../../src/utils/weak-maps'
@@ -124,6 +129,35 @@ describe('editor content API', () => {
     const htmlWithInvalidKey = editor.getHtmlWithId?.('invalid key') || ''
 
     expect(htmlWithInvalidKey).toContain('data-w-e-id="w-e-element-paragraph-')
+  })
+
+  it('applies document html transforms to getHtml and getHtmlWithId', () => {
+    const transform: HtmlTransformFnType = (htmlList, _nodes, _editor, options) => {
+      const includesId = options.includeId ? 'true' : 'false'
+
+      return [`<section data-transform-includes-id="${includesId}">${htmlList.join('')}</section>`]
+    }
+    const editor = createEditor({
+      content: [{ type: 'paragraph', children: [{ text: 'hello' }] }],
+    })
+
+    registerHtmlTransformHandler(transform)
+
+    try {
+      expect(editor.getHtml()).toBe(
+        '<section data-transform-includes-id="false"><div>hello</div></section>'
+      )
+      expect(editor.getHtmlWithId?.('data-node-id')).toContain('data-transform-includes-id="true"')
+      expect(editor.getHtmlWithId?.('data-node-id')).toContain(
+        'data-node-id="w-e-element-paragraph-'
+      )
+    } finally {
+      const index = HTML_TRANSFORM_HANDLER_LIST.indexOf(transform)
+
+      if (index >= 0) {
+        HTML_TRANSFORM_HANDLER_LIST.splice(index, 1)
+      }
+    }
   })
 
   it('getText', () => {

--- a/packages/core/src/editor/plugins/with-content.ts
+++ b/packages/core/src/editor/plugins/with-content.ts
@@ -14,6 +14,7 @@ import { htmlToContent } from '../../create/helper'
 import { PARSE_ELEM_HTML_CONF, TEXT_TAGS } from '../../parse-html/index'
 import parseElemHtml from '../../parse-html/parse-elem-html'
 import { genElemId } from '../../render/helper'
+import { transformHtml } from '../../to-html'
 import node2html from '../../to-html/node2html'
 import $, {
   DOMElement, isDOMElement, isDOMText,
@@ -272,7 +273,7 @@ export const withContent = <T extends Editor>(editor: T) => {
     const { children = [] } = e
     const { skipCacheTypes = ['list-item'] } = e.getConfig()
 
-    const html = children.map(child => {
+    const htmlList = children.map(child => {
       const nodeType = DomEditor.getNodeType(child)
 
       // 如果节点类型在跳过缓存列表中，不使用缓存
@@ -283,14 +284,16 @@ export const withContent = <T extends Editor>(editor: T) => {
       // 尝试从缓存中获取
       const cached = NODE_TO_HTML.get(child)
 
-      if (cached) { return cached }
+      if (cached) { return cached.toString() }
 
       // 生成新的HTML并缓存
       const htmlStr = node2html(child, e)
 
       NODE_TO_HTML.set(child, htmlStr)
       return htmlStr
-    }).join('')
+    })
+
+    const html = transformHtml(htmlList, children, e).join('')
 
     return html
   }
@@ -302,7 +305,9 @@ export const withContent = <T extends Editor>(editor: T) => {
   e.getHtmlWithId = (idKey = 'data-w-e-id'): string => {
     const { children = [] } = e
 
-    return children.map(child => node2html(child, e, { includeId: true, idKey })).join('')
+    const htmlList = children.map(child => node2html(child, e, { includeId: true, idKey }))
+
+    return transformHtml(htmlList, children, e, { includeId: true, idKey }).join('')
   }
 
   // 获取 text

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,7 +9,7 @@ import type { IDomEditor } from './editor/interface'
 import type { IRegisterMenuConf } from './menus/index'
 import type { IParseElemHtmlConf, IPreParseHtmlConf, ParseStyleHtmlFnType } from './parse-html/index'
 import type { IRenderElemConf, RenderStyleFnType } from './render/index'
-import type { IElemToHtmlConf, styleToHtmlFnType } from './to-html/index'
+import type { HtmlTransformFnType, IElemToHtmlConf, styleToHtmlFnType } from './to-html/index'
 import createUploaderRuntime from './upload/createUploader'
 import createUppyUploaderRuntime from './upload/createUppyUploader'
 import type { IUploadConfig } from './upload/interface'
@@ -29,6 +29,7 @@ export type {
   StyleClassTokenType,
   TextStyleMode,
 } from './config/interface'
+export { EditorEvents } from './config/interface'
 export * from './config/style-mode'
 
 // editor 接口和 command
@@ -109,6 +110,7 @@ export interface IModuleConf {
 
   // to html
   styleToHtml: styleToHtmlFnType
+  htmlTransform?: HtmlTransformFnType
   elemsToHtml: Array<IElemToHtmlConf>
 
   // parse html

--- a/packages/core/src/to-html/index.ts
+++ b/packages/core/src/to-html/index.ts
@@ -6,6 +6,7 @@
 import { Descendant, Element as SlateElement } from 'slate'
 
 import { IDomEditor } from '../editor/interface'
+import type { INodeToHtmlOptions } from './node2html'
 
 // ------------------------------------ style to html ------------------------------------
 
@@ -23,6 +24,39 @@ export const STYLE_TO_HTML_FN_LIST: styleToHtmlFnType[] = []
  */
 export function registerStyleToHtmlHandler(fn: styleToHtmlFnType) {
   STYLE_TO_HTML_FN_LIST.push(fn)
+}
+
+// ------------------------------------ document html transform ------------------------------------
+
+/**
+ * Transform the HTML fragments of the document's top-level nodes.
+ *
+ * Element serializers intentionally stay node-local. Modules that need
+ * neighboring blocks to produce valid HTML (for example semantic lists) use
+ * this hook after every node has been serialized.
+ */
+export type HtmlTransformFnType = (
+  htmlList: string[],
+  nodes: Descendant[],
+  editor: IDomEditor,
+  options: INodeToHtmlOptions
+) => string[]
+
+export const HTML_TRANSFORM_HANDLER_LIST: HtmlTransformFnType[] = []
+
+export function registerHtmlTransformHandler(fn: HtmlTransformFnType) {
+  HTML_TRANSFORM_HANDLER_LIST.push(fn)
+}
+
+export function transformHtml(
+  htmlList: string[],
+  nodes: Descendant[],
+  editor: IDomEditor,
+  options: INodeToHtmlOptions = {}
+): string[] {
+  return HTML_TRANSFORM_HANDLER_LIST.reduce((result, handler) => {
+    return handler(result, nodes, editor, options)
+  }, htmlList)
 }
 
 // ------------------------------------ elem node to html ------------------------------------

--- a/packages/editor/src/Boot.ts
+++ b/packages/editor/src/Boot.ts
@@ -4,6 +4,7 @@
  */
 
 import type {
+  HtmlTransformFnType,
   IEditorConfig,
   IElemToHtmlConf,
   IModuleConf,
@@ -21,6 +22,7 @@ import {
   IDomEditor,
   // parseHtml
   registerElemToHtmlConf,
+  registerHtmlTransformHandler,
   registerMenu,
   registerParseElemHtmlConf,
   registerParseStyleHtmlHandler,
@@ -108,6 +110,11 @@ class Boot {
   // 注册 styleToHtml
   static registerStyleToHtml(fn: styleToHtmlFnType) {
     registerStyleToHtmlHandler(fn)
+  }
+
+  // 注册 document html transform
+  static registerHtmlTransform(fn: HtmlTransformFnType) {
+    registerHtmlTransformHandler(fn)
   }
 
   // 注册 preParseHtml

--- a/packages/editor/src/register-builtin-modules/register.ts
+++ b/packages/editor/src/register-builtin-modules/register.ts
@@ -14,6 +14,7 @@ function registerModule(module: Partial<IModuleConf>) {
     renderStyle,
     elemsToHtml,
     styleToHtml,
+    htmlTransform,
     preParseHtml,
     parseElemsHtml,
     parseStyleHtml,
@@ -34,6 +35,9 @@ function registerModule(module: Partial<IModuleConf>) {
   }
   if (styleToHtml) {
     Boot.registerStyleToHtml(styleToHtml)
+  }
+  if (htmlTransform) {
+    Boot.registerHtmlTransform(htmlTransform)
   }
   if (preParseHtml) {
     preParseHtml.forEach(conf => Boot.registerPreParseHtml(conf))

--- a/packages/list-module/README.md
+++ b/packages/list-module/README.md
@@ -1,3 +1,59 @@
 # wangEditor list-module
 
 List module built in [wangeditor-next](https://wangeditor-next.github.io/docs/) by default.
+
+## Semantic heading outlines
+
+Heading outlines preserve the historical list-item JSON shape. The existing `type`, `ordered`,
+`level`, and text children remain unchanged; outline-specific fields are optional metadata.
+
+```ts
+{
+  type: 'list-item',
+  ordered: true,
+  level: 1,
+  headingType: 'header2',
+  listMode: 'outline',
+  children: [{ text: 'Scope' }],
+}
+```
+
+- `headingType`: optional original heading type (`'header1'` through `'header6'`)
+- `listMode`: optional `'outline'` marker for a semantic heading outline
+- `listRestart`: optional restart value for an outline item
+
+The default numbered-list menu applies `listMode: 'outline'` to headings. The visible marker is
+derived from heading levels, so `h1`, `h2`, and `h3` render as `1.`, `1.1`, and `1.1.1` without
+writing a number into the heading text. Clicking an outline marker provides continue and restart
+actions.
+
+## HTML contract
+
+An outline exports semantic `ol > li > hN` HTML, with nested `ol` elements reflecting heading
+depth:
+
+```html
+<ol data-w-e-list-mode="outline">
+  <li data-w-e-list-indent="0" data-w-e-outline-number="1.">
+    <h1>Overview</h1>
+    <ol data-w-e-list-mode="outline">
+      <li data-w-e-list-indent="1" data-w-e-outline-number="1.1"><h2>Scope</h2></li>
+    </ol>
+  </li>
+</ol>
+```
+
+`data-w-e-list-indent` preserves a source heading's depth when semantic HTML cannot express a
+missing parent level. `data-w-e-outline-number` is derived display metadata. Import recomputes it
+from the retained heading level and optional `data-w-e-list-restart`; it is not part of the heading
+text. Ordered standard lists carry `data-w-e-list-mode="standard"` so a semantic heading in a
+non-outline list round-trips without being reclassified as an outline.
+
+When an outline continues after a separate top-level HTML fragment, its new `ol` receives the
+derived `start` value needed for correct rendering outside the editor. Because that fragment also
+carries `data-w-e-outline-number`, parsing retains the original implicit continuation rather than
+turning it into an explicit restart.
+
+Historical `list-item` JSON and ordinary `<ol><li>text</li></ol>` HTML remain supported. Consumers
+that inspect editor JSON can continue using `type: 'list-item'`, `ordered`, `level`, and text
+children; they may ignore the optional outline metadata when that feature is not needed.

--- a/packages/list-module/__tests__/issue-912-outline-numbering.test.ts
+++ b/packages/list-module/__tests__/issue-912-outline-numbering.test.ts
@@ -1,0 +1,412 @@
+/**
+ * @description issue #912 heading and ordered-list composition
+ */
+
+import createEditor from '../../../tests/utils/create-editor'
+import HeaderSelectMenu from '../../basic-modules/src/modules/header/menu/HeaderSelectMenu'
+import NumberedListMenu from '../src/module/menu/NumberedListMenu'
+
+function createOutlineContent() {
+  return [
+    {
+      type: 'list-item',
+      ordered: true,
+      level: 0,
+      headingType: 'header1',
+      listMode: 'outline',
+      children: [{ text: 'Overview' }],
+    },
+    {
+      type: 'list-item',
+      ordered: true,
+      level: 1,
+      headingType: 'header2',
+      listMode: 'outline',
+      children: [{ text: 'Scope' }],
+    },
+    {
+      type: 'list-item',
+      ordered: true,
+      level: 2,
+      headingType: 'header3',
+      listMode: 'outline',
+      children: [{ text: 'Details' }],
+    },
+    {
+      type: 'list-item',
+      ordered: true,
+      level: 1,
+      headingType: 'header2',
+      listMode: 'outline',
+      children: [{ text: 'Delivery' }],
+    },
+    {
+      type: 'list-item',
+      ordered: true,
+      level: 0,
+      headingType: 'header1',
+      listMode: 'outline',
+      listRestart: 1,
+      children: [{ text: 'Appendix' }],
+    },
+  ]
+}
+
+function getMarkers(editor: ReturnType<typeof createEditor>): string[] {
+  editor.updateView()
+
+  return Array.from(editor.getEditableContainer().querySelectorAll('.w-e-list-marker')).map(
+    marker => marker.textContent || ''
+  )
+}
+
+describe('list issue #912 outline numbering', () => {
+  it('keeps the legacy list-item shape while both heading and ordered-list menus are active', () => {
+    const editor = createEditor({
+      content: [
+        { type: 'header1', children: [{ text: 'Overview' }] },
+        { type: 'header2', children: [{ text: 'Scope' }] },
+        { type: 'header3', children: [{ text: 'Details' }] },
+        { type: 'header2', children: [{ text: 'Delivery' }] },
+        { type: 'header1', children: [{ text: 'Summary' }] },
+      ],
+    })
+    const numberedListMenu = new NumberedListMenu()
+    const headerMenu = new HeaderSelectMenu()
+
+    editor.children.forEach((_node, index) => {
+      editor.select({ path: [index, 0], offset: 0 })
+      numberedListMenu.exec(editor, '')
+    })
+
+    expect(editor.children).toEqual([
+      {
+        type: 'list-item',
+        ordered: true,
+        level: 0,
+        headingType: 'header1',
+        listMode: 'outline',
+        children: [{ text: 'Overview' }],
+      },
+      {
+        type: 'list-item',
+        ordered: true,
+        level: 1,
+        headingType: 'header2',
+        listMode: 'outline',
+        children: [{ text: 'Scope' }],
+      },
+      {
+        type: 'list-item',
+        ordered: true,
+        level: 2,
+        headingType: 'header3',
+        listMode: 'outline',
+        children: [{ text: 'Details' }],
+      },
+      {
+        type: 'list-item',
+        ordered: true,
+        level: 1,
+        headingType: 'header2',
+        listMode: 'outline',
+        children: [{ text: 'Delivery' }],
+      },
+      {
+        type: 'list-item',
+        ordered: true,
+        level: 0,
+        headingType: 'header1',
+        listMode: 'outline',
+        children: [{ text: 'Summary' }],
+      },
+    ])
+
+    editor.select({ path: [2, 0], offset: 0 })
+    expect(numberedListMenu.isActive(editor)).toBe(true)
+    expect(headerMenu.getValue(editor)).toBe('header3')
+    expect(getMarkers(editor)).toEqual(['1.', '1.1', '1.1.1', '1.2', '2.'])
+
+    numberedListMenu.exec(editor, '')
+    expect(editor.children[2]).toEqual({ type: 'header3', children: [{ text: 'Details' }] })
+  })
+
+  it('exports semantic heading lists and preserves every HTML/Slate round trip', () => {
+    const source = createEditor({ content: createOutlineContent() })
+    const html = source.getHtml()
+    const wrapper = document.createElement('div')
+
+    wrapper.innerHTML = html
+    expect(wrapper.querySelector('ol[data-w-e-list-mode="outline"] > li > h1')?.textContent).toBe(
+      'Overview'
+    )
+    expect(wrapper.querySelector('ol > li > ol > li > h2')?.textContent).toBe('Scope')
+    expect(wrapper.querySelector('ol > li > ol > li > ol > li > h3')?.textContent).toBe('Details')
+    expect(html).not.toContain('>1.1 Scope<')
+
+    const slateToHtmlToSlate = createEditor({ html })
+    const htmlWithId = source.getHtmlWithId?.('data-node-id') || ''
+
+    expect(slateToHtmlToSlate.children).toEqual(source.children)
+    expect(slateToHtmlToSlate.getHtml()).toBe(html)
+    expect(htmlWithId).toContain('<ol data-w-e-list-mode="outline">')
+    expect(htmlWithId).toMatch(/<h1 data-node-id="w-e-element-list-item-/)
+
+    source.setHtml(html)
+    expect(source.getHtml()).toBe(html)
+    expect(createEditor({ html }).getHtml()).toBe(html)
+  })
+
+  it('keeps top-level blocks after an outline outside the preceding list item', () => {
+    const source = createEditor({
+      content: [
+        {
+          type: 'list-item',
+          ordered: true,
+          level: 0,
+          headingType: 'header1',
+          listMode: 'outline',
+          children: [{ text: 'Chapter' }],
+        },
+        { type: 'paragraph', children: [{ text: 'Following paragraph' }] },
+      ],
+    })
+    const html = source.getHtml()
+    const parsed = createEditor({ html })
+
+    expect(html).toBe(
+      '<ol data-w-e-list-mode="outline"><li data-w-e-list-indent="0" data-w-e-outline-number="1."><h1>Chapter</h1></li></ol><p>Following paragraph</p>'
+    )
+    expect(parsed.children).toEqual(source.children)
+    expect(parsed.getHtml()).toBe(html)
+
+    source.setHtml(html)
+    expect(source.children).toEqual(parsed.children)
+    expect(source.getHtml()).toBe(html)
+  })
+
+  it('uses a container start value only for the first imported outline item', () => {
+    const editor = createEditor({
+      html: '<ol start="3" data-w-e-list-mode="outline"><li><h1>One</h1></li><li><h1>Two</h1></li></ol>',
+    })
+
+    expect(editor.children).toEqual([
+      {
+        type: 'list-item',
+        ordered: true,
+        level: 0,
+        headingType: 'header1',
+        listMode: 'outline',
+        listRestart: 3,
+        children: [{ text: 'One' }],
+      },
+      {
+        type: 'list-item',
+        ordered: true,
+        level: 0,
+        headingType: 'header1',
+        listMode: 'outline',
+        children: [{ text: 'Two' }],
+      },
+    ])
+    expect(getMarkers(editor)).toEqual(['3.', '4.'])
+    expect(editor.getHtml()).toContain('<ol start="3" data-w-e-list-mode="outline">')
+  })
+
+  it('keeps a standard heading list as standard after every HTML round trip', () => {
+    const source = createEditor({
+      content: [
+        {
+          type: 'list-item',
+          ordered: true,
+          level: 0,
+          orderType: 'a',
+          headingType: 'header2',
+          children: [{ text: 'Appendix item' }],
+        },
+      ],
+    })
+    const html = source.getHtml()
+    const parsed = createEditor({ html })
+
+    expect(html).toBe(
+      '<ol type="a" data-w-e-list-mode="standard"><li><h2>Appendix item</h2></li></ol>'
+    )
+    expect(parsed.children).toEqual(source.children)
+    expect(parsed.getHtml()).toBe(html)
+
+    source.setHtml(html)
+    expect(source.children).toEqual(parsed.children)
+  })
+
+  it.each([
+    {
+      mode: 'inline',
+      color: 'rgb(235, 144, 58)',
+      config: {},
+      expectedListColor: 'style="color:rgb(235, 144, 58)"',
+    },
+    {
+      mode: 'class',
+      color: 'rgb(1, 2, 3)',
+      config: {
+        textStyleMode: 'class',
+        styleClassTokens: { color: ['rgb(1, 2, 3)'] },
+      },
+      expectedListColor: 'data-w-e-color="rgb(1, 2, 3)"',
+    },
+  ])(
+    'keeps standard list colors through render and HTML round-trip in $mode mode',
+    ({ color, config, expectedListColor }) => {
+      const source = createEditor({
+        config,
+        content: [
+          {
+            type: 'list-item',
+            ordered: true,
+            level: 0,
+            children: [{ text: 'Parent', color }],
+          },
+          {
+            type: 'list-item',
+            ordered: true,
+            level: 1,
+            children: [{ text: 'Child', color }],
+          },
+        ],
+      })
+      const html = source.getHtml()
+      const parsed = createEditor({ html, config })
+
+      expect(html).toContain(expectedListColor)
+      expect(parsed.children).toEqual(source.children)
+      expect(parsed.getHtml()).toBe(html)
+      expect(getMarkers(parsed)).toEqual(['1.', '1.'])
+      expect(
+        parsed.getEditableContainer().querySelector<HTMLElement>('.w-e-list-marker')?.style.color
+      ).toBe(color)
+    }
+  )
+
+  it.each([
+    {
+      mode: 'inline',
+      color: 'rgb(235, 144, 58)',
+      config: {},
+      expectedListColor: 'style="color:rgb(235, 144, 58)"',
+    },
+    {
+      mode: 'class',
+      color: 'rgb(1, 2, 3)',
+      config: {
+        textStyleMode: 'class',
+        styleClassTokens: { color: ['rgb(1, 2, 3)'] },
+      },
+      expectedListColor: 'data-w-e-color="rgb(1, 2, 3)"',
+    },
+  ])(
+    'keeps outline list colors through render and HTML round-trip in $mode mode',
+    ({ color, config, expectedListColor }) => {
+      const source = createEditor({
+        config,
+        content: [
+          {
+            type: 'list-item',
+            ordered: true,
+            level: 0,
+            headingType: 'header1',
+            listMode: 'outline',
+            children: [{ text: 'Overview', color }],
+          },
+          {
+            type: 'list-item',
+            ordered: true,
+            level: 1,
+            headingType: 'header2',
+            listMode: 'outline',
+            children: [{ text: 'Scope', color }],
+          },
+        ],
+      })
+      const html = source.getHtml()
+      const parsed = createEditor({ html, config })
+
+      expect(html).toContain('data-w-e-list-mode="outline"')
+      expect(html).toContain(expectedListColor)
+      expect(parsed.children).toEqual(source.children)
+      expect(parsed.getHtml()).toBe(html)
+      expect(getMarkers(parsed)).toEqual(['1.', '1.1'])
+      expect(
+        parsed.getEditableContainer().querySelector<HTMLElement>('.w-e-list-marker')?.style.color
+      ).toBe(color)
+    }
+  )
+
+  it('uses an HTML start value when an outline continues after a heading boundary', () => {
+    const source = createEditor({
+      content: [
+        {
+          type: 'list-item',
+          ordered: true,
+          level: 0,
+          headingType: 'header1',
+          listMode: 'outline',
+          children: [{ text: 'First chapter' }],
+        },
+        { type: 'header1', children: [{ text: 'Unnumbered boundary' }] },
+        {
+          type: 'list-item',
+          ordered: true,
+          level: 0,
+          headingType: 'header1',
+          listMode: 'outline',
+          children: [{ text: 'Continued chapter' }],
+        },
+      ],
+    })
+    const html = source.getHtml()
+    const parsed = createEditor({ html })
+
+    expect(getMarkers(source)).toEqual(['1.', '2.'])
+    expect(html).toContain('<ol start="2" data-w-e-list-mode="outline">')
+    expect(parsed.children).toEqual(source.children)
+    expect(parsed.getHtml()).toBe(html)
+  })
+
+  it('continues and restarts numbering through the marker action panel', () => {
+    const editor = createEditor({ content: createOutlineContent() })
+    const getSecondRootMarker = () => {
+      const markers = editor
+        .getEditableContainer()
+        .querySelectorAll<HTMLButtonElement>('.w-e-list-marker')
+
+      return markers[4]
+    }
+
+    editor.updateView()
+    getSecondRootMarker().click()
+
+    let panel = editor.getEditableContainer().querySelector('.w-e-list-outline-actions')
+
+    expect(panel?.querySelectorAll('button')).toHaveLength(2)
+    panel?.querySelectorAll<HTMLButtonElement>('button')[0].click()
+    expect((editor.children[4] as any).listRestart).toBeUndefined()
+    expect(getMarkers(editor)).toEqual(['1.', '1.1', '1.1.1', '1.2', '2.'])
+
+    getSecondRootMarker().click()
+    panel = editor.getEditableContainer().querySelector('.w-e-list-outline-actions')
+    panel?.querySelectorAll<HTMLButtonElement>('button')[1].click()
+    expect((editor.children[4] as any).listRestart).toBe(1)
+    expect(getMarkers(editor)).toEqual(['1.', '1.1', '1.1.1', '1.2', '1.'])
+  })
+
+  it('continues to read and export historical list-item content', () => {
+    const editor = createEditor({ html: '<ol><li>One</li><li>Two</li></ol>' })
+
+    expect(editor.children).toEqual([
+      { type: 'list-item', ordered: true, level: 0, children: [{ text: 'One' }] },
+      { type: 'list-item', ordered: true, level: 0, children: [{ text: 'Two' }] },
+    ])
+    expect(editor.getHtml()).toBe('<ol><li>One</li><li>Two</li></ol>')
+  })
+})

--- a/packages/list-module/__tests__/menu/bulleted-list-menu.test.ts
+++ b/packages/list-module/__tests__/menu/bulleted-list-menu.test.ts
@@ -79,6 +79,7 @@ describe('list BulletedListMenu', () => {
       {
         type: 'list-item',
         ordered: false,
+        level: 0,
         children: [{ text: 'hello' }],
       },
     ])

--- a/packages/list-module/__tests__/menu/lower-alpha-list-menu.test.ts
+++ b/packages/list-module/__tests__/menu/lower-alpha-list-menu.test.ts
@@ -87,6 +87,7 @@ describe('list LowerAlphaListMenu', () => {
       {
         type: 'list-item',
         ordered: true,
+        level: 0,
         orderType: 'a',
         children: [{ text: 'hello' }],
       },
@@ -108,6 +109,7 @@ describe('list LowerAlphaListMenu', () => {
       {
         type: 'list-item',
         ordered: true,
+        level: 0,
         orderType: 'a',
         children: [{ text: 'hello' }],
       },

--- a/packages/list-module/__tests__/menu/numbered-list-menu.test.ts
+++ b/packages/list-module/__tests__/menu/numbered-list-menu.test.ts
@@ -85,6 +85,7 @@ describe('list NumberedListMenu', () => {
       {
         type: 'list-item',
         ordered: true,
+        level: 0,
         children: [{ text: 'hello' }],
       },
     ])
@@ -107,6 +108,7 @@ describe('list NumberedListMenu', () => {
       {
         type: 'list-item',
         ordered: true,
+        level: 0,
         children: [{ text: 'hello' }],
       },
     ])

--- a/packages/list-module/__tests__/render-elem.test.ts
+++ b/packages/list-module/__tests__/render-elem.test.ts
@@ -89,7 +89,7 @@ describe('list module - render elem', () => {
 
     expect(style).toEqual({
       margin: '5px 0 5px 60px',
-      alignItems: 'flex-start',
+      alignItems: 'baseline',
       display: 'flex',
     }) // margin-left 60px
   })

--- a/packages/list-module/src/assets/index.less
+++ b/packages/list-module/src/assets/index.less
@@ -1,1 +1,48 @@
 @import "style-class.less";
+
+.w-e-list-item {
+  .w-e-list-marker {
+    flex: 0 0 auto;
+    min-width: 1.5em;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    line-height: inherit;
+    text-align: right;
+
+    &:is(button) {
+      cursor: pointer;
+    }
+  }
+}
+
+.w-e-list-outline-actions {
+  position: absolute;
+  z-index: 3;
+  display: flex;
+  min-width: 176px;
+  flex-direction: column;
+  padding: 4px;
+  border: 1px solid #d9d9d9;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+
+  .w-e-list-outline-action {
+    width: 100%;
+    padding: 6px 8px;
+    border: 0;
+    background: transparent;
+    color: #333;
+    cursor: pointer;
+    font-size: 14px;
+    text-align: left;
+
+    &:hover,
+    &:focus-visible {
+      background: #f5f5f5;
+      outline: 0;
+    }
+  }
+}

--- a/packages/list-module/src/locale/en.ts
+++ b/packages/list-module/src/locale/en.ts
@@ -8,5 +8,8 @@ export default {
     unOrderedList: 'Unordered list',
     orderedList: 'Ordered list',
     lowerAlphaList: 'Ordered list (a,b,c)',
+    numberingActions: 'Heading numbering actions',
+    continueNumbering: 'Continue heading numbering',
+    restartNumbering: 'Restart numbering',
   },
 }

--- a/packages/list-module/src/locale/zh-CN.ts
+++ b/packages/list-module/src/locale/zh-CN.ts
@@ -8,5 +8,8 @@ export default {
     unOrderedList: '无序列表',
     orderedList: '有序列表',
     lowerAlphaList: '有序列表（a,b,c）',
+    numberingActions: '标题编号操作',
+    continueNumbering: '继续标题编号',
+    restartNumbering: '重新开始编号',
   },
 }

--- a/packages/list-module/src/module/custom-types.ts
+++ b/packages/list-module/src/module/custom-types.ts
@@ -9,11 +9,26 @@ import { Text } from 'slate'
 
 export type OrderedListType = '1' | 'a' | 'A' | 'i' | 'I'
 
+/**
+ * An outline keeps the established list-item wire format and records the
+ * heading semantics as additive metadata.
+ */
+export type HeadingType = 'header1' | 'header2' | 'header3' | 'header4' | 'header5' | 'header6'
+
 export type ListItemElement = {
   type: 'list-item'
   ordered: boolean // 有序/无序
   level: number // 层级：0 1 2 ...
   start?: number // ol start
   orderType?: OrderedListType // ol type
+  headingType?: HeadingType
+  listMode?: 'outline'
+  listRestart?: number
   children: Text[]
+}
+
+export type OutlineListItemElement = ListItemElement & {
+  ordered: true
+  headingType: HeadingType
+  listMode: 'outline'
 }

--- a/packages/list-module/src/module/elem-to-html.ts
+++ b/packages/list-module/src/module/elem-to-html.ts
@@ -10,9 +10,11 @@ import { ELEM_TO_EDITOR } from '../utils/maps'
 import { getListItemColor } from '../utils/util'
 import { ListItemElement } from './custom-types'
 import {
+  getHeadingType,
   getNormalizedOrderedListStart,
   getNormalizedOrderedListType,
   hasSameListConfig,
+  isOutlineListNode,
 } from './helpers'
 import { genListColorClassName, resolveListColorAction } from './style-class'
 
@@ -43,6 +45,9 @@ function genContainerStartTag(elem: ListItemElement): string {
   if (orderStart !== 1) {
     attrs.push(`start="${orderStart}"`)
   }
+  if (getHeadingType(elem) != null) {
+    attrs.push('data-w-e-list-mode="standard"')
+  }
 
   if (attrs.length === 0) { return '<ol>' }
   return `<ol ${attrs.join(' ')}>`
@@ -59,7 +64,9 @@ function getAdjacentListItem(
   const targetIndex = direction === 'prev' ? index - 1 : index + 1
   const targetNode = editor.children[targetIndex] as any
 
-  if (!DomEditor.checkNodeType(targetNode, 'list-item')) { return null }
+  if (!DomEditor.checkNodeType(targetNode, 'list-item') || isOutlineListNode(targetNode)) {
+    return null
+  }
   return targetNode as ListItemElement
 }
 
@@ -71,7 +78,7 @@ function getPrevSameLevelListItem(
   for (let i = index - 1; i >= 0; i -= 1) {
     const node = editor.children[i] as any
 
-    if (!DomEditor.checkNodeType(node, 'list-item')) { continue }
+    if (!DomEditor.checkNodeType(node, 'list-item') || isOutlineListNode(node)) { continue }
     if ((node.level || 0) === level) {
       return node as ListItemElement
     }
@@ -92,6 +99,21 @@ function elemToHtml(
   let endContainerStr = ''
 
   const listItemElem = elem as ListItemElement
+  const headingType = getHeadingType(listItemElem)
+  const headingTag = headingType == null ? null : headingType.replace('header', 'h')
+
+  if (isOutlineListNode(listItemElem) && headingTag != null) {
+    return {
+      html: `<${headingTag}>${childrenHtml}</${headingTag}>`,
+      prefix: '',
+      suffix: '',
+    }
+  }
+
+  if (headingTag != null) {
+    childrenHtml = `<${headingTag}>${childrenHtml}</${headingTag}>`
+  }
+
   const { level = 0 } = listItemElem
   const containerTag = getContainerTag(listItemElem)
   const containerStartTag = genContainerStartTag(listItemElem)

--- a/packages/list-module/src/module/helpers.ts
+++ b/packages/list-module/src/module/helpers.ts
@@ -1,28 +1,82 @@
 /**
- * @description table menu helpers
- * @author wangfupeng
+ * @description list helpers
  */
 
 import { DomEditor, IDomEditor } from '@wangeditor-next/core'
-import { Editor, Path } from 'slate'
+import { Editor, Node, Path } from 'slate'
 
-import { ListItemElement, OrderedListType } from './custom-types'
+import {
+  HeadingType,
+  ListItemElement,
+  OrderedListType,
+  OutlineListItemElement,
+} from './custom-types'
+
+export function isListNode(node: Node): node is ListItemElement {
+  return DomEditor.checkNodeType(node, 'list-item')
+}
+
+// Keep the legacy name for callers that distinguish the persisted list shape.
+export const isLegacyListItem = isListNode
+
+export function isHeadingType(value: unknown): value is HeadingType {
+  return typeof value === 'string' && /^header[1-6]$/.test(value)
+}
+
+export function getHeadingType(node: Node): HeadingType | null {
+  if (!isListNode(node) || !isHeadingType(node.headingType)) {
+    return null
+  }
+
+  return node.headingType
+}
+
+export function getListIndent(node: Node): number {
+  if (!isListNode(node)) {
+    return 0
+  }
+
+  return node.level > 0 ? Math.floor(node.level) : 0
+}
+
+export function getListMode(node: Node): 'standard' | 'outline' {
+  return isListNode(node) && node.listMode === 'outline' ? 'outline' : 'standard'
+}
+
+export function isOutlineListNode(node: Node): node is OutlineListItemElement {
+  return (
+    isListNode(node) &&
+    node.ordered === true &&
+    node.listMode === 'outline' &&
+    isHeadingType(node.headingType)
+  )
+}
+
+export function getOutlineLevel(node: Node): number {
+  const headingType = getHeadingType(node)
+  const match = headingType == null ? null : /^header([1-6])$/.exec(headingType)
+
+  if (match != null) {
+    return Number.parseInt(match[1], 10)
+  }
+
+  return getListIndent(node) + 1
+}
 
 export function getNormalizedOrderedListStart(elem: ListItemElement): number {
   const { ordered = false, start } = elem
 
-  if (!ordered) { return 1 }
-  if (typeof start !== 'number' || Number.isNaN(start)) { return 1 }
+  if (!ordered || typeof start !== 'number' || Number.isNaN(start)) {
+    return 1
+  }
+
   return start
 }
 
 export function getNormalizedOrderedListType(elem: ListItemElement): OrderedListType {
   const { orderType } = elem
 
-  if (orderType === 'a'
-    || orderType === 'A'
-    || orderType === 'i'
-    || orderType === 'I') {
+  if (orderType === 'a' || orderType === 'A' || orderType === 'i' || orderType === 'I') {
     return orderType
   }
 
@@ -30,52 +84,119 @@ export function getNormalizedOrderedListType(elem: ListItemElement): OrderedList
 }
 
 export function hasSameListConfig(a: ListItemElement, b: ListItemElement): boolean {
-  if (a.ordered !== b.ordered) { return false }
-  if (!a.ordered) { return true }
+  if (a.ordered !== b.ordered) {
+    return false
+  }
+  if (!a.ordered) {
+    return true
+  }
 
-  return getNormalizedOrderedListType(a) === getNormalizedOrderedListType(b)
-    && getNormalizedOrderedListStart(a) === getNormalizedOrderedListStart(b)
+  return (
+    getNormalizedOrderedListType(a) === getNormalizedOrderedListType(b) &&
+    getNormalizedOrderedListStart(a) === getNormalizedOrderedListStart(b)
+  )
+}
+
+export function getOrderedItemNumber(editor: IDomEditor, elem: ListItemElement): number {
+  if (!elem.ordered) {
+    return 1
+  }
+
+  const level = getListIndent(elem)
+  let number = getNormalizedOrderedListStart(elem)
+  const index = DomEditor.findPath(editor, elem)[0]
+
+  if (index <= 0) {
+    return number
+  }
+
+  for (let previousIndex = index - 1; previousIndex >= 0; previousIndex -= 1) {
+    const previous = editor.children[previousIndex]
+
+    if (!isListNode(previous)) {
+      break
+    }
+
+    const previousLevel = getListIndent(previous)
+
+    if (previousLevel < level) {
+      break
+    }
+    if (previousLevel === level) {
+      if (!hasSameListConfig(previous, elem) || isOutlineListNode(previous)) {
+        break
+      }
+      number += 1
+    }
+  }
+
+  return number
+}
+
+export function getOutlineNumber(editor: IDomEditor, elem: ListItemElement): string {
+  const counters = Array.from({ length: 6 }, () => 0)
+
+  for (const current of editor.children) {
+    if (!isOutlineListNode(current)) {
+      continue
+    }
+
+    const level = getOutlineLevel(current)
+    const index = level - 1
+
+    for (let parentIndex = 0; parentIndex < index; parentIndex += 1) {
+      if (counters[parentIndex] === 0) {
+        counters[parentIndex] = 1
+      }
+    }
+
+    if (typeof current.listRestart === 'number' && current.listRestart > 0) {
+      counters[index] = Math.floor(current.listRestart)
+    } else if (counters[index] === 0) {
+      counters[index] = 1
+    } else {
+      counters[index] += 1
+    }
+
+    for (let childIndex = index + 1; childIndex < counters.length; childIndex += 1) {
+      counters[childIndex] = 0
+    }
+
+    if (current === elem) {
+      const label = counters.slice(0, level).join('.')
+
+      return level === 1 ? `${label}.` : label
+    }
+  }
+
+  return ''
 }
 
 /**
  * 获取上一个同一 level 的 list item
- * @param editor 编辑器实例
+ * @param editor editor
  * @param elem elem
  */
 export function getBrotherListNodeByLevel(
   editor: IDomEditor,
   elem: ListItemElement,
-  level?: number,
+  level?: number
 ): ListItemElement | null {
-  const { type, ...otherProps } = elem
-  // level 可能是 退格前的值,所以这里需要判断
-  const elemLevel = level !== undefined ? level : otherProps.level || 0
+  const elemLevel = level !== undefined ? level : elem.level || 0
+  let brotherPath = DomEditor.findPath(editor, elem)
 
-  const path = DomEditor.findPath(editor, elem)
-  let brotherPath = path
-
-  // eslint-disable-next-line no-constant-condition
   while (true) {
     if (brotherPath.length === 0 || brotherPath[brotherPath.length - 1] === 0) {
-      return null // 已经是最后一个节点或没有找到有效的前一个 list 节点
+      return null
     }
     brotherPath = Path.previous(brotherPath)
     const brotherEntry = Editor.node(editor, brotherPath)
 
-    if (!brotherEntry) {
-      return null // 没有找到有效的前一个节点
-    }
-
-    const [brotherElem] = brotherEntry
-    const { level: brotherLevel = 0 } = brotherElem as ListItemElement
-    const brotherType = DomEditor.getNodeType(brotherElem)
-
-    // 验证兄弟节点是否是期望的类型和层级
-    if (brotherType !== type) {
+    if (brotherEntry == null || !isListNode(brotherEntry[0])) {
       return null
     }
-    if (brotherLevel === elemLevel) {
-      return brotherElem as ListItemElement
+    if (getListIndent(brotherEntry[0]) === elemLevel) {
+      return brotherEntry[0]
     }
   }
 }
@@ -83,9 +204,9 @@ export function getBrotherListNodeByLevel(
 export function hasSameOrderWithBrother(
   editor: IDomEditor,
   elem: ListItemElement,
-  level?: number,
+  level?: number
 ): boolean {
   const brotherElem = getBrotherListNodeByLevel(editor, elem, level)
 
-  return brotherElem ? hasSameListConfig(brotherElem, elem) : false
+  return brotherElem != null && hasSameListConfig(brotherElem, elem)
 }

--- a/packages/list-module/src/module/html-transform.ts
+++ b/packages/list-module/src/module/html-transform.ts
@@ -1,0 +1,179 @@
+/**
+ * @description compose semantic outline HTML from additive list-item metadata
+ */
+
+import { getTextStyleMode, HtmlTransformFnType, IDomEditor } from '@wangeditor-next/core'
+
+import { getListItemColor } from '../utils/util'
+import { ListItemElement } from './custom-types'
+import {
+  getOutlineLevel,
+  getOutlineNumber,
+  hasSameListConfig,
+  isOutlineListNode,
+} from './helpers'
+import { genListColorClassName, resolveListColorAction } from './style-class'
+
+type OutlineItem = {
+  node: ListItemElement
+  html: string
+  children: OutlineContainer[]
+}
+
+type OutlineContainer = {
+  node: ListItemElement
+  items: OutlineItem[]
+}
+
+type OutlineLevel = {
+  container: OutlineContainer
+  lastItem: OutlineItem
+}
+
+type OutlineContext = {
+  roots: OutlineContainer[]
+  levels: OutlineLevel[]
+}
+
+function getOutlineContainerStart(editor: IDomEditor, node: ListItemElement): number {
+  const lastSegment = getOutlineNumber(editor, node).split('.').filter(Boolean).pop()
+  const start = Number.parseInt(lastSegment || '', 10)
+
+  return Number.isFinite(start) && start > 0 ? start : 1
+}
+
+function getContainerStartTag(container: OutlineContainer, editor: IDomEditor): string {
+  const start = getOutlineContainerStart(editor, container.node)
+  const startAttr = start === 1 ? '' : ` start="${start}"`
+
+  return `<ol${startAttr} data-w-e-list-mode="outline">`
+}
+
+function getColorAttrs(node: ListItemElement, editor: IDomEditor): string[] {
+  const color = getListItemColor(node)
+
+  if (!color) {
+    return []
+  }
+
+  if (getTextStyleMode(editor) !== 'class') {
+    return [`style="color:${color}"`]
+  }
+
+  const attrs = [`data-w-e-color="${color}"`]
+  const action = resolveListColorAction(editor, color)
+
+  if (action === 'class') {
+    attrs.unshift(`class="${genListColorClassName(color)}"`)
+  } else if (action === 'inline') {
+    attrs.push(`style="color:${color}"`)
+  }
+
+  return attrs
+}
+
+function getListItemStartTag(node: ListItemElement, editor: IDomEditor): string {
+  const attrs = getColorAttrs(node, editor)
+
+  attrs.push(`data-w-e-list-indent="${getOutlineLevel(node) - 1}"`)
+
+  if (typeof node.listRestart === 'number') {
+    attrs.push(`data-w-e-list-restart="${node.listRestart}"`)
+  }
+  attrs.push(`data-w-e-outline-number="${getOutlineNumber(editor, node)}"`)
+
+  return `<li ${attrs.join(' ')}>`
+}
+
+function renderContainer(container: OutlineContainer, editor: IDomEditor): string {
+  const itemsHtml = container.items
+    .map(item => {
+      const childrenHtml = item.children.map(child => renderContainer(child, editor)).join('')
+
+      return `${getListItemStartTag(item.node, editor)}${item.html}${childrenHtml}</li>`
+    })
+    .join('')
+
+  return `${getContainerStartTag(container, editor)}${itemsHtml}</ol>`
+}
+
+function addOutlineItem(
+  roots: OutlineContainer[],
+  levels: OutlineLevel[],
+  node: ListItemElement,
+  html: string
+): OutlineItem {
+  let level = Math.max(0, getOutlineLevel(node) - 1)
+
+  // A standalone h3 cannot have a semantic parent. Preserve the source depth
+  // in data-w-e-list-indent while emitting valid nested HTML.
+  if (level > levels.length) {
+    level = levels.length
+  }
+
+  levels.length = level + 1
+  const parent = level > 0 ? levels[level - 1]?.lastItem : null
+  const current = levels[level]
+  const restart = typeof node.listRestart === 'number'
+  const needsNewContainer =
+    current == null || !hasSameListConfig(current.container.node, node) || restart
+
+  let container: OutlineContainer
+
+  if (needsNewContainer) {
+    container = { node, items: [] }
+    if (parent != null) {
+      parent.children.push(container)
+    } else {
+      roots.push(container)
+    }
+  } else {
+    container = current.container
+  }
+
+  const item: OutlineItem = { node, html, children: [] }
+
+  container.items.push(item)
+  levels[level] = { container, lastItem: item }
+
+  return item
+}
+
+/**
+ * List-item serialization remains backward compatible for ordinary lists.
+ * Only outline list items need document-level composition to create valid
+ * `ol > li > hN` structure.
+ */
+export const transformListHtml: HtmlTransformFnType = (htmlList, nodes, editor) => {
+  const result: string[] = []
+  let outlineContext: OutlineContext | null = null
+
+  const flushOutline = () => {
+    if (outlineContext == null || outlineContext.roots.length === 0) {
+      return
+    }
+
+    result.push(outlineContext.roots.map(container => renderContainer(container, editor)).join(''))
+    outlineContext = null
+  }
+
+  nodes.forEach((node, index) => {
+    const html = htmlList[index] || ''
+
+    if (isOutlineListNode(node)) {
+      if (outlineContext == null) {
+        outlineContext = { roots: [], levels: [] }
+      }
+
+      addOutlineItem(outlineContext.roots, outlineContext.levels, node, html)
+      return
+    }
+
+    flushOutline()
+    result.push(html)
+  })
+
+  flushOutline()
+
+  return result
+}

--- a/packages/list-module/src/module/index.ts
+++ b/packages/list-module/src/module/index.ts
@@ -6,6 +6,7 @@
 import { IModuleConf } from '@wangeditor-next/core'
 
 import listItemToHtmlConf from './elem-to-html'
+import { transformListHtml } from './html-transform'
 import {
   bulletedListMenuConf,
   numberedListLowerAlphaMenuConf,
@@ -19,6 +20,7 @@ const list: Partial<IModuleConf> = {
   renderElems: [renderListItemConf],
   editorPlugin: withList,
   menus: [bulletedListMenuConf, numberedListMenuConf, numberedListLowerAlphaMenuConf],
+  htmlTransform: transformListHtml,
   elemsToHtml: [listItemToHtmlConf],
   parseElemsHtml: [parseListHtmlConf, parseItemHtmlConf],
 }

--- a/packages/list-module/src/module/menu/BaseMenu.ts
+++ b/packages/list-module/src/module/menu/BaseMenu.ts
@@ -1,15 +1,55 @@
 /**
- * @description base menu
+ * @description list menu base class
  * @author wangfupeng
  */
 
-import { DomEditor, IButtonMenu, IDomEditor } from '@wangeditor-next/core'
-import {
-  Editor, Element, Node, Transforms,
-} from 'slate'
+import { IButtonMenu, IDomEditor } from '@wangeditor-next/core'
+import { Editor, Element, Node, Path, Transforms } from 'slate'
 
-import { ListItemElement, OrderedListType } from '../custom-types'
-import { getNormalizedOrderedListType } from '../helpers'
+import { HeadingType, ListItemElement, OrderedListType } from '../custom-types'
+import {
+  getHeadingType,
+  getListIndent,
+  getNormalizedOrderedListType,
+  isHeadingType,
+  isListNode,
+} from '../helpers'
+
+function getSelectedTopLevelBlocks(editor: IDomEditor): Array<[Element, Path]> {
+  if (editor.selection == null) {
+    return []
+  }
+
+  const entries = Array.from(
+    Editor.nodes(editor, {
+      at: editor.selection,
+      match: node => Element.isElement(node) && Editor.isBlock(editor, node),
+      mode: 'highest',
+    })
+  ) as Array<[Element, Path]>
+
+  return entries.filter(([, path]) => path.length === 1)
+}
+
+function isListableBlock(editor: IDomEditor, elem: Element): boolean {
+  if (Editor.isVoid(editor, elem)) {
+    return false
+  }
+
+  return !['pre', 'code', 'table', 'table-row', 'table-cell'].includes(elem.type)
+}
+
+function getHeadingLevel(headingType: HeadingType): number {
+  return Number.parseInt(headingType.slice('header'.length), 10) - 1
+}
+
+function getOriginalHeadingType(node: Element): HeadingType | null {
+  if (isListNode(node)) {
+    return getHeadingType(node)
+  }
+
+  return isHeadingType(node.type) ? node.type : null
+}
 
 abstract class BaseMenu implements IButtonMenu {
   readonly type = 'list-item'
@@ -24,10 +64,15 @@ abstract class BaseMenu implements IButtonMenu {
 
   readonly tag = 'button'
 
-  private getListNode(editor: IDomEditor): Node | null {
-    const { type } = this
+  private isTargetListNode(node: Node): boolean {
+    if (!isListNode(node) || Boolean(node.ordered) !== this.ordered) {
+      return false
+    }
+    if (!this.ordered) {
+      return true
+    }
 
-    return DomEditor.getSelectedNodeByType(editor, type)
+    return getNormalizedOrderedListType(node) === (this.orderType || '1')
   }
 
   getValue(_editor: IDomEditor): string | boolean {
@@ -35,62 +80,67 @@ abstract class BaseMenu implements IButtonMenu {
   }
 
   isActive(editor: IDomEditor): boolean {
-    const node = this.getListNode(editor)
+    const selectedBlocks = getSelectedTopLevelBlocks(editor)
 
-    if (node == null) { return false }
-    const listNode = node as ListItemElement
-    const { ordered = false } = listNode
-
-    if (ordered !== this.ordered) { return false }
-    if (!ordered) { return true }
-
-    const currentOrderType = getNormalizedOrderedListType(listNode)
-    const targetOrderType = this.orderType || '1'
-
-    return currentOrderType === targetOrderType
+    return selectedBlocks.length > 0 && selectedBlocks.every(([node]) => this.isTargetListNode(node))
   }
 
   isDisabled(editor: IDomEditor): boolean {
-    if (editor.selection == null) { return true }
+    const selectedBlocks = getSelectedTopLevelBlocks(editor)
 
-    const selectedElems = DomEditor.getSelectedElems(editor)
-    const notMatch = selectedElems.some((elem: Element) => {
-      if (Editor.isVoid(editor, elem) && Editor.isBlock(editor, elem)) { return true }
-
-      const { type } = elem as Element
-
-      if (['pre', 'code', 'table'].includes(type)) { return true }
-      return false
-    })
-
-    if (notMatch) { return true }
-
-    return false
+    return selectedBlocks.length === 0 || selectedBlocks.some(([node]) => !isListableBlock(editor, node))
   }
 
   exec(editor: IDomEditor, _value: string | boolean): void {
     const active = this.isActive(editor)
+    const selectedBlocks = getSelectedTopLevelBlocks(editor)
 
-    if (active) {
-      // 如果当前 active ，则转换为 p 标签
-      Transforms.setNodes(editor, {
-        type: 'paragraph',
-        // @ts-ignore
-        ordered: undefined,
-        level: undefined,
-        start: undefined,
-        orderType: undefined,
-      })
-    } else {
-      // 否则，转换为 list-item
-      Transforms.setNodes(editor, {
-        type: 'list-item',
-        ordered: this.ordered, // 有序/无序
-        indent: undefined,
-        start: undefined,
-        orderType: this.ordered ? this.orderType : undefined,
-      })
+    if (selectedBlocks.length === 0) {
+      return
     }
+
+    Editor.withoutNormalizing(editor, () => {
+      selectedBlocks.forEach(([node, path]) => {
+        if (active) {
+          const listNode = node as ListItemElement
+          const headingType = getHeadingType(listNode)
+
+          Transforms.setNodes(
+            editor,
+            {
+              type: headingType || 'paragraph',
+              ordered: undefined,
+              level: undefined,
+              start: undefined,
+              orderType: undefined,
+              headingType: undefined,
+              listMode: undefined,
+              listRestart: undefined,
+            } as any,
+            { at: path }
+          )
+          return
+        }
+
+        const headingType = getOriginalHeadingType(node)
+        const outline = this.ordered && this.orderType == null && headingType != null
+
+        Transforms.setNodes(
+          editor,
+          {
+            type: 'list-item',
+            ordered: this.ordered,
+            level: outline ? getHeadingLevel(headingType as HeadingType) : getListIndent(node),
+            start: undefined,
+            orderType: this.ordered ? this.orderType : undefined,
+            headingType: outline ? headingType : undefined,
+            listMode: outline ? 'outline' : undefined,
+            listRestart: undefined,
+          } as any,
+          { at: path }
+        )
+      })
+    })
   }
 }
 

--- a/packages/list-module/src/module/outline-actions.ts
+++ b/packages/list-module/src/module/outline-actions.ts
@@ -1,0 +1,127 @@
+/**
+ * @description outline numbering marker actions
+ */
+
+import { DomEditor, EditorEvents, IDomEditor, t } from '@wangeditor-next/core'
+import { Transforms } from 'slate'
+
+import { ListItemElement } from './custom-types'
+
+type OutlineActionPanel = {
+  elem: HTMLElement
+  dispose: () => void
+}
+
+const PANEL_BY_EDITOR = new WeakMap<IDomEditor, OutlineActionPanel>()
+
+function updateRestart(editor: IDomEditor, node: ListItemElement, restart?: number) {
+  const index = editor.children.indexOf(node)
+
+  if (index < 0) {
+    return
+  }
+
+  Transforms.setNodes(editor, { listRestart: restart }, { at: [index] })
+}
+
+export function continueOutlineNumbering(editor: IDomEditor, node: ListItemElement) {
+  updateRestart(editor, node)
+}
+
+export function restartOutlineNumbering(editor: IDomEditor, node: ListItemElement) {
+  updateRestart(editor, node, 1)
+}
+
+export function hideOutlineActionPanel(editor: IDomEditor) {
+  const panel = PANEL_BY_EDITOR.get(editor)
+
+  if (panel == null) {
+    return
+  }
+  panel.dispose()
+  PANEL_BY_EDITOR.delete(editor)
+}
+
+function createActionButton(
+  document: Document,
+  label: string,
+  onClick: () => void
+): HTMLButtonElement {
+  const button = document.createElement('button')
+
+  button.type = 'button'
+  button.className = 'w-e-list-outline-action'
+  button.textContent = label
+  button.addEventListener('mousedown', event => event.preventDefault())
+  button.addEventListener('click', event => {
+    event.preventDefault()
+    event.stopPropagation()
+    onClick()
+  })
+
+  return button
+}
+
+export function showOutlineActionPanel(editor: IDomEditor, node: ListItemElement, marker: HTMLElement) {
+  if (editor.isDisabled()) {
+    return
+  }
+
+  hideOutlineActionPanel(editor)
+
+  const document = marker.ownerDocument
+  const panel = document.createElement('div')
+
+  panel.className = 'w-e-list-outline-actions'
+  panel.setAttribute('role', 'menu')
+  panel.addEventListener('mousedown', event => event.preventDefault())
+  panel.append(
+    createActionButton(document, t('listModule.continueNumbering'), () => {
+      continueOutlineNumbering(editor, node)
+      hideOutlineActionPanel(editor)
+    }),
+    createActionButton(document, t('listModule.restartNumbering'), () => {
+      restartOutlineNumbering(editor, node)
+      hideOutlineActionPanel(editor)
+    })
+  )
+
+  const textarea = DomEditor.getTextarea(editor)
+  const container = textarea.$textAreaContainer[0] as HTMLElement
+  const scroll = textarea.$scroll[0] as HTMLElement
+  const markerRect = marker.getBoundingClientRect()
+  const containerRect = container.getBoundingClientRect()
+
+  panel.style.top = `${markerRect.bottom - containerRect.top + scroll.scrollTop + 4}px`
+  panel.style.left = `${markerRect.left - containerRect.left + scroll.scrollLeft}px`
+  container.append(panel)
+
+  const onDocumentMouseDown = (event: MouseEvent) => {
+    const target = event.target
+
+    if (!(target instanceof Node)) {
+      return
+    }
+    if (panel.contains(target) || marker.contains(target)) {
+      return
+    }
+
+    hideOutlineActionPanel(editor)
+  }
+  const onEditorChange = () => hideOutlineActionPanel(editor)
+  const onEditorDestroyed = () => hideOutlineActionPanel(editor)
+
+  document.addEventListener('mousedown', onDocumentMouseDown, true)
+  editor.on(EditorEvents.CHANGE, onEditorChange)
+  editor.on(EditorEvents.DESTROYED, onEditorDestroyed)
+
+  PANEL_BY_EDITOR.set(editor, {
+    elem: panel,
+    dispose: () => {
+      document.removeEventListener('mousedown', onDocumentMouseDown, true)
+      editor.off(EditorEvents.CHANGE, onEditorChange)
+      editor.off(EditorEvents.DESTROYED, onEditorDestroyed)
+      panel.remove()
+    },
+  })
+}

--- a/packages/list-module/src/module/parse-elem-html.ts
+++ b/packages/list-module/src/module/parse-elem-html.ts
@@ -1,184 +1,223 @@
 /**
- * @description parse elem html
- * @author wangfupeng
+ * @description parse list HTML
  */
 
-import { DomEditor, IDomEditor } from '@wangeditor-next/core'
+import { IDomEditor } from '@wangeditor-next/core'
 import { Dom7Array } from 'dom7'
 import { Descendant, Element as SlateElement, Text } from 'slate'
 
 import $, { DOMElement, getTagName } from '../utils/dom'
-import { ListItemElement, OrderedListType } from './custom-types'
+import { HeadingType, ListItemElement, OrderedListType } from './custom-types'
+import { isHeadingType, isListNode } from './helpers'
 
-/**
- * 获取 ordered
- * @param $elem list $elem
- */
 function getOrdered($elem: Dom7Array): boolean {
-  const $list = $elem.parent()
-  const listTagName = getTagName($list)
-
-  if (listTagName === 'ol') { return true }
-  return false
+  return getTagName($elem.parent()) === 'ol'
 }
 
 function getOrderedStart($elem: Dom7Array): number | undefined {
   const $list = $elem.parent()
 
-  if (getTagName($list) !== 'ol') { return undefined }
-  const startStr = ($list.attr('start') || '').trim()
+  if (getTagName($list) !== 'ol') {
+    return undefined
+  }
 
-  if (startStr === '') { return undefined }
-  const start = Number.parseInt(startStr, 10)
+  const value = ($list.attr('start') || '').trim()
+  const start = Number.parseInt(value, 10)
 
-  if (Number.isNaN(start)) { return undefined }
-  return start
+  return Number.isNaN(start) ? undefined : start
 }
 
 function getOrderedType($elem: Dom7Array): OrderedListType | undefined {
   const $list = $elem.parent()
 
-  if (getTagName($list) !== 'ol') { return undefined }
+  if (getTagName($list) !== 'ol') {
+    return undefined
+  }
+
   const orderType = ($list.attr('type') || '').trim()
 
-  if (orderType === '1'
-    || orderType === 'a'
-    || orderType === 'A'
-    || orderType === 'i'
-    || orderType === 'I') {
+  if (orderType === '1' || orderType === 'a' || orderType === 'A' || orderType === 'i' || orderType === 'I') {
     return orderType
   }
 
   return undefined
 }
 
-/**
- * 获取 level
- * @param $elem list $elem
- */
 function getLevel($elem: Dom7Array): number {
-  let listAncestorCount = 0
-  let $cur: Dom7Array = $elem.parent()
+  const indent = ($elem.attr('data-w-e-list-indent') || '').trim()
 
-  while ($cur.length > 0) {
-    const tagName = getTagName($cur)
+  if (/^\d+$/.test(indent)) {
+    return Number.parseInt(indent, 10)
+  }
+
+  let listAncestorCount = 0
+  let $current: Dom7Array = $elem.parent()
+
+  while ($current.length > 0) {
+    const tagName = getTagName($current)
 
     if (tagName === 'ul' || tagName === 'ol') {
       listAncestorCount += 1
     }
-    $cur = $cur.parent()
+    $current = $current.parent()
   }
 
   return Math.max(0, listAncestorCount - 1)
+}
+
+function getListMode($elem: Dom7Array, children: Descendant[]): 'standard' | 'outline' {
+  const declaredMode = $elem.parent().attr('data-w-e-list-mode')
+
+  if (declaredMode === 'outline' || declaredMode === 'standard') {
+    return declaredMode
+  }
+
+  return getOrdered($elem) && children.some(child => {
+    return SlateElement.isElement(child) && isHeadingType(child.type)
+  })
+    ? 'outline'
+    : 'standard'
+}
+
+function getRestart($elem: Dom7Array): number | undefined {
+  const value = ($elem.attr('data-w-e-list-restart') || '').trim()
+
+  if (!/^\d+$/.test(value)) {
+    return undefined
+  }
+
+  const restart = Number.parseInt(value, 10)
+
+  return restart > 0 ? restart : undefined
+}
+
+function isFirstListItem($elem: Dom7Array): boolean {
+  let previous = $elem[0]?.previousElementSibling
+
+  while (previous != null) {
+    if (previous.tagName.toLowerCase() === 'li') {
+      return false
+    }
+    previous = previous.previousElementSibling
+  }
+
+  return true
+}
+
+function getOutlineRestart($elem: Dom7Array): number | undefined {
+  const restart = getRestart($elem)
+
+  if (restart !== undefined) {
+    return restart
+  }
+  if ($elem.attr('data-w-e-outline-number') != null || !isFirstListItem($elem)) {
+    return undefined
+  }
+
+  return getOrderedStart($elem)
 }
 
 function isStructuralWhitespaceText(child: Descendant): boolean {
   return Text.isText(child) && child.text.trim() === ''
 }
 
-function appendTextLikeChildren(
-  target: Descendant[],
-  children: Descendant[],
-  editor: IDomEditor,
-) {
+function appendTextLikeChildren(target: Descendant[], children: Descendant[], editor: IDomEditor) {
   children.forEach(child => {
     if (isStructuralWhitespaceText(child)) {
       return
     }
-
-    if (Text.isText(child)) {
+    if (Text.isText(child) || editor.isInline(child)) {
       target.push(child)
       return
     }
-
-    if (editor.isInline(child)) {
-      target.push(child)
-      return
-    }
-
     if (SlateElement.isElement(child)) {
       appendTextLikeChildren(target, child.children, editor)
     }
   })
 }
 
+function getHeadingNode(children: Descendant[]): SlateElement | null {
+  for (const child of children) {
+    if (SlateElement.isElement(child) && isHeadingType(child.type)) {
+      return child
+    }
+  }
+
+  return null
+}
+
 function parseItemHtml(
   elem: DOMElement,
   children: Descendant[],
-  editor: IDomEditor,
+  editor: IDomEditor
 ): ListItemElement | ListItemElement[] {
   const $elem = $(elem)
-  const normalizedChildren: Descendant[] = []
+  const level = getLevel($elem)
+  const directChildren: Descendant[] = []
   const nestedListChildren: ListItemElement[] = []
 
   children.forEach(child => {
     if (isStructuralWhitespaceText(child)) {
       return
     }
-
-    if (Text.isText(child)) {
-      normalizedChildren.push(child)
+    if (isListNode(child) && child.level > level) {
+      nestedListChildren.push(child)
       return
     }
-
-    if (editor.isInline(child)) {
-      normalizedChildren.push(child)
-      return
-    }
-
-    if (DomEditor.checkNodeType(child, 'list-item')) {
-      nestedListChildren.push(child as ListItemElement)
-      return
-    }
-
-    if (SlateElement.isElement(child)) {
-      appendTextLikeChildren(normalizedChildren, child.children, editor)
-    }
+    directChildren.push(child)
   })
 
-  // 无 children ，则用纯文本
+  const headingNode = getHeadingNode(directChildren)
+  const headingType = headingNode != null && isHeadingType(headingNode.type)
+    ? (headingNode.type as HeadingType)
+    : undefined
+  const listMode = getListMode($elem, directChildren)
+  const normalizedChildren: Descendant[] = []
+
+  appendTextLikeChildren(normalizedChildren, directChildren, editor)
+
   if (normalizedChildren.length === 0) {
-    if (nestedListChildren.length > 0) {
-      normalizedChildren.push({ text: '' })
-    } else {
-      normalizedChildren.push({ text: $elem.text().replace(/\s+/gm, ' ') })
-    }
+    normalizedChildren.push(
+      nestedListChildren.length > 0 ? { text: '' } : { text: $elem.text().replace(/\s+/gm, ' ') }
+    )
   }
 
   const ordered = getOrdered($elem)
-  const level = getLevel($elem)
   const start = getOrderedStart($elem)
   const orderType = getOrderedType($elem)
-
-  const currentItem: ListItemElement = {
+  const outline = ordered && listMode === 'outline' && headingType !== undefined
+  const listRestart = outline ? getOutlineRestart($elem) : undefined
+  const item: ListItemElement = {
     type: 'list-item',
     ordered,
-    level,
-    ...(start !== undefined ? { start } : {}),
+    level: outline ? Number.parseInt(headingType.slice('header'.length), 10) - 1 : level,
+    ...(start !== undefined && !outline ? { start } : {}),
     ...(orderType !== undefined ? { orderType } : {}),
-    // @ts-ignore
+    ...(headingType !== undefined ? { headingType } : {}),
+    ...(outline ? { listMode: 'outline' as const } : {}),
+    ...(listRestart !== undefined ? { listRestart } : {}),
+    // @ts-ignore List items retain the established text/inline children shape.
     children: normalizedChildren,
   }
 
-  if (nestedListChildren.length === 0) { return currentItem }
-  return [currentItem, ...nestedListChildren]
+  return nestedListChildren.length === 0 ? item : [item, ...nestedListChildren]
 }
 
 export const parseItemHtmlConf = {
-  selector: 'li:not([data-w-e-type])', // data-w-e-type 属性，留给自定义元素，保证扩展性
+  selector: 'li:not([data-w-e-type])',
   parseElemHtml: parseItemHtml,
 }
 
 function parseListHtml(
   _elem: DOMElement,
   children: Descendant[],
-  _editor: IDomEditor,
+  _editor: IDomEditor
 ): ListItemElement[] {
-  // @ts-ignore flatten 因为可能有 ul/ol 嵌套，重要！！！
+  // @ts-ignore Nested lists return arrays which must be flattened.
   return children.flat(Infinity)
 }
 
 export const parseListHtmlConf = {
-  selector: 'ul:not([data-w-e-type]),ol:not([data-w-e-type])', // data-w-e-type 属性，留给自定义元素，保证扩展性
+  selector: 'ul:not([data-w-e-type]),ol:not([data-w-e-type])',
   parseElemHtml: parseListHtml,
 }

--- a/packages/list-module/src/module/plugin.ts
+++ b/packages/list-module/src/module/plugin.ts
@@ -1,122 +1,127 @@
 /**
- * @description editor 插件，重写 editor API
+ * @description list editor plugin
  * @author wangfupeng
  */
 
 import { DomEditor, IDomEditor } from '@wangeditor-next/core'
-import {
-  Editor, Range, Transforms,
-} from 'slate'
+import { Editor, Element, Node, Path, Range, Transforms } from 'slate'
 
 import { ListItemElement } from './custom-types'
-import { getBrotherListNodeByLevel } from './helpers'
+import {
+  getBrotherListNodeByLevel,
+  getHeadingType,
+  getListIndent,
+  isListNode,
+  isOutlineListNode,
+} from './helpers'
 
-/**
- * 获取选中的 top elems
- * @param editor editor
- */
-function getTopSelectedElemsBySelection(editor: IDomEditor) {
-  return Editor.nodes(editor, {
+function getTopSelectedElemsBySelection(editor: IDomEditor): Array<[Element, Path]> {
+  const entries = Array.from(
+    Editor.nodes(editor, {
+      at: editor.selection || undefined,
+      match: node => Element.isElement(node) && Editor.isBlock(editor, node),
+      mode: 'highest',
+    })
+  ) as Array<[Element, Path]>
+
+  return entries.filter(([, path]) => path.length === 1)
+}
+
+function getSelectedListEntry(editor: IDomEditor): [ListItemElement, Path] | null {
+  const [entry] = Editor.nodes(editor, {
     at: editor.selection || undefined,
-    match: n => DomEditor.findPath(editor, n).length === 1, // 只匹配顶级元素
+    match: isListNode,
+    universal: true,
   })
+
+  return entry == null ? null : (entry as [ListItemElement, Path])
+}
+
+function clearListItem(editor: IDomEditor, path: Path, node: ListItemElement, type?: string) {
+  Transforms.setNodes(
+    editor,
+    {
+      type: type || getHeadingType(node) || 'paragraph',
+      ordered: undefined,
+      level: undefined,
+      start: undefined,
+      orderType: undefined,
+      headingType: undefined,
+      listMode: undefined,
+      listRestart: undefined,
+    } as any,
+    { at: path }
+  )
 }
 
 function withList<T extends IDomEditor>(editor: T): T {
-  const {
-    deleteBackward, handleTab, normalizeNode, insertBreak,
-  } = editor
+  const { deleteBackward, handleTab, normalizeNode, insertBreak } = editor
   const newEditor = editor
 
-  // 重写 insertBreak - 空 list 点击回车时删除该空 list
   newEditor.insertBreak = () => {
-    const [nodeEntry] = Editor.nodes(editor, {
-      match: n => DomEditor.checkNodeType(n, 'list-item'),
-      universal: true,
-    })
+    const entry = getSelectedListEntry(newEditor)
 
-    if (!nodeEntry) { return insertBreak() }
-    const listElem = nodeEntry[0] as ListItemElement
+    if (entry == null) {
+      return insertBreak()
+    }
 
-    if (listElem.children[0].text === '') {
-      Transforms.setNodes(newEditor, {
-        type: 'paragraph',
-        // @ts-ignore
-        ordered: undefined,
-        level: undefined,
-        start: undefined,
-        orderType: undefined,
-      })
+    const [listItem, path] = entry
+
+    if (Node.string(listItem) === '') {
+      clearListItem(newEditor, path, listItem, 'paragraph')
       return
     }
+
     return insertBreak()
   }
 
-  // 重写 deleteBackward - 降低 level 或者转换为 p 元素
   newEditor.deleteBackward = unit => {
     const { selection } = newEditor
 
-    if (selection == null) {
+    if (selection == null || Range.isExpanded(selection)) {
       deleteBackward(unit)
       return
     }
 
-    if (Range.isExpanded(selection)) {
+    const entry = getSelectedListEntry(newEditor)
+
+    if (entry == null || selection.focus.offset !== 0) {
       deleteBackward(unit)
       return
     }
 
-    const listItemElem = DomEditor.getSelectedNodeByType(newEditor, 'list-item')
+    const [listItem, path] = entry
 
-    if (listItemElem == null) {
-      // 未匹配到 list-item
-      deleteBackward(unit)
+    if (isOutlineListNode(listItem)) {
+      clearListItem(newEditor, path, listItem)
       return
     }
 
-    if (selection.focus.offset === 0) {
-      // 选中了当前 list-item 文本的开头，此时按删除键，应该降低 level 或转换为 p 元素
-      const { level = 0 } = listItemElem as ListItemElement
+    const level = getListIndent(listItem)
 
-      if (level > 0) {
-        // 如果有兄弟节点，则对齐兄弟节点的列表配置
-        const brotherElem = getBrotherListNodeByLevel(
-          editor,
-          listItemElem as ListItemElement,
-          level - 1,
-        )
-
-        if (brotherElem) {
-          const nextOrdered = brotherElem.ordered
-
-          Transforms.setNodes(newEditor, {
-            level: level - 1,
-            ordered: nextOrdered,
-            start: nextOrdered ? brotherElem.start : undefined,
-            orderType: nextOrdered ? brotherElem.orderType : undefined,
-          })
-        } else {
-          Transforms.setNodes(newEditor, { level: level - 1 })
-        }
-      } else {
-        // 转换为 p 元素
-        Transforms.setNodes(newEditor, {
-          type: 'paragraph',
-          // @ts-ignore
-          ordered: undefined,
-          level: undefined,
-          start: undefined,
-          orderType: undefined,
-        })
-      }
+    if (level <= 0) {
+      clearListItem(newEditor, path, listItem)
       return
     }
 
-    // 其他情况
-    deleteBackward(unit)
+    const brother = getBrotherListNodeByLevel(editor, listItem, level - 1)
+
+    if (brother != null) {
+      Transforms.setNodes(
+        newEditor,
+        {
+          level: level - 1,
+          ordered: brother.ordered,
+          start: brother.ordered ? brother.start : undefined,
+          orderType: brother.ordered ? brother.orderType : undefined,
+        },
+        { at: path }
+      )
+    } else {
+      Transforms.setNodes(newEditor, { level: level - 1 }, { at: path })
+    }
   }
 
-  // 重写 tab - 当选中 list-item 文本开头时，增加 level
   newEditor.handleTab = () => {
     const { selection } = newEditor
 
@@ -125,58 +130,35 @@ function withList<T extends IDomEditor>(editor: T): T {
       return
     }
 
-    // 选区是合并的，判断单个 list-item 即可
     if (Range.isCollapsed(selection)) {
-      const listItemElem = DomEditor.getSelectedNodeByType(newEditor, 'list-item')
+      const entry = getSelectedListEntry(newEditor)
 
-      if (listItemElem == null) {
-        // 未匹配到 list-item
+      if (entry == null || isOutlineListNode(entry[0]) || selection.focus.offset !== 0) {
         handleTab()
         return
       }
 
-      if (selection.focus.offset === 0) {
-        // 选中了当前 list-item 文本的开头，此时按 tab 应该增加 level
-        const { level = 0 } = listItemElem as ListItemElement
+      const [listItem, path] = entry
 
-        Transforms.setNodes(newEditor, { level: level + 1 })
-        return
-      }
-    }
-
-    // 选区是展开的，要判断多个 list-item
-    if (Range.isExpanded(selection)) {
-      let listItemNum = 0 // 选中的 list-item 有几个
-      let hasOtherElem = false // 是否有其他元素
-
-      for (const entry of getTopSelectedElemsBySelection(newEditor)) {
-        const [elem] = entry
-        const type = DomEditor.getNodeType(elem)
-
-        if (type === 'list-item') { listItemNum += 1 } else { hasOtherElem = true }
-      }
-
-      if (hasOtherElem || listItemNum <= 1) {
-        // 选中了其他元素，或者只选中一个 list-item ，则执行默认行为
-        handleTab()
-        return
-      }
-
-      // 未选中其他元素，且选中多个 list-item ，则增加 level
-      for (const entry of getTopSelectedElemsBySelection(newEditor)) {
-        const [elem, path] = entry
-        const { level = 0 } = elem as ListItemElement
-
-        Transforms.setNodes(newEditor, { level: level + 1 }, { at: path })
-      }
+      Transforms.setNodes(newEditor, { level: getListIndent(listItem) + 1 }, { at: path })
       return
     }
 
-    // 其他情况
-    handleTab()
+    const selectedEntries = getTopSelectedElemsBySelection(newEditor)
+    const listEntries = selectedEntries.filter(([node]) => {
+      return isListNode(node) && !isOutlineListNode(node)
+    })
+
+    if (listEntries.length !== selectedEntries.length || listEntries.length <= 1) {
+      handleTab()
+      return
+    }
+
+    listEntries.forEach(([node, path]) => {
+      Transforms.setNodes(newEditor, { level: getListIndent(node) + 1 }, { at: path })
+    })
   }
 
-  // 兼容之前的 JSON 格式 `numbered-list` 和 `bulleted-list` （之前的 list 没有嵌套功能）
   newEditor.normalizeNode = ([node, path]) => {
     const type = DomEditor.getNodeType(node)
 
@@ -184,7 +166,6 @@ function withList<T extends IDomEditor>(editor: T): T {
       Transforms.unwrapNodes(newEditor, { at: path })
     }
 
-    // 执行默认行为
     return normalizeNode([node, path])
   }
 

--- a/packages/list-module/src/module/render-elem.tsx
+++ b/packages/list-module/src/module/render-elem.tsx
@@ -3,10 +3,8 @@
  * @author wangfupeng
  */
 
-import { DomEditor, IDomEditor } from '@wangeditor-next/core'
-import {
-  Editor, Element as SlateElement, Path,
-} from 'slate'
+import { IDomEditor, t } from '@wangeditor-next/core'
+import { Element as SlateElement } from 'slate'
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { jsx, VNode } from 'snabbdom'
 
@@ -14,53 +12,49 @@ import { ELEM_TO_EDITOR } from '../utils/maps'
 import { getListItemColor } from '../utils/util'
 import { ListItemElement } from './custom-types'
 import {
-  getNormalizedOrderedListStart,
+  getHeadingType,
+  getListIndent,
   getNormalizedOrderedListType,
-  hasSameListConfig,
+  getOrderedItemNumber,
+  getOutlineNumber,
+  isOutlineListNode,
 } from './helpers'
+import { showOutlineActionPanel } from './outline-actions'
 
-/**
- * 无序列表：根据 level 获取的前置符号
- * @param level 层级
- */
 function genPreSymbol(level = 0): string {
-  let s = ''
-
   switch (level) {
     case 0:
-      s = '•' // 第一层级
-      break
+      return '•'
     case 1:
-      s = '◦' // 第一层级
-      break
-    case 2:
-      s = '▪' // 第三层级
-      break
+      return '◦'
     default:
-      s = '▪' // 其他层级
+      return '▪'
   }
-  return s
 }
 
-function genAlphabetIndex(num: number, upper = false): string {
-  if (num <= 0) { return String(num) }
+function genAlphabetIndex(number: number, upper = false): string {
+  if (number <= 0) {
+    return String(number)
+  }
 
-  let n = num
+  let current = number
   let result = ''
 
-  while (n > 0) {
-    const rem = (n - 1) % 26
-    const charCode = (upper ? 65 : 97) + rem
+  while (current > 0) {
+    const remainder = (current - 1) % 26
+    const charCode = (upper ? 65 : 97) + remainder
 
     result = String.fromCharCode(charCode) + result
-    n = Math.floor((n - 1) / 26)
+    current = Math.floor((current - 1) / 26)
   }
 
   return result
 }
 
-function genRomanIndex(num: number, upper = false): string {
-  if (num <= 0 || num >= 4000) { return String(num) }
+function genRomanIndex(number: number, upper = false): string {
+  if (number <= 0 || number >= 4000) {
+    return String(number)
+  }
 
   const romanMap: Array<[number, string]> = [
     [1000, 'M'],
@@ -77,129 +71,99 @@ function genRomanIndex(num: number, upper = false): string {
     [4, 'IV'],
     [1, 'I'],
   ]
-
-  let n = num
+  let current = number
   let result = ''
 
   for (const [value, roman] of romanMap) {
-    while (n >= value) {
+    while (current >= value) {
       result += roman
-      n -= value
+      current -= value
     }
   }
 
   return upper ? result : result.toLowerCase()
 }
 
-function genOrderedPrefix(num: number, orderType: string): string {
+function genOrderedPrefix(number: number, orderType: string): string {
   switch (orderType) {
     case 'a':
-      return `${genAlphabetIndex(num)}.`
+      return `${genAlphabetIndex(number)}.`
     case 'A':
-      return `${genAlphabetIndex(num, true)}.`
+      return `${genAlphabetIndex(number, true)}.`
     case 'i':
-      return `${genRomanIndex(num)}.`
+      return `${genRomanIndex(number)}.`
     case 'I':
-      return `${genRomanIndex(num, true)}.`
+      return `${genRomanIndex(number, true)}.`
     default:
-      return `${num}.`
+      return `${number}.`
   }
-}
-
-/**
- * 有序列表：获取前缀 number
- * @param editor editor
- * @param elem listItem elem
- */
-function getOrderedItemNumber(editor: IDomEditor, elem: SlateElement): number {
-  const listItemElem = elem as ListItemElement
-  const { type, level = 0, ordered = false } = listItemElem
-
-  let num = getNormalizedOrderedListStart(listItemElem)
-  let curElem = elem
-  let curPath = DomEditor.findPath(editor, curElem)
-
-  // 第一个元素，直接返回起始值
-  if (curPath[0] === 0) { return num }
-
-  while (curPath[0] > 0) {
-    const prevPath = Path.previous(curPath)
-    const prevEntry = Editor.node(editor, prevPath)
-
-    if (prevEntry == null) { break }
-    const prevElem = prevEntry[0] as ListItemElement // 上一个节点
-    const { level: prevLevel = 0, type: prevType, ordered: prevOrdered } = prevElem
-
-    // type 不一致，退出循环，不再累加 num
-    if (prevType !== type) { break }
-    // prevLevel 更小，退出循环，不再累加 num
-    if (prevLevel < level) { break }
-
-    if (prevLevel === level) {
-      // level 一样，如果 list 配置不一致，则退出循环，不再累加 num
-      if (prevOrdered !== ordered || !hasSameListConfig(prevElem, listItemElem)) { break }
-      // level 一样，order 配置一致，则累加 num
-      num += 1
-    }
-
-    // prevLevel 更大，不累加 num ，继续向前
-    curElem = prevElem
-    curPath = prevPath
-  }
-
-  return num
 }
 
 function renderListElem(
   elemNode: SlateElement,
   children: VNode[] | null,
-  editor: IDomEditor,
+  editor: IDomEditor
 ): VNode {
-  ELEM_TO_EDITOR.set(elemNode, editor) // 记录 elem 和 editor 关系，elem-to-html 时要用
+  ELEM_TO_EDITOR.set(elemNode, editor)
 
-  const { level = 0, ordered = false } = elemNode as ListItemElement
-
-  // 根据 level 增加 margin-left
+  const listItem = elemNode as ListItemElement
+  const outline = isOutlineListNode(listItem)
+  const level = getListIndent(listItem)
   const listStyle = {
     margin: `5px 0 5px ${level * 20}px`,
     display: 'flex',
-    alignItems: 'flex-start',
+    alignItems: 'baseline',
   }
-
-  // list-item 前缀
+  const prefixColor = getListItemColor(listItem)
   let prefix = ''
 
-  if (ordered) {
-    // 有序列表：获取前缀 number
-    const orderedNumber = getOrderedItemNumber(editor, elemNode)
-    const orderType = getNormalizedOrderedListType(elemNode as ListItemElement)
-
-    prefix = genOrderedPrefix(orderedNumber, orderType)
+  if (outline) {
+    prefix = getOutlineNumber(editor, listItem)
+  } else if (listItem.ordered) {
+    prefix = genOrderedPrefix(getOrderedItemNumber(editor, listItem), getNormalizedOrderedListType(listItem))
   } else {
-    // 无序列表：根据层级，使用不同的前缀符号
     prefix = genPreSymbol(level)
   }
 
-  // 获取前缀颜色
-  const prefixColor = getListItemColor(elemNode)
+  const markerStyle = { marginRight: '0.5em', color: prefixColor }
+  const marker = outline ? (
+    <button
+      type="button"
+      className="w-e-list-marker"
+      contentEditable={false}
+      data-w-e-reserve
+      aria-label={t('listModule.numberingActions')}
+      title={t('listModule.numberingActions')}
+      style={markerStyle}
+      on={{
+        mousedown: event => event.preventDefault(),
+        click: event => {
+          event.preventDefault()
+          event.stopPropagation()
 
-  const vnode = (
-    <div style={listStyle}>
-      <span
-        contentEditable={false}
-        style={{ marginRight: '0.5em', color: prefixColor }}
-        data-w-e-reserve
-      >
-        {prefix}
-      </span>
-      <span style={{
-        flex: '1',
-        wordBreak: 'break-word',
-      }}>{children}</span>
-    </div>
+          if (event.currentTarget instanceof HTMLElement) {
+            showOutlineActionPanel(editor, listItem, event.currentTarget)
+          }
+        },
+      }}
+    >
+      {prefix}
+    </button>
+  ) : (
+    <span className="w-e-list-marker" contentEditable={false} style={markerStyle} data-w-e-reserve>
+      {prefix}
+    </span>
   )
 
-  return vnode
+  const headingType = getHeadingType(listItem)
+  const ContentTag = headingType == null ? 'span' : headingType.replace('header', 'h')
+
+  return (
+    <div className="w-e-list-item" style={listStyle}>
+      {marker}
+      <ContentTag style={{ flex: '1', minWidth: '0', wordBreak: 'break-word' }}>{children}</ContentTag>
+    </div>
+  )
 }
 
 const renderListItemConf = {

--- a/packages/plugin-attachment/package.json
+++ b/packages/plugin-attachment/package.json
@@ -41,7 +41,7 @@
     "url": "https://github.com/wangeditor-next/wangEditor-next/issues"
   },
   "peerDependencies": {
-    "@wangeditor-next/editor": "6.0.2",
+    "@wangeditor-next/editor": ">=6.0.2 <7",
     "dom7": "^3.0.0 || ^4.0.0",
     "snabbdom": "^3.6.0"
   },

--- a/packages/plugin-ctrl-enter/package.json
+++ b/packages/plugin-ctrl-enter/package.json
@@ -41,7 +41,7 @@
     "url": "https://github.com/wangeditor-next/wangEditor-next/issues"
   },
   "peerDependencies": {
-    "@wangeditor-next/editor": "6.0.2"
+    "@wangeditor-next/editor": ">=6.0.2 <7"
   },
   "devDependencies": {
     "@wangeditor-next-shared/rollup-config": "workspace:^"

--- a/packages/upload-image-module/package.json
+++ b/packages/upload-image-module/package.json
@@ -46,7 +46,7 @@
   "peerDependencies": {
     "@uppy/core": "^2.0.3 || ^5.0.0",
     "@uppy/xhr-upload": "^2.0.3 || ^5.0.0",
-    "@wangeditor-next/basic-modules": "3.1.0",
+    "@wangeditor-next/basic-modules": ">=3.1.0 <4",
     "@wangeditor-next/core": ">=1.9.6",
     "dom7": "^3.0.0 || ^4.0.0",
     "lodash.foreach": "^4.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -669,7 +669,7 @@ importers:
   packages/plugin-attachment:
     dependencies:
       '@wangeditor-next/editor':
-        specifier: 6.0.2
+        specifier: '>=6.0.2 <7'
         version: link:../editor
       dom7:
         specifier: ^3.0.0 || ^4.0.0
@@ -685,7 +685,7 @@ importers:
   packages/plugin-ctrl-enter:
     dependencies:
       '@wangeditor-next/editor':
-        specifier: 6.0.2
+        specifier: '>=6.0.2 <7'
         version: link:../editor
     devDependencies:
       '@wangeditor-next-shared/rollup-config':
@@ -821,7 +821,7 @@ importers:
         specifier: ^2.0.3 || ^5.0.0
         version: 2.1.3(@uppy/core@2.3.4)
       '@wangeditor-next/basic-modules':
-        specifier: 3.1.0
+        specifier: '>=3.1.0 <4'
         version: link:../basic-modules
       '@wangeditor-next/core':
         specifier: '>=1.9.6'

--- a/tests/e2e/editor.smoke.spec.ts
+++ b/tests/e2e/editor.smoke.spec.ts
@@ -277,7 +277,36 @@ test.describe('Cross Browser Smoke', () => {
     await getToolbarMenu(page, 'bulletedList').click()
 
     await expect(page.getByTestId('editor-html')).toContainText('<ul>')
-    await expect(page.getByTestId('editor-html')).toContainText('<li>list item</li>')
+    await expect(page.getByTestId('editor-html')).toContainText('<ul><li>list item</li></ul>')
+  })
+
+  test('regression #912: renders and exports semantic heading outlines', async ({ page }) => {
+    await setEditorHtml(
+      page,
+      [
+        '<ol data-w-e-list-mode="outline">',
+        '<li data-w-e-list-indent="0"><h1>Overview</h1>',
+        '<ol data-w-e-list-mode="outline">',
+        '<li data-w-e-list-indent="1"><h2>Scope</h2>',
+        '<ol data-w-e-list-mode="outline"><li data-w-e-list-indent="2"><h3>Details</h3></li></ol>',
+        '</li></ol></li></ol><p>Following paragraph</p>',
+      ].join('')
+    )
+
+    const markers = page.locator('[data-testid="editor-textarea"] .w-e-list-marker')
+
+    await expect(markers).toHaveText(['1.', '1.1', '1.1.1'])
+    await expect(page.locator('[data-testid="editor-textarea"] h2')).toHaveText('Scope')
+
+    const exportedHtml = await page.evaluate(() => {
+      return (window as any).wangEditorExampleBridge?.editor?.getHtml() || ''
+    })
+
+    expect(exportedHtml).toContain('<ol data-w-e-list-mode="outline">')
+    expect(exportedHtml).toContain(
+      '<li data-w-e-list-indent="2" data-w-e-outline-number="1.1.1"><h3>Details</h3>'
+    )
+    expect(exportedHtml).toContain('</ol><p>Following paragraph</p>')
   })
 
   test('inserts a table', async ({ page }) => {

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -982,7 +982,7 @@ test.describe('Basic Editor', () => {
     await getToolbarMenu(page, 'bulletedList').click()
 
     await expect(page.getByTestId('editor-html')).toContainText('<ul>')
-    await expect(page.getByTestId('editor-html')).toContainText('<li>list item</li>')
+    await expect(page.getByTestId('editor-html')).toContainText('<ul><li>list item</li></ul>')
   })
 
   test('creates a numbered list item', async ({ page }) => {
@@ -991,8 +991,104 @@ test.describe('Basic Editor', () => {
     await waitForMenuEnabled(page, 'numberedList')
     await getToolbarMenu(page, 'numberedList').click()
 
-    await expect(page.getByTestId('editor-html')).toContainText('<ol>')
-    await expect(page.getByTestId('editor-html')).toContainText('<li>numbered item</li>')
+    await expect(page.getByTestId('editor-html')).toContainText('<ol><li>numbered item</li></ol>')
+  })
+
+  test('regression #912: headings keep semantic outline numbering and marker actions', async ({
+    page,
+  }) => {
+    const pageErrors: string[] = []
+
+    page.on('pageerror', err => {
+      pageErrors.push(err?.stack || err?.message || String(err))
+    })
+
+    const semanticOutlineHtml = [
+      '<ol data-w-e-list-mode="outline">',
+      '<li data-w-e-list-indent="0"><h1>Overview</h1>',
+      '<ol data-w-e-list-mode="outline">',
+      '<li data-w-e-list-indent="1"><h2>Scope</h2>',
+      '<ol data-w-e-list-mode="outline"><li data-w-e-list-indent="2"><h3>Details</h3></li></ol>',
+      '</li><li data-w-e-list-indent="1"><h2>Delivery</h2></li>',
+      '</ol></li><li data-w-e-list-indent="0"><h1>Appendix</h1></li>',
+      '</ol>',
+    ].join('')
+
+    await page.evaluate(html => {
+      const editor = (window as any).wangEditorExampleBridge?.editor
+
+      if (!editor) {
+        throw new Error('editor missing')
+      }
+
+      editor.setHtml(html)
+      editor.focus()
+      editor.select({
+        anchor: { path: [2, 0], offset: 0 },
+        focus: { path: [2, 0], offset: 0 },
+      })
+    }, semanticOutlineHtml)
+
+    const markers = page.locator('[data-testid="editor-textarea"] .w-e-list-marker')
+
+    await expect(markers).toHaveText(['1.', '1.1', '1.1.1', '1.2', '2.'])
+    await expect(getToolbarMenu(page, 'numberedList')).toHaveClass(/active/)
+    await expect(getToolbarMenu(page, 'headerSelect')).toContainText('H3')
+
+    const markerAlignment = await page
+      .locator('[data-testid="editor-textarea"] .w-e-list-item')
+      .evaluateAll(items =>
+        items.slice(0, 5).map(item => {
+          const marker = item.querySelector('.w-e-list-marker')
+          const heading = item.querySelector('h1, h2, h3')
+
+          if (marker == null || heading == null) {
+            return false
+          }
+
+          const markerRect = marker.getBoundingClientRect()
+          const headingRect = heading.getBoundingClientRect()
+          const markerCenter = markerRect.top + markerRect.height / 2
+
+          return markerCenter >= headingRect.top && markerCenter <= headingRect.bottom
+        })
+      )
+
+    expect(markerAlignment).toEqual([true, true, true, true, true])
+
+    await markers.nth(4).click()
+
+    const actionPanel = page.locator('[data-testid="editor-textarea"] .w-e-list-outline-actions')
+
+    await expect(actionPanel).toBeVisible()
+    await expect(actionPanel.locator('button')).toHaveCount(2)
+    await actionPanel.locator('button').nth(1).click()
+
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const editor = (window as any).wangEditorExampleBridge?.editor
+
+          return editor?.children?.[4]?.listRestart
+        })
+      )
+      .toBe(1)
+    await expect(markers).toHaveText(['1.', '1.1', '1.1.1', '1.2', '1.'])
+
+    const exportedHtml = await page.evaluate(() => {
+      return (window as any).wangEditorExampleBridge?.editor?.getHtml() || ''
+    })
+
+    expect(exportedHtml).toContain('<ol data-w-e-list-mode="outline">')
+    expect(exportedHtml).toContain(
+      '<li data-w-e-list-indent="0" data-w-e-outline-number="1."><h1>Overview</h1>'
+    )
+    expect(exportedHtml).toContain(
+      '<li data-w-e-list-indent="2" data-w-e-outline-number="1.1.1"><h3>Details</h3>'
+    )
+    expect(exportedHtml).toContain('data-w-e-list-restart="1"')
+    expect(exportedHtml).not.toContain('>1.1 Scope<')
+    expect(pageErrors).toEqual([])
   })
 
   test('regression #543: nested list should stay inside parent li after round-trip', async ({ page }) => {


### PR DESCRIPTION
## Changes Overview

Implements #912: headings can be combined with the default numbered-list menu to form semantic outline numbering. The editor renders derived markers such as 1., 1.1, and 1.1.1 without writing numbers into heading text. Marker actions support continuing and restarting an outline.

## Implementation Approach

- Keep the persisted list-item shape and add only optional headingType, listMode, and listRestart metadata.
- Export semantic ol > li > hN structure and parse it back without losing existing list data.
- Add a module-level HTML composition hook so neighboring outline items can form valid nested lists while ordinary list serialization is unchanged.
- Use bounded internal peer ranges and Changesets out-of-range handling so this feature remains a minor release rather than forcing editor v7.

## Testing Done

- pnpm build
- pnpm lint
- pnpm typecheck
- pnpm check:compatibility
- pnpm check:published-types
- pnpm --filter @wangeditor-next/core test
- pnpm --filter @wangeditor-next/basic-modules test
- pnpm --filter @wangeditor-next/list-module test
- pnpm e2e:matrix

## Verification Steps

1. Create an H1, H2, and H3, then apply the default numbered-list menu to each.
2. Confirm toolbar state, visible markers, and semantic exported HTML use headings and nested ordered lists.
3. Click an outline marker and verify continue and restart actions.
4. Verify setHtml(getHtml()) and getHtmlWithId() retain the outline structure.

## Additional Notes

- Release plan: core 1.10.0, basic-modules 3.2.0, list-module 3.1.0, and editor 6.1.0. Changeset status reports no major package bump.
- Risk: HTML output changes only for list items explicitly marked as outlines; ordinary lists and historical list-item JSON retain their existing behavior.
- Rollback: revert commit 4a7493d2 before release. After release, publish a patch that removes the optional outline metadata and transform registration; no content migration is required.

## Checklist
- [x] I have created a changeset for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

Closes #912

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added semantic heading outline numbering for ordered lists, including nested levels, continuation, and restart actions.
  * Preserved outline structure when importing and exporting HTML.
  * Added an outline numbering demo and improved list marker styling.
  * Added support for document-level HTML transformations during export.

* **Bug Fixes**
  * Corrected heading level-6 HTML parsing.
  * Improved list editing, indentation, and heading menu behavior.
  * Expanded compatibility across compatible package versions.

* **Documentation**
  * Documented outline list behavior and HTML transformation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->