### PR TITLE
fix(core): scope editor content styles

### DIFF
--- a/.changeset/bright-editors-resist.md
+++ b/.changeset/bright-editors-resist.md
@@ -1,0 +1,7 @@
+---
+'@wangeditor-next/core': patch
+'@wangeditor-next/editor': patch
+---
+
+Scope built-in editable-content styles under the editor root so headings, lists, controls, code,
+tables, and media remain stable when host reset styles such as Tailwind Preflight are present.

--- a/packages/core/src/assets/content.less
+++ b/packages/core/src/assets/content.less
@@ -1,0 +1,97 @@
+@import "../../../vars.less";
+
+// Keep the editable content predictable when the host application ships a reset
+// stylesheet (for example, Tailwind Preflight). This is intentionally scoped to
+// the editor root so the surrounding page keeps its own design system.
+.w-e-text-container [data-slate-editor] {
+  color: @textarea-color;
+  line-height: 1.5;
+
+  p {
+    margin: 15px 0;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    margin: 20px 0;
+    line-height: 1.5;
+  }
+
+  h1 {
+    font-size: 2em;
+    font-weight: bold;
+  }
+
+  h2 {
+    font-size: 1.5em;
+    font-weight: bold;
+  }
+
+  h3 {
+    font-size: 1.17em;
+    font-weight: bold;
+  }
+
+  h4 {
+    font-size: 1em;
+    font-weight: bold;
+  }
+
+  h5 {
+    font-size: 0.83em;
+    font-weight: bold;
+  }
+
+  h6 {
+    font-size: 0.67em;
+    font-weight: bold;
+  }
+
+  ul,
+  ol,
+  menu {
+    margin: 15px 0;
+    padding: 0 0 0 40px;
+    list-style: revert;
+  }
+
+  li {
+    margin: 0;
+    padding: 0;
+    line-height: 1.5;
+  }
+
+  blockquote {
+    margin: 10px 0;
+    line-height: 1.5;
+  }
+
+  pre {
+    font-family: monospace;
+    line-height: 1.5;
+    white-space: pre-wrap;
+  }
+
+  code {
+    font-family: monospace;
+  }
+
+  button {
+    font: inherit;
+    line-height: inherit;
+  }
+
+  table {
+    border-collapse: collapse;
+  }
+
+  img,
+  video,
+  iframe {
+    max-width: 100%;
+  }
+}

--- a/packages/core/src/assets/index.less
+++ b/packages/core/src/assets/index.less
@@ -1,5 +1,6 @@
 @import "common.less";
 @import "textarea.less";
+@import "content.less";
 @import "bar.less";
 @import "bar-item.less";
 @import "select-list.less";

--- a/packages/core/src/assets/textarea.less
+++ b/packages/core/src/assets/textarea.less
@@ -25,13 +25,6 @@
   border-top: 1px solid transparent; // 防止 margin-top 溢出
   min-height: 100%;
 
-  p {
-    margin: 15px 0;
-  }
-  h1,h2,h3,h4,h5 {
-    margin: 20px 0 20px 0;
-  }
-
   img {
     max-width: 100%;
     min-width: 20px;

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -2481,6 +2481,94 @@ test('regression #929: block video keeps explicit media alignment under CSS rese
   expect(exportedHtml).toContain('justify-content: flex-start')
 })
 
+test('regression #988: editable content keeps its structural styles under host resets', async ({
+  page,
+}) => {
+  await page.goto('/examples/default-mode.html')
+  await page.getByTestId('btn-create').click()
+  await expect(getEditable(page)).toBeVisible()
+
+  await page.addStyleTag({
+    content: `
+      [data-testid="editor-textarea"] h1,
+      [data-testid="editor-textarea"] h2,
+      [data-testid="editor-textarea"] h3,
+      [data-testid="editor-textarea"] h4,
+      [data-testid="editor-textarea"] h5,
+      [data-testid="editor-textarea"] h6 {
+        margin: 0;
+        font-size: inherit;
+        font-weight: inherit;
+        line-height: 1;
+      }
+      [data-testid="editor-textarea"] ul,
+      [data-testid="editor-textarea"] ol {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+      }
+      [data-testid="editor-textarea"] button {
+        border: 10px solid red;
+        font-size: 1px;
+        line-height: 1;
+      }
+      [data-testid="editor-textarea"] table {
+        border-collapse: separate;
+      }
+    `,
+  })
+  await page.evaluate(() => {
+    const editor = (window as any).wangEditorExampleBridge.editor
+
+    editor.setHtml(
+      [
+        '<h1>Heading</h1>',
+        '<ul><li>Bullet</li></ul>',
+        '<ol data-w-e-list-mode="outline"><li data-w-e-list-indent="0" data-w-e-outline-number="1."><h1>Chapter</h1></li></ol>',
+        '<table><tbody><tr><td>Cell</td></tr></tbody></table>',
+        '<p><br></p>',
+      ].join(''),
+    )
+  })
+
+  const styles = await page.evaluate(() => {
+    const root = document.querySelector('[data-testid="editor-textarea"] [data-slate-editor]')
+    const heading = root?.querySelector('h1')
+    const marker = root?.querySelector('.w-e-list-marker')
+    const outlineButton = root?.querySelector('button.w-e-list-marker')
+    const table = root?.querySelector('table')
+
+    if (!root || !heading || !marker || !outlineButton || !table) {
+      throw new Error('editor content styles regression fixture was not rendered')
+    }
+
+    const headingStyle = getComputedStyle(heading)
+    const markerStyle = getComputedStyle(marker)
+    const outlineButtonStyle = getComputedStyle(outlineButton)
+    const tableStyle = getComputedStyle(table)
+
+    return {
+      headingMarginTop: headingStyle.marginTop,
+      headingFontWeight: headingStyle.fontWeight,
+      headingLineHeight: headingStyle.lineHeight,
+      markerText: marker.textContent,
+      markerDisplay: markerStyle.display,
+      outlineButtonBorderWidth: outlineButtonStyle.borderWidth,
+      outlineButtonFontSize: outlineButtonStyle.fontSize,
+      tableBorderCollapse: tableStyle.borderCollapse,
+    }
+  })
+
+  expect(styles.headingMarginTop).toBe('20px')
+  expect(styles.headingFontWeight).toBe('700')
+  expect(styles.headingLineHeight).not.toBe('1px')
+  expect(styles.markerText).toBe('•')
+  expect(styles.markerDisplay).not.toBe('none')
+  expect(styles.outlineButtonBorderWidth).toBe('0px')
+  expect(styles.outlineButtonFontSize).not.toBe('1px')
+  expect(styles.tableBorderCollapse).toBe('collapse')
+})
+
 test.describe('Multi Editors', () => {
   test('edits each editor independently', async ({ page }) => {
     await page.goto('/examples/multi-editors.html')


### PR DESCRIPTION
Closes #988

## Summary

- Scope editor content defaults under .w-e-text-container [data-slate-editor].
- Keep headings, lists, buttons, tables, code, and media predictable under host CSS resets.
- Add a Playwright regression scenario and a patch changeset.

## Verification

- Core tests: 304 passed.
- Editor tests: 24 passed.
- Full pnpm build passed.
- E2E source lint and release-group checks passed.
- Browser smoke verification passed with heading, list marker, outline button, and table assertions.

Documentation PR: https://github.com/wangeditor-next/docs/pull/19