### PR TITLE
fix(build): unify internal UMD globals

### DIFF
--- a/.changeset/fix-umd-internal-globals.md
+++ b/.changeset/fix-umd-internal-globals.md
@@ -1,0 +1,19 @@
+---
+'@wangeditor-next/basic-modules': patch
+'@wangeditor-next/code-highlight': patch
+'@wangeditor-next/editor-for-react': patch
+'@wangeditor-next/list-module': patch
+'@wangeditor-next/plugin-attachment': patch
+'@wangeditor-next/plugin-ctrl-enter': patch
+'@wangeditor-next/plugin-float-image': patch
+'@wangeditor-next/plugin-formula': patch
+'@wangeditor-next/plugin-link-card': patch
+'@wangeditor-next/plugin-markdown': patch
+'@wangeditor-next/plugin-mention': patch
+'@wangeditor-next/table-module': patch
+'@wangeditor-next/upload-image-module': patch
+'@wangeditor-next/video-module': patch
+'@wangeditor-next/yjs': patch
+---
+
+Use the documented public globals for internal UMD dependencies.

--- a/apps/demo-html/examples/umd-plugin.html
+++ b/apps/demo-html/examples/umd-plugin.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>UMD plugin smoke</title>
+
+  <body>
+    <script src="../dist/index.js"></script>
+    <script src="../plugin-ctrl-enter-dist/index.js"></script>
+    <script>
+      const editor = window.wangEditor
+      const module = window.WangEditorCtrlEnterPlugin
+      const handlers = {}
+      const originalGetTextarea = editor.DomEditor.getTextarea
+      let insertBreakCalls = 0
+
+      editor.DomEditor.getTextarea = () => ({
+        $textArea: {
+          on(eventName, handler) {
+            handlers[eventName] = handler
+          },
+        },
+      })
+
+      const fakeEditor = {
+        insertBreak() {
+          insertBreakCalls += 1
+        },
+      }
+
+      editor.Boot.registerModule(module)
+      editor.Boot.plugins.at(-1)(fakeEditor)
+
+      setTimeout(() => {
+        const event = {
+          ctrlKey: true,
+          defaultPrevented: false,
+          key: 'Enter',
+          preventDefault() {
+            this.defaultPrevented = true
+          },
+        }
+
+        handlers.keydown?.(event)
+        editor.DomEditor.getTextarea = originalGetTextarea
+        window.umdPluginSmoke = {
+          bound: typeof handlers.keydown === 'function',
+          defaultPrevented: event.defaultPrevented,
+          insertBreakCalls,
+          loadedEditorGlobal: editor === window.wangEditor,
+          registered: editor.Boot.plugins.length > 0,
+        }
+      })
+    </script>
+  </body>
+</html>

--- a/apps/demo-html/serve.js
+++ b/apps/demo-html/serve.js
@@ -7,6 +7,7 @@ const examplesDir = path.join(__dirname, 'examples')
 const editorDistDir = path.join(__dirname, '../../packages/editor/dist')
 const coreDistDir = path.join(__dirname, '../../packages/core/dist')
 const markdownDistDir = path.join(__dirname, '../../packages/plugin-markdown/dist')
