### PR TITLE
fix(packaging): validate published package entrypoints

### DIFF
--- a/.changeset/fix-published-entrypoints.md
+++ b/.changeset/fix-published-entrypoints.md
@@ -1,0 +1,14 @@
+---
+'@wangeditor-next/basic-modules': patch
+'@wangeditor-next/editor-for-react': patch
+'@wangeditor-next/plugin-attachment': patch
+'@wangeditor-next/plugin-ctrl-enter': patch
+'@wangeditor-next/plugin-formula': patch
+'@wangeditor-next/plugin-markdown': patch
+'@wangeditor-next/plugin-mention': patch
+'@wangeditor-next/yjs': patch
+'@wangeditor-next/yjs-for-react': patch
+'@wangeditor-next/yjs-for-vue': patch
+---
+
+Fix published package entrypoint metadata and validate generated artifact paths.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test-c:split": "node scripts/test-coverage-split.js",
     "dev": "cross-env FORCE_COLOR=1 turbo dev",
     "dev:sh": "sh scripts/build-base.sh dev",
-    "build": "pnpm check:release-group && cross-env FORCE_COLOR=1 turbo build && pnpm check:published-types",
+    "build": "pnpm check:release-group && cross-env FORCE_COLOR=1 turbo build && pnpm check:published-types && pnpm check:published-entrypoints",
     "typecheck": "node scripts/typecheck-all.js",
     "publish": "pnpm changeset publish",
     "prerelease": "pnpm build",
@@ -50,7 +50,8 @@
     "check:editor:pack-size": "node scripts/check-editor-pack-size.js",
     "check:compatibility": "node scripts/check-compatibility-inventory.js",
     "check:release-group": "node scripts/check-release-package-group.js",
-    "check:published-types": "node scripts/check-published-types.js"
+    "check:published-types": "node scripts/check-published-types.js",
+    "check:published-entrypoints": "node scripts/check-published-entrypoints.js && tsc --noEmit -p tests/fixtures/published-package-consumer/tsconfig.json"
   },
   "workspaces": [
     "apps/*",

--- a/packages/basic-modules/package.json
+++ b/packages/basic-modules/package.json
@@ -11,7 +11,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
-      "types": "./dist/packages/basic-modules/src/index.d.ts",
+      "types": "./dist/basic-modules/src/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },

--- a/packages/editor-for-react/package.json
+++ b/packages/editor-for-react/package.json
@@ -14,8 +14,7 @@
       "types": "./dist/editor-for-react/src/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
-    },
-    "./dist/css/style.css": "./dist/css/style.css"
+    }
   },
   "directories": {
     "lib": "dist"

--- a/packages/plugin-attachment/package.json
+++ b/packages/plugin-attachment/package.json
@@ -14,8 +14,7 @@
       "types": "./dist/plugin-attachment/src/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
-    },
-    "./dist/css/style.css": "./dist/css/style.css"
+    }
   },
   "directories": {
     "lib": "dist"

--- a/packages/plugin-ctrl-enter/package.json
+++ b/packages/plugin-ctrl-enter/package.json
@@ -14,8 +14,7 @@
       "types": "./dist/plugin-ctrl-enter/src/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
-    },
-    "./dist/css/style.css": "./dist/css/style.css"
+    }
   },
   "directories": {
     "lib": "dist"

--- a/packages/plugin-formula/package.json
+++ b/packages/plugin-formula/package.json
@@ -14,8 +14,7 @@
       "types": "./dist/plugin-formula/src/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
-    },
-    "./dist/css/style.css": "./dist/css/style.css"
+    }
   },
   "directories": {
     "lib": "dist"

--- a/packages/plugin-markdown/package.json
+++ b/packages/plugin-markdown/package.json
@@ -14,8 +14,7 @@
       "types": "./dist/plugin-markdown/src/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
-    },
-    "./dist/css/style.css": "./dist/css/style.css"
+    }
   },
   "directories": {
     "lib": "dist"

--- a/packages/plugin-mention/package.json
+++ b/packages/plugin-mention/package.json
@@ -14,8 +14,7 @@
       "types": "./dist/plugin-mention/src/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
-    },
-    "./dist/css/style.css": "./dist/css/style.css"
+    }
   },
   "directories": {
     "lib": "dist"

--- a/packages/yjs-for-react/package.json
+++ b/packages/yjs-for-react/package.json
@@ -9,7 +9,7 @@
   "types": "dist/yjs-for-react/src/index.d.ts",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
-  "unpkg": "dist/index.global.js",
+  "unpkg": "dist/index.js",
   "keywords": [
     "slate",
     "wangEditor-next",
@@ -22,8 +22,7 @@
       "types": "./dist/yjs-for-react/src/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
-    },
-    "./dist/css/style.css": "./dist/css/style.css"
+    }
   },
   "files": [
     "dist"

--- a/packages/yjs-for-vue/package.json
+++ b/packages/yjs-for-vue/package.json
@@ -9,7 +9,7 @@
   "types": "dist/yjs-for-vue/src/index.d.ts",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
-  "unpkg": "dist/index.global.js",
+  "unpkg": "dist/index.js",
   "keywords": [
     "slate",
     "wangEditor-next",
@@ -22,8 +22,7 @@
       "types": "./dist/yjs-for-vue/src/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
-    },
-    "./dist/css/style.css": "./dist/css/style.css"
+    }
   },
   "files": [
     "dist"

--- a/packages/yjs/package.json
+++ b/packages/yjs/package.json
@@ -12,17 +12,16 @@
     "collaborative"
   ],
   "license": "MIT",
