### PR TITLE
fix(build): include shared compiler inputs in Turbo cache keys

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,10 +1,13 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": [
+    "babel.config.json",
     "package.json",
+    "packages/custom-types.d.ts",
     "pnpm-lock.yaml",
-    "tsconfig.json",
-    "shared/rollup-config/**"
+    "pnpm-workspace.yaml",
+    "shared/rollup-config/**",
+    "tsconfig.json"
   ],
   "tasks": {
     "dev": {


### PR DESCRIPTION
## Summary
- include shared Babel, custom type, and workspace configuration inputs in Turbo build cache keys
- prevent stale package build artifacts when shared compiler inputs change

## Validation
- pnpm build
- pnpm lint
- verified a second target build hits the Turbo cache

Fixes #965

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration tracking so workspace-wide type declarations and shared bundling configuration changes are recognized consistently.
  * Improved build cache invalidation for affected projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->