### PR TITLE
fix(list): prevent pasted lists from truncating content

### DIFF
--- a/.changeset/fix-pasted-list-truncation.md
+++ b/.changeset/fix-pasted-list-truncation.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/list-module': patch
+---
+
+Fix external HTML list pastes truncating the list and all following content.

--- a/packages/list-module/__tests__/issue-983-paste-list.test.ts
+++ b/packages/list-module/__tests__/issue-983-paste-list.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @description issue #983 pasted lists should not truncate following content
+ */
+
+import { Editor } from 'slate'
+
+import createEditor from '../../../tests/utils/create-editor'
+
+const PASTED_HTML = '<p>before</p><ul><li>one</li><li>two</li></ul><p>after</p>'
+
+describe('list issue #983 pasted list', () => {
+  it('dangerouslyInsertHtml should preserve a list and the content after it', () => {
+    const editor = createEditor()
+    const hiddenContainerCount = document.body.querySelectorAll(
+      ':scope > div[hidden="true"]'
+    ).length
+
+    editor.select(Editor.start(editor, []))
+
+    expect(() => editor.dangerouslyInsertHtml(PASTED_HTML)).not.toThrow()
+
+    const output = editor.getHtml()
+    const wrapper = document.createElement('div')
+
+    wrapper.innerHTML = output
+
+    expect(wrapper.querySelector('p')?.textContent).toBe('before')
+    expect(wrapper.querySelectorAll('ul > li')).toHaveLength(2)
+    expect(wrapper.querySelector('ul > li')?.textContent).toBe('one')
+    expect(wrapper.querySelector('p:last-child')?.textContent).toBe('after')
+    expect(document.body.querySelectorAll(':scope > div[hidden="true"]')).toHaveLength(
+      hiddenContainerCount
+    )
+
+    const roundTripEditor = createEditor({ html: output })
+
+    expect(roundTripEditor.getHtml()).toBe(output)
+    expect(roundTripEditor.children).toEqual(editor.children)
+  })
+
+  it('insertData should preserve ordered lists from external HTML', () => {
+    const editor = createEditor()
+    const data = {
+      getData(type: string) {
+        if (type === 'text/html') {
+          return '<p>before</p><ol><li>one</li><li>two</li></ol><p>after</p>'
+        }
+        if (type === 'text/plain') {
+          return 'before\none\ntwo\nafter'
+        }
+        return ''
+      },
+    } as DataTransfer
+
+    editor.select(Editor.start(editor, []))
+
+    expect(() => editor.insertData(data)).not.toThrow()
+
+    const output = editor.getHtml()
+    const wrapper = document.createElement('div')
+
+    wrapper.innerHTML = output
+
+    expect(wrapper.querySelectorAll('ol > li')).toHaveLength(2)
+    expect(wrapper.querySelector('p:last-child')?.textContent).toBe('after')
+  })
+
+  it('should preserve nested list levels while parsing mounted HTML', () => {
+    const editor = createEditor()
+    const html = '<p>before</p><ul><li>parent<ol><li>child</li></ol></li></ul><p>after</p>'
+
+    editor.select(Editor.start(editor, []))
+    editor.dangerouslyInsertHtml(html)
+
+    const output = editor.getHtml()
+    const wrapper = document.createElement('div')
+
+    wrapper.innerHTML = output
+
+    expect(wrapper.querySelectorAll('ul > li')).toHaveLength(1)
+    expect(wrapper.querySelectorAll('ul > li > ol > li')).toHaveLength(1)
+    expect(wrapper.querySelector('ul > li > ol > li')?.textContent).toBe('child')
+    expect(wrapper.querySelector('p:last-child')?.textContent).toBe('after')
+
+    const roundTripEditor = createEditor({ html: output })
+
+    expect(roundTripEditor.getHtml()).toBe(output)
+    expect(roundTripEditor.children).toEqual(editor.children)
+  })
+})

--- a/packages/list-module/src/utils/dom.ts
+++ b/packages/list-module/src/utils/dom.ts
@@ -38,6 +38,9 @@ export {
  * @param $elem $elem
  */
 export function getTagName($elem: Dom7Array): string {
-  if ($elem.length) { return $elem[0].tagName.toLowerCase() }
-  return ''
+  if ($elem.length === 0) { return '' }
+  const elem = $elem[0]
+
+  if (elem.nodeType !== DOMNode.ELEMENT_NODE) { return '' }
+  return elem.tagName.toLowerCase()
 }


### PR DESCRIPTION
## Summary

- Guard list tag-name reads when ancestor traversal reaches a non-element node.
- Preserve pasted unordered, ordered, and nested lists together with all following content.
- Add mounted HTML insertion, external `insertData`, cleanup, and HTML/Slate round-trip regressions.
- Add a patch Changeset for `@wangeditor-next/list-module`.

## Root cause

`dangerouslyInsertHtml` mounts its temporary container under `document.body`. List level parsing walks all ancestors, eventually reaches the `Document` node, and previously called `tagName.toLowerCase()` on that non-element node. The exception aborted the insertion at the list and dropped every following top-level node.

## Compatibility and risk

- Low behavioral risk: non-element ancestors now return an empty tag name, matching the existing helpers in core and basic-modules.
- Existing nested-list level counting is unchanged and covered by a mounted nested-list regression.
- HTML and Slate round trips are asserted to remain stable.

## Verification

- list-module: 12 files, 71 tests passed.
- core/editor/React: 45 files, 333 tests passed.
- Changed-file ESLint passed.
- Release group and UMD global checks passed.
- Turbo build completed 25/25 tasks successfully.
- Published declarations: 5,524 files checked.
- Published entrypoints: 170 paths checked.

Local Windows note: after printing successful task summaries, some Node wrappers returned `0xC0000409` during process teardown. The test assertions, all Turbo tasks, and both post-build publication checks completed successfully.

## Rollback

Revert commit `012ad5b1`. The change is isolated to the list-module DOM helper, its regression tests, and the Changeset.

Fixes #983

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where pasting externally created HTML lists could truncate the list or content that followed it.
  * Improved handling of nested ordered and unordered lists.
  * Increased stability when processing list content in hidden editor containers.

* **Tests**
  * Added coverage for pasted lists, nested levels, content following lists, and HTML round trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->