-  "types": "dist/index.d.ts",
+  "types": "dist/yjs/src/index.d.ts",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
-  "unpkg": "dist/index.global.js",
+  "unpkg": "dist/index.js",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/yjs/src/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
-    },
-    "./dist/css/style.css": "./dist/css/style.css"
+    }
   },
   "directories": {
     "lib": "dist",

--- a/scripts/check-published-entrypoints.js
+++ b/scripts/check-published-entrypoints.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs')
+const path = require('node:path')
+const ts = require('typescript')
+
+const rootDir = path.resolve(__dirname, '..')
+const packageDir = path.join(rootDir, 'packages')
+const entrypointFields = ['main', 'module', 'types', 'typings', 'unpkg', 'jsdelivr', 'browser']
+const failures = []
+const packageRecords = []
+let checked = 0
+
+function isLocalTarget(target) {
+  return typeof target === 'string' && target.length > 0 && !target.includes('://')
+}
+
+function isInsidePackage(packagePath, targetPath) {
+  const relativePath = path.relative(packagePath, targetPath)
+
+  return (
+    relativePath.length > 0 && !relativePath.startsWith(`..${path.sep}`) && relativePath !== '..'
+  )
+}
+
+function checkTarget(packagePath, packageName, label, target, requiresDotPrefix = false) {
+  if (!isLocalTarget(target)) {
+    return
+  }
+
+  checked += 1
+
+  if (requiresDotPrefix && !target.startsWith('.')) {
+    failures.push(`${packageName} ${label} must start with ".": ${target}`)
+    return
+  }
+
+  const targetPath = path.resolve(packagePath, target)
+
+  if (!isInsidePackage(packagePath, targetPath)) {
+    failures.push(`${packageName} ${label} points outside the package: ${target}`)
+    return
+  }
+
+  if (!fs.existsSync(targetPath) || !fs.statSync(targetPath).isFile()) {
+    failures.push(`${packageName} ${label} does not exist: ${target}`)
+  }
+}
+
+function checkExports(packagePath, packageName, value, label = 'exports') {
+  if (typeof value === 'string') {
+    checkTarget(packagePath, packageName, label, value, true)
+    return
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((child, index) => {
+      checkExports(packagePath, packageName, child, `${label}[${index}]`)
+    })
+    return
+  }
+
+  if (!value || typeof value !== 'object') {
+    return
+  }
+
+  Object.entries(value).forEach(([key, child]) => {
+    checkExports(packagePath, packageName, child, `${label}.${key}`)
+  })
+}
+
+function hasTypesEntrypoint(value) {
+  if (Array.isArray(value)) {
+    return value.some(hasTypesEntrypoint)
+  }
+
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+
+  return Object.entries(value).some(([key, child]) => key === 'types' || hasTypesEntrypoint(child))
+}
+
+function checkNodeNextTypes() {
+  const consumerPath = path.join(
+    rootDir,
+    'tests',
+    'fixtures',
+    'published-package-consumer',
+    'index.ts'
+  )
+  const compilerOptions = {
+    module: ts.ModuleKind.NodeNext,
+    moduleResolution: ts.ModuleResolutionKind.NodeNext,
+  }
+
+  packageRecords.forEach(({ packageName, packageJson }) => {
+    if (!packageJson.types && !packageJson.typings && !hasTypesEntrypoint(packageJson.exports)) {
+      return
+    }
+
+    checked += 1
+    const { resolvedModule } = ts.resolveModuleName(
+      packageName,
+      consumerPath,
+      compilerOptions,
+      ts.sys
+    )
+
+    if (!resolvedModule) {
+      failures.push(`${packageName} cannot be resolved by a NodeNext consumer`)
+      return
+    }
+
+    if (!/\.d\.(?:ts|mts|cts)$/.test(resolvedModule.resolvedFileName)) {
+      failures.push(
+        `${packageName} resolves to JavaScript instead of declarations: ${resolvedModule.resolvedFileName}`
+      )
+    }
+  })
+}
+
+fs.readdirSync(packageDir, { withFileTypes: true })
+  .filter(entry => entry.isDirectory())
+  .sort((first, second) => first.name.localeCompare(second.name))
+  .forEach(entry => {
+    const packagePath = path.join(packageDir, entry.name)
+    const packageJsonPath = path.join(packagePath, 'package.json')
+
+    if (!fs.existsSync(packageJsonPath)) {
+      return
+    }
+
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+
+    if (!packageJson.name) {
+      return
+    }
+
+    packageRecords.push({
+      packageName: packageJson.name,
+      packageJson,
+    })
+
+    entrypointFields.forEach(field => {
+      checkTarget(packagePath, packageJson.name, field, packageJson[field])
+    })
+    checkExports(packagePath, packageJson.name, packageJson.exports)
+  })
+
+checkNodeNextTypes()
+
+if (failures.length > 0) {
+  console.error('Published package entrypoint check failed:')
+  failures.forEach(failure => console.error(`- ${failure}`))
+  process.exit(1)
+}
+
+// eslint-disable-next-line no-console
+console.log(`Published package entrypoint check passed (${checked} paths checked).`)

--- a/tests/fixtures/published-package-consumer/index.ts
+++ b/tests/fixtures/published-package-consumer/index.ts
@@ -1,0 +1,5 @@
+import '@wangeditor-next/yjs'
+
+import basicModules from '@wangeditor-next/basic-modules'
+
+void basicModules

--- a/tests/fixtures/published-package-consumer/package.json
+++ b/tests/fixtures/published-package-consumer/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "published-package-consumer",
+  "private": true,
+  "type": "module"
+}