+const ctrlEnterDistDir = path.join(__dirname, '../../packages/plugin-ctrl-enter/dist')
 const vue2AdapterDistDir = path.join(__dirname, '../../packages/editor-for-vue2/dist')
 const vue2RuntimeDistDir = path.join(
   __dirname,
@@ -64,6 +65,12 @@ function resolvePath(urlPath) {
     return { filePath: path.join(markdownDistDir, urlPath.replace('/plugin-markdown-dist/', '')) }
   }
 
+  if (urlPath.startsWith('/plugin-ctrl-enter-dist/')) {
+    return {
+      filePath: path.join(ctrlEnterDistDir, urlPath.replace('/plugin-ctrl-enter-dist/', '')),
+    }
+  }
+
   if (urlPath.startsWith('/editor-for-vue2-dist/')) {
     return {
       filePath: path.join(vue2AdapterDistDir, urlPath.replace('/editor-for-vue2-dist/', '')),
@@ -107,6 +114,8 @@ const server = http.createServer((req, res) => {
     baseDir = coreDistDir
   } else if (requestUrl.pathname.startsWith('/plugin-markdown-dist/')) {
     baseDir = markdownDistDir
+  } else if (requestUrl.pathname.startsWith('/plugin-ctrl-enter-dist/')) {
+    baseDir = ctrlEnterDistDir
   } else if (requestUrl.pathname.startsWith('/editor-for-vue2-dist/')) {
     baseDir = vue2AdapterDistDir
   } else if (requestUrl.pathname.startsWith('/vue2-dist/')) {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test-c:split": "node scripts/test-coverage-split.js",
     "dev": "cross-env FORCE_COLOR=1 turbo dev",
     "dev:sh": "sh scripts/build-base.sh dev",
-    "build": "pnpm check:release-group && cross-env FORCE_COLOR=1 turbo build && pnpm check:published-types && pnpm check:published-entrypoints",
+    "build": "pnpm check:release-group && pnpm check:umd-globals && cross-env FORCE_COLOR=1 turbo build && pnpm check:published-types && pnpm check:published-entrypoints",
     "typecheck": "node scripts/typecheck-all.js",
     "publish": "pnpm changeset publish",
     "prerelease": "pnpm build",
@@ -50,6 +50,7 @@
     "check:editor:pack-size": "node scripts/check-editor-pack-size.js",
     "check:compatibility": "node scripts/check-compatibility-inventory.js",
     "check:release-group": "node scripts/check-release-package-group.js",
+    "check:umd-globals": "cross-env NODE_ENV=production node scripts/check-umd-globals.mjs",
     "check:published-types": "node scripts/check-published-types.js",
     "check:published-entrypoints": "node scripts/check-published-entrypoints.js && tsc --noEmit -p tests/fixtures/published-package-consumer/tsconfig.json"
   },

--- a/packages/yjs-for-react/rollup.config.js
+++ b/packages/yjs-for-react/rollup.config.js
@@ -4,8 +4,6 @@ import pkg from './package.json' with { type: 'json' }
 
 const name = 'WangEditorYjsForReact'
 const globals = {
-  '@wangeditor-next/editor': 'wangEditor',
-  '@wangeditor-next/yjs': 'WangEditorYjsModule',
   react: 'React',
   slate: 'Slate',
 }

--- a/packages/yjs-for-vue/rollup.config.js
+++ b/packages/yjs-for-vue/rollup.config.js
@@ -4,8 +4,6 @@ import pkg from './package.json' with { type: 'json' }
 
 const name = 'WangEditorYjsForVue'
 const globals = {
-  '@wangeditor-next/editor': 'wangEditor',
-  '@wangeditor-next/yjs': 'WangEditorYjsModule',
   slate: 'Slate',
   vue: 'Vue',
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,7 +9,7 @@ function createHtmlDemoCommand(buildCommand: string) {
 }
 
 let webServerCommand = createHtmlDemoCommand(
-  'pnpm turbo build --filter=@wangeditor-next/editor-for-vue2 --filter=@wangeditor-next/plugin-markdown'
+  'pnpm turbo build --filter=@wangeditor-next/editor-for-vue2 --filter=@wangeditor-next/plugin-ctrl-enter --filter=@wangeditor-next/plugin-markdown'
 )
 const reactDemoDevCommand =
   'pnpm --filter @wangeditor-next/demo-react exec vite --host 127.0.0.1 --port 3102 --strictPort'
@@ -26,11 +26,11 @@ if (process.env.PLAYWRIGHT_SKIP_BUILD) {
   // CI e2e sets PLAYWRIGHT_SKIP_BUILD=1 and prebuilds only part of packages.
   // Keep this lightweight but ensure plugin-markdown dist exists for markdown demos.
   webServerCommand = createHtmlDemoCommand(
-    'pnpm turbo build --filter=@wangeditor-next/editor-for-vue2 --filter=@wangeditor-next/plugin-markdown'
+    'pnpm turbo build --filter=@wangeditor-next/editor-for-vue2 --filter=@wangeditor-next/plugin-ctrl-enter --filter=@wangeditor-next/plugin-markdown'
   )
 } else if (process.env.CI) {
   webServerCommand = createHtmlDemoCommand(
-    'pnpm turbo build --force --filter=@wangeditor-next/editor-for-vue2 --filter=@wangeditor-next/plugin-markdown'
+    'pnpm turbo build --force --filter=@wangeditor-next/editor-for-vue2 --filter=@wangeditor-next/plugin-ctrl-enter --filter=@wangeditor-next/plugin-markdown'
   )
 }
 

--- a/scripts/check-umd-globals.mjs
+++ b/scripts/check-umd-globals.mjs
@@ -1,0 +1,67 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+// eslint-disable-next-line import/extensions
+import { INTERNAL_UMD_GLOBALS } from '../shared/rollup-config/index.js'
+
+const packagesDir = path.resolve('packages')
+const packageDirs = fs
+  .readdirSync(packagesDir, { withFileTypes: true })
+  .filter(entry => entry.isDirectory())
+  .map(entry => entry.name)
+  .sort()
+const errors = []
+
+for (const packageDir of packageDirs) {
+  const packagePath = path.join(packagesDir, packageDir, 'package.json')
+  const rollupConfigPath = path.join(packagesDir, packageDir, 'rollup.config.js')
+
+  if (!fs.existsSync(packagePath) || !fs.existsSync(rollupConfigPath)) {
+    continue
+  }
+
+  const pkg = JSON.parse(fs.readFileSync(packagePath, 'utf8'))
+  const internalPeers = Object.keys(pkg.peerDependencies || {}).filter(name =>
+    name.startsWith('@wangeditor-next/')
+  )
+
+  if (internalPeers.length === 0) {
+    continue
+  }
+
+  const configUrl = pathToFileURL(rollupConfigPath).href
+  const { default: rollupConfigs } = await import(configUrl)
+  const configs = Array.isArray(rollupConfigs) ? rollupConfigs : [rollupConfigs]
+  const umdConfigs = configs.filter(config => config.output?.format === 'umd')
+
+  if (umdConfigs.length === 0) {
+    errors.push(`${pkg.name}: no UMD output found`)
+    continue
+  }
+
+  for (const dependency of internalPeers) {
+    const expectedGlobal = INTERNAL_UMD_GLOBALS[dependency]
+
+    if (!expectedGlobal) {
+      errors.push(`${pkg.name}: ${dependency} is missing from INTERNAL_UMD_GLOBALS`)
+      continue
+    }
+
+    for (const config of umdConfigs) {
+      const actualGlobal = config.output.globals?.[dependency]
+
+      if (actualGlobal !== expectedGlobal) {
+        errors.push(
+          `${pkg.name}: ${dependency} resolves to ${actualGlobal || 'undefined'}, expected ${expectedGlobal}`
+        )
+      }
+    }
+  }
+}
+
+if (errors.length > 0) {
+  throw new Error(`Invalid internal UMD globals:\n${errors.join('\n')}`)
+}
+
+process.stdout.write(`Validated internal UMD globals for ${packageDirs.length} packages.\n`)

--- a/shared/rollup-config/index.js
+++ b/shared/rollup-config/index.js
@@ -20,6 +20,35 @@ const IS_SIZE_STATS = ENV.indexOf('size_stats') >= 0 // 分析包体积
 export const IS_DEV = ENV.indexOf('development') >= 0
 export const IS_PRD = ENV.indexOf('production') >= 0
 
+// Keep UMD dependency names aligned with the globals exposed by each package's UMD entry.
+// Package configs may still add or override third-party mappings through output.globals.
+export const INTERNAL_UMD_GLOBALS = {
+  '@wangeditor-next/basic-modules': 'WangEditorBasicModules',
+  '@wangeditor-next/code-highlight': 'WangEditorCodeHighLight',
+  '@wangeditor-next/core': 'WangEditorCore',
+  '@wangeditor-next/core/upload': 'WangEditorCoreUpload',
+  '@wangeditor-next/editor': 'wangEditor',
+  '@wangeditor-next/editor/core': 'wangEditorCore',
+  '@wangeditor-next/editor/upload': 'wangEditorUpload',
+  '@wangeditor-next/editor-for-react': 'WangEditorForReact',
+  '@wangeditor-next/editor-for-vue': 'WangEditorForVue',
+  '@wangeditor-next/editor-for-vue2': 'WangEditorForVue',
+  '@wangeditor-next/list-module': 'WangEditorListModule',
+  '@wangeditor-next/plugin-attachment': 'WangEditorAttachmentPlugin',
+  '@wangeditor-next/plugin-ctrl-enter': 'WangEditorCtrlEnterPlugin',
+  '@wangeditor-next/plugin-float-image': 'WangEditorFloatImagePlugin',
+  '@wangeditor-next/plugin-formula': 'WangEditorFormulaPlugin',
+  '@wangeditor-next/plugin-link-card': 'WangEditorLinkCardPlugin',
+  '@wangeditor-next/plugin-markdown': 'WangEditorMarkDownPlugin',
+  '@wangeditor-next/plugin-mention': 'WangEditorMentionPlugin',
+  '@wangeditor-next/table-module': 'WangEditorTableModule',
+  '@wangeditor-next/upload-image-module': 'WangEditorUploadImageModule',
+  '@wangeditor-next/video-module': 'WangEditorVideoModule',
+  '@wangeditor-next/yjs': 'WangEditorYjsModule',
+  '@wangeditor-next/yjs-for-react': 'WangEditorYjsForReact',
+  '@wangeditor-next/yjs-for-vue': 'WangEditorYjsForVue',
+}
+
 /**
  * 生成单个 rollup 配置
  * @param {object} customConfig { input, output, plugins ... }
@@ -27,6 +56,16 @@ export const IS_PRD = ENV.indexOf('production') >= 0
 export function createRollupConfig(customConfig = {}) {
   const { input, output = {}, plugins = [] } = customConfig
   const { format } = output
+  const normalizedOutput =
+    format === 'umd'
+      ? {
+          ...output,
+          globals: {
+            ...INTERNAL_UMD_GLOBALS,
+            ...output.globals,
+          },
+        }
+      : output
 
   let baseConfig
 
@@ -43,7 +82,7 @@ export function createRollupConfig(customConfig = {}) {
 
   const config = {
     input: input || baseConfig.input,
-    output,
+    output: normalizedOutput,
     plugins,
   }
 

--- a/tests/e2e/umd.spec.ts
+++ b/tests/e2e/umd.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '@playwright/test'
+
+test('loads the editor and ctrl-enter UMD bundles using their public globals', async ({ page }) => {
+  const errors: string[] = []
+
+  page.on('pageerror', error => errors.push(error.message))
+
+  await page.goto('/examples/umd-plugin.html')
+
+  await expect
+    .poll(() => page.evaluate(() => (window as any).umdPluginSmoke))
+    .toEqual({
+      bound: true,
+      defaultPrevented: true,
+      insertBreakCalls: 1,
+      loadedEditorGlobal: true,
+      registered: true,
+    })
+  expect(errors).toEqual([])
+})


### PR DESCRIPTION
## Summary
- centralize internal wangEditor package to UMD global mappings in the shared Rollup config
- add a build-time check that validates every internal peer mapping
- add an editor + ctrl-enter browser UMD smoke fixture and remove duplicated Yjs mappings

## Validation
- `pnpm check:umd-globals`
- `pnpm --filter @wangeditor-next/plugin-ctrl-enter build`
- Chromium Playwright UMD smoke: 1 passed
- `pnpm lint`

The remaining build warnings are limited to stale Browserslist/Baseline data and third-party externals; internal package guessing warnings are gone.

Fixes #966

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UMD builds so internal packages use the correct public global references.
  * Added validation to catch incorrect UMD global mappings during builds.

* **Tests**
  * Added end-to-end coverage for UMD plugin loading and Ctrl+Enter behavior.
  * Added a browser smoke test verifying plugin registration, event handling, and line-break insertion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->