### PR TITLE
perf(demo): split Yjs collaboration chunks

### DIFF
--- a/apps/demo-yjs-react/src/index.tsx
+++ b/apps/demo-yjs-react/src/index.tsx
@@ -1,22 +1,27 @@
 import 'virtual:windi.css'
 import 'virtual:windi-devtools'
 
-import React, { StrictMode } from 'react'
+import React, { lazy, StrictMode, Suspense } from 'react'
 import ReactDOM from 'react-dom'
-import {
-  BrowserRouter, Route, Routes,
-} from 'react-router-dom'
+import { BrowserRouter, Route, Routes } from 'react-router-dom'
 
-import { RemoteCursorsOverlayPage } from './pages/RemoteCursorOverlay'
+const RemoteCursorsOverlayPage = lazy(() => import('./pages/RemoteCursorOverlay'))
 
 ReactDOM.render(
   <StrictMode>
     <BrowserRouter>
       <Routes>
         {/* <Route path="/" element={<SimplePage />} /> */}
-        <Route path="/" element={<RemoteCursorsOverlayPage />} />
+        <Route
+          path="/"
+          element={
+            <Suspense fallback={<div data-testid="yjs-demo-loading">Loading...</div>}>
+              <RemoteCursorsOverlayPage />
+            </Suspense>
+          }
+        />
       </Routes>
     </BrowserRouter>
   </StrictMode>,
-  document.getElementById('root'),
+  document.getElementById('root')
 )

--- a/apps/demo-yjs-vue3/src/App.vue
+++ b/apps/demo-yjs-vue3/src/App.vue
@@ -1,13 +1,15 @@
 <template>
-  <remote-cursors-overlay-page v-if="!showBaseVersion"/>
+  <remote-cursors-overlay-page v-if="!showBaseVersion" />
   <simple v-else></simple>
 </template>
 
 <script lang="ts">
-import { defineComponent, ref } from 'vue'
+import { defineAsyncComponent, defineComponent, ref } from 'vue'
 
-import RemoteCursorsOverlayPage from './components/RemoteCursorsOverlayPage.vue'
-import Simple from './components/Simple.vue'
+const RemoteCursorsOverlayPage = defineAsyncComponent(
+  () => import('./components/RemoteCursorsOverlayPage.vue')
+)
+const Simple = defineAsyncComponent(() => import('./components/Simple.vue'))
 
 export default defineComponent({
   components: { Simple, RemoteCursorsOverlayPage },


### PR DESCRIPTION
## Summary

- lazy-load the React remote cursor route behind `Suspense`
- lazy-load the Vue remote cursor and simple views
- preserve the existing `/` entry URL for both demos

## Bundle result

| Demo | Previous initial chunk | New initial chunk | Deferred collaboration chunk |
| --- | ---: | ---: | ---: |
| React Yjs | 4,597.99 KiB | 147.48 KiB | 4,449.47 KiB |
| Vue Yjs | 4,591.32 KiB | 63.41 KiB | 4,440.05 KiB |

The large collaboration dependency remains visible as an async chunk rather than being hidden by a higher warning threshold.

## Validation

- `pnpm --filter @wangeditor-next/demo-yjs-react build`
- `pnpm --filter @wangeditor-next/demo-yjs-vue3 build`
- `PLAYWRIGHT_SKIP_BUILD=1 pnpm e2e:yjs` (4 passed: native, React, Vue, React-Vue)
- targeted ESLint and Prettier checks

Fixes #968

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved initial loading by loading demo pages asynchronously.
  * Added a loading fallback while remote cursor and base-version pages are prepared.
  * Preserved existing navigation and conditional rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->