### PR TITLE
fix(release): configure source tag identity

### DIFF
--- a/.github/scripts/__tests__/release-workflow-policy.test.js
+++ b/.github/scripts/__tests__/release-workflow-policy.test.js
@@ -60,3 +60,13 @@ test('repair splits release run metadata with real tab characters', () => {
   assert.match(repairWorkflow, /\.join\("\\t"\)/)
   assert.doesNotMatch(repairWorkflow, /\.join\("\\\\t"\)/)
 })
+
+test('package source tags have an explicit automation identity', () => {
+  for (const workflow of [releaseWorkflow, repairWorkflow]) {
+    assert.match(workflow, /git config user\.name 'github-actions\[bot\]'/)
+    assert.match(
+      workflow,
+      /git config user\.email '41898282\+github-actions\[bot\]@users\.noreply\.github\.com'/
+    )
+  }
+})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,6 +199,8 @@ jobs:
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
         run: |
           gh auth setup-git
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           node .github/scripts/push-package-release-tags.js
 
       # The editor gets a product-level Release. Leaf packages remain

--- a/.github/workflows/repair-release-provenance.yml
+++ b/.github/workflows/repair-release-provenance.yml
@@ -163,6 +163,8 @@ jobs:
           PUBLISHED_PACKAGES: ${{ steps.packages.outputs.published_packages }}
         run: |
           gh auth setup-git
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           node ../.github/scripts/push-package-release-tags.js
 
       - name: Restore product GitHub Release


### PR DESCRIPTION
Fixes the provenance repair failure where annotated package tags could not be created because the GitHub Actions runner had no Git committer identity.\n\nApplies the same explicit github-actions[bot] identity to normal releases and provenance repairs, with a policy regression test.\n\nValidation: node --test .github/scripts/__tests__/release-workflow-policy.test.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated release and release-repair workflows by assigning a consistent GitHub Actions identity to Git operations.
  * Ensured package source tags are created and restored with explicit commit author information.

* **Tests**
  * Added coverage verifying the required automation identity configuration in both workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->