### PR TITLE
fix(vue2): remove unused template compiler

### DIFF
--- a/.changeset/remove-stale-vue2-compiler.md
+++ b/.changeset/remove-stale-vue2-compiler.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/editor-for-vue2': patch
+---
+
+Remove the unused Vue 2 template compiler build dependency.

--- a/packages/editor-for-vue2/package.json
+++ b/packages/editor-for-vue2/package.json
@@ -56,7 +56,6 @@
     "typescript": "5.2.2",
     "vite": "^6.4.3",
     "vite-plugin-dts": "^5.0.3",
-    "vue": "^2.7.16",
-    "vue-template-compiler": "^2.7.16"
+    "vue": "^2.7.16"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -736,9 +736,6 @@ importers:
       vue:
         specifier: ^2.7.16
         version: 2.7.16
-      vue-template-compiler:
-        specifier: ^2.7.16
-        version: 2.7.16
 
   packages/list-module:
     dependencies:
@@ -6584,9 +6581,6 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-
-  vue-template-compiler@2.7.16:
-    resolution: {integrity: sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==}
 
   vue-tsc@2.2.12:
     resolution: {integrity: sha512-P7OP77b2h/Pmk+lZdJ0YWs+5tJ6J2+uOQPo7tlBnY44QqQSPYvS0qVT4wqDJgwrZaLe47etJLLQRFia71GYITw==}
@@ -13010,11 +13004,6 @@ snapshots:
       semver: 7.8.1
     transitivePeerDependencies:
       - supports-color
-
-  vue-template-compiler@2.7.16:
-    dependencies:
-      de-indent: 1.0.2
-      he: 1.2.0
 
   vue-tsc@2.2.12(typescript@5.2.2):
     dependencies:


### PR DESCRIPTION
## Summary
- remove the unused `vue-template-compiler` development dependency from `@wangeditor-next/editor-for-vue2`
- remove its lockfile entries
- add a patch Changeset for the adapter package

## Security impact
Resolves Dependabot alerts #318 and #192 after merge. Alert #333 remains an accepted Vue 2 EOL risk because no compatible Vue 2 patch exists; it requires a future breaking migration or retirement of the Vue 2 adapter.

## Validation
- `pnpm install --offline --frozen-lockfile`
- `pnpm --filter @wangeditor-next/editor-for-vue2 typecheck`
- `pnpm --filter @wangeditor-next/editor-for-vue2 build`
- `pnpm audit --prod --json` (0 vulnerabilities)

`pnpm lint; pnpm build` was also started locally but exceeded the 5-minute execution limit without output, so it is not claimed as passing.

## Rollback
Restore the removed development dependency and its lockfile entry. No published runtime dependency is removed by this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed an unused Vue 2 build dependency.
  * Added release metadata documenting the package maintenance update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->