--- a/tests/fixtures/published-package-consumer/tsconfig.json
+++ b/tests/fixtures/published-package-consumer/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022"
+  },
+  "files": [
+    "index.ts"
+  ]
+}


### PR DESCRIPTION
## Summary

- Correct `basic-modules` and Yjs type/UMD entrypoint metadata to match generated files.
- Remove nine CSS subpath exports that were never generated or documented.
- Add a post-build manifest-entrypoint validator and a real NodeNext consumer fixture.
- Add a patch Changeset for the affected packages; the configured fixed group will release all 21 runtime packages together.

Fixes #964

## Validation

- `pnpm build` (25/25 Turbo tasks, published declaration check, new entrypoint check, and NodeNext fixture)
- `pnpm lint`
- `pnpm changeset status` (21 fixed-group patch releases)
- Packed all 10 affected packages and verified 64 manifest paths inside the tarballs
- Targeted Vitest suites for `basic-modules`, `editor-for-react`, `plugin-attachment`, `plugin-ctrl-enter`, `plugin-formula`, `plugin-markdown`, `plugin-mention`, `yjs`, `yjs-for-react`, and `yjs-for-vue`

## Risk and rollback

- The removed CSS entries previously resolved to no file, so this turns a broken subpath into an explicit non-export. These packages do not generate or document package-local CSS; editor CSS remains unchanged.
- The manifest changes are patch releases and are coupled by the existing fixed release group.
- Roll back by reverting this commit; no persisted document format or runtime editor behavior changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected published package entrypoints for reliable JavaScript and TypeScript resolution.
  - Removed invalid CSS subpath exports from affected packages.
  - Updated browser bundle paths for Yjs integrations.

- **Tests**
  - Added automated validation for published entrypoints, generated files, and declaration resolution.
  - Added a consumer fixture to verify published packages can be imported successfully.

- **Chores**
  - Added patch release notices for the affected packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->