### PR TITLE
fix(release): retry npm visibility and repair provenance

### DIFF
--- a/.github/scripts/__tests__/push-package-release-tags.test.js
+++ b/.github/scripts/__tests__/push-package-release-tags.test.js
@@ -52,7 +52,11 @@ exit 1
   try {
     const result = spawnSync(
       process.execPath,
-      [scriptPath, '[{"name":"@wangeditor-next/editor","version":"6.0.2"}]', '--dry-run'],
+      [
+        scriptPath,
+        JSON.stringify([{ name: '@wangeditor-next/editor', version: editorVersion }]),
+        '--dry-run',
+      ],
       {
         cwd: rootDir,
         encoding: 'utf8',

--- a/.github/scripts/__tests__/release-workflow-policy.test.js
+++ b/.github/scripts/__tests__/release-workflow-policy.test.js
@@ -55,3 +55,8 @@ test('repair trusts master runs and uses the protected automation token', () => 
 
   assert.match('chore(release): publish a new release version (#949)', pattern)
 })
+
+test('repair splits release run metadata with real tab characters', () => {
+  assert.match(repairWorkflow, /\.join\("\\t"\)/)
+  assert.doesNotMatch(repairWorkflow, /\.join\("\\\\t"\)/)
+})

--- a/.github/scripts/__tests__/verify-published-packages.test.js
+++ b/.github/scripts/__tests__/verify-published-packages.test.js
@@ -79,3 +79,97 @@ printf '"0.0.0"\\n'
     fs.rmSync(temporaryBin, { recursive: true, force: true })
   }
 })
+
+test('retries an npm registry lookup until the published version is visible', () => {
+  const temporaryBin = fs.mkdtempSync(path.join(os.tmpdir(), 'wangeditor-fake-npm-'))
+  const fakeNpm = path.join(temporaryBin, 'npm')
+  const callsPath = path.join(temporaryBin, 'calls')
+  const scriptPath = path.resolve(__dirname, '../verify-published-packages.js')
+  const rootDir = path.resolve(__dirname, '../../..')
+
+  fs.writeFileSync(
+    fakeNpm,
+    `#!/bin/sh
+calls=0
+if [ -f "$FAKE_NPM_CALLS_PATH" ]; then
+  calls=$(cat "$FAKE_NPM_CALLS_PATH")
+fi
+
+calls=$((calls + 1))
+printf '%s' "$calls" > "$FAKE_NPM_CALLS_PATH"
+
+if [ "$calls" -lt 2 ]; then
+  printf 'not visible yet\\n' >&2
+  exit 1
+fi
+
+printf '"%s"\\n' "$FAKE_NPM_VERSION"
+`
+  )
+  fs.chmodSync(fakeNpm, 0o755)
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [scriptPath, JSON.stringify([{ name: '@wangeditor-next/editor', version: editorVersion }])],
+      {
+        cwd: rootDir,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          FAKE_NPM_CALLS_PATH: callsPath,
+          FAKE_NPM_VERSION: editorVersion,
+          NPM_VERIFY_RETRY_DELAY_MS: '1',
+          NPM_VERIFY_TIMEOUT_MS: '1000',
+          PATH: `${temporaryBin}:${process.env.PATH}`,
+        },
+      }
+    )
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.equal(fs.readFileSync(callsPath, 'utf8'), '2')
+    assert.match(result.stdout, /verified=false\tattempt=1\tretrying=true/)
+    assert.match(result.stdout, new RegExp(`${editorVersion}\\tverified=true`))
+  } finally {
+    fs.rmSync(temporaryBin, { recursive: true, force: true })
+  }
+})
+
+test('fails after the configured npm registry propagation window', () => {
+  const temporaryBin = fs.mkdtempSync(path.join(os.tmpdir(), 'wangeditor-fake-npm-'))
+  const fakeNpm = path.join(temporaryBin, 'npm')
+  const scriptPath = path.resolve(__dirname, '../verify-published-packages.js')
+  const rootDir = path.resolve(__dirname, '../../..')
+
+  fs.writeFileSync(
+    fakeNpm,
+    `#!/bin/sh
+printf 'not visible yet\\n' >&2
+exit 1
+`
+  )
+  fs.chmodSync(fakeNpm, 0o755)
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [scriptPath, JSON.stringify([{ name: '@wangeditor-next/editor', version: editorVersion }])],
+      {
+        cwd: rootDir,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          NPM_VERIFY_RETRY_DELAY_MS: '1',
+          NPM_VERIFY_TIMEOUT_MS: '40',
+          PATH: `${temporaryBin}:${process.env.PATH}`,
+        },
+      }
+    )
+
+    assert.notEqual(result.status, 0)
+    assert.match(result.stdout, /verified=false\tattempt=1\tretrying=true/)
+    assert.match(result.stderr, /npm registry did not report/)
+  } finally {
+    fs.rmSync(temporaryBin, { recursive: true, force: true })
+  }
+})

--- a/.github/scripts/__tests__/verify-published-packages.test.js
+++ b/.github/scripts/__tests__/verify-published-packages.test.js
@@ -160,7 +160,7 @@ exit 1
         env: {
           ...process.env,
           NPM_VERIFY_RETRY_DELAY_MS: '1',
-          NPM_VERIFY_TIMEOUT_MS: '40',
+          NPM_VERIFY_TIMEOUT_MS: '200',
           PATH: `${temporaryBin}:${process.env.PATH}`,
         },
       }

--- a/.github/scripts/verify-published-packages.js
+++ b/.github/scripts/verify-published-packages.js
@@ -1,11 +1,31 @@
 #!/usr/bin/env node
 
-const { execFileSync } = require('child_process')
+const { execFile } = require('child_process')
 const fs = require('fs')
 const path = require('path')
+const { promisify } = require('util')
 const { parsePublishedPackages } = require('./release-utils')
 
-const NPM_TIMEOUT_MS = 60_000
+const execFileAsync = promisify(execFile)
+const NPM_COMMAND_TIMEOUT_MS = 60_000
+const NPM_VERIFY_TIMEOUT_MS = 5 * 60_000
+const NPM_VERIFY_RETRY_DELAY_MS = 5_000
+
+function getPositiveIntegerEnv(name, fallback) {
+  const value = process.env[name]
+  if (value == null || value === '') return fallback
+
+  const parsed = Number(value)
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`)
+  }
+
+  return parsed
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
 
 function getWorkspacePackage(rootDir, packageName) {
   const packagesDir = path.join(rootDir, 'packages')
@@ -23,29 +43,68 @@ function getWorkspacePackage(rootDir, packageName) {
   throw new Error(`Published package ${packageName} does not exist in packages/`)
 }
 
-function getNpmVersion(packageName, version) {
-  const output = execFileSync('npm', ['view', `${packageName}@${version}`, 'version', '--json'], {
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-    timeout: NPM_TIMEOUT_MS,
-  }).trim()
+async function getNpmVersion(packageName, version, options = {}) {
+  const {
+    command = execFileAsync,
+    now = Date.now,
+    retryDelayMs = getPositiveIntegerEnv('NPM_VERIFY_RETRY_DELAY_MS', NPM_VERIFY_RETRY_DELAY_MS),
+    sleepFn = sleep,
+    timeoutMs = getPositiveIntegerEnv('NPM_VERIFY_TIMEOUT_MS', NPM_VERIFY_TIMEOUT_MS),
+  } = options
+  const deadline = now() + timeoutMs
+  let attempt = 0
+  let lastError
 
-  let reportedVersion
-  try {
-    reportedVersion = JSON.parse(output)
-  } catch {
-    throw new Error(`npm returned an invalid version response for ${packageName}@${version}`)
+  while (now() < deadline) {
+    attempt += 1
+
+    try {
+      const remaining = deadline - now()
+      const { stdout } = await command(
+        'npm',
+        ['view', `${packageName}@${version}`, 'version', '--json'],
+        {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'pipe'],
+          timeout: Math.min(NPM_COMMAND_TIMEOUT_MS, remaining),
+        }
+      )
+      let reportedVersion
+      try {
+        reportedVersion = JSON.parse(stdout.trim())
+      } catch {
+        lastError = new Error(
+          `npm returned an invalid version response for ${packageName}@${version}`
+        )
+      }
+
+      if (Array.isArray(reportedVersion)) [reportedVersion] = reportedVersion
+      if (reportedVersion === version) return
+      if (reportedVersion !== undefined) {
+        throw new Error(
+          `npm registry reports ${packageName}@${reportedVersion || 'missing'}, expected ${version}`
+        )
+      }
+    } catch (error) {
+      if (/^npm registry reports /.test(error.message)) throw error
+      lastError = error
+    }
+
+    const remaining = deadline - now()
+    if (remaining <= 0) break
+
+    const delay = Math.min(retryDelayMs, remaining)
+    console.log(`${packageName}@${version}\tverified=false\tattempt=${attempt}\tretrying=true`)
+    await sleepFn(delay)
   }
 
-  if (Array.isArray(reportedVersion)) [reportedVersion] = reportedVersion
-  if (reportedVersion !== version) {
-    throw new Error(
-      `npm registry reports ${packageName}@${reportedVersion || 'missing'}, expected ${version}`
-    )
-  }
+  const lastMessage = lastError ? `: ${lastError.message}` : ''
+  throw new Error(
+    `npm registry did not report ${packageName}@${version} within ${timeoutMs}ms${lastMessage}`
+  )
 }
 
-function main() {
+async function main() {
   const packagesInput = process.argv[2] || process.env.PUBLISHED_PACKAGES
   const packages = parsePublishedPackages(packagesInput)
   if (packages.length === 0) {
@@ -60,17 +119,25 @@ function main() {
         `${name} is ${packageJson.version} in ${packageJsonPath}, expected ${version}`
       )
     }
-
-    getNpmVersion(name, version)
-    console.log(`${name}@${version}\tverified=true`)
   }
+
+  await Promise.all(
+    packages.map(async ({ name, version }) => {
+      await getNpmVersion(name, version)
+      console.log(`${name}@${version}\tverified=true`)
+    })
+  )
 }
 
 if (require.main === module) {
-  main()
+  main().catch(error => {
+    console.error(error.stack || error.message)
+    process.exitCode = 1
+  })
 }
 
 module.exports = {
   getNpmVersion,
   getWorkspacePackage,
+  main,
 }

--- a/.github/workflows/repair-release-provenance.yml
+++ b/.github/workflows/repair-release-provenance.yml
@@ -76,7 +76,7 @@ jobs:
           release_run_fields="$(node -e '
             const run = JSON.parse(process.argv[1])
             process.stdout.write(
-              [run.path, run.event, run.status, run.head_sha, run.head_branch].join("\\t")
+              [run.path, run.event, run.status, run.head_sha, run.head_branch].join("\t")
             )
           ' "${release_run}")"
           IFS=$'\t' read -r run_path run_event run_status run_sha run_branch \


### PR DESCRIPTION
## Summary

- Retry npm registry visibility checks for up to five minutes after Changesets publishes packages.
- Parse repair workflow run metadata with real tab delimiters.
- Keep the package-tag script test aligned with the current editor version.

## Validation

- `node --test .github/scripts/__tests__/*.test.js`
- Prettier checks for the changed JavaScript and YAML files
- Verified all seven packages from the failed `v6.1.0` release against npm.

## Risk and rollback

- A delayed registry response now waits before failing; a definitive mismatched version still fails immediately.
- No package source or published version changes. Revert this commit to restore the previous fail-fast behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability Improvements**
  * Package publication verification now uses an asynchronous, retry-based registry check with configurable timeouts, and can verify multiple packages concurrently with clearer error reporting.

* **Bug Fixes**
  * Corrected release run metadata output to use actual tab separators, improving reliable parsing in downstream steps.

* **Tests**
  * Added integration-style coverage for retry success and timeout failure cases in publication verification.
  * Updated release workflow tests to assert tab character splitting and enhanced tag verification behavior when remote tags can’t be confirmed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->