### PR TITLE
feat(plugin-link-card): support converting cards to links

### DIFF
--- a/.changeset/warm-links-convert.md
+++ b/.changeset/warm-links-convert.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/plugin-link-card': minor
+---
+
+Add link-card to link conversion and preserve link targets during card conversion.

--- a/packages/basic-modules/__tests__/link/helper.test.ts
+++ b/packages/basic-modules/__tests__/link/helper.test.ts
@@ -3,7 +3,7 @@
  * @author wangfupeng
  */
 
-import { Editor, Transforms } from 'slate'
+import { Editor, Node, Transforms } from 'slate'
 
 import createEditor from '../../../../tests/utils/create-editor'
 import { insertLink, isMenuDisabled, updateLink } from '../../src/modules/link/helper'
@@ -289,7 +289,7 @@ describe('link module helper', () => {
 
     expect(links).toHaveLength(1)
     expect(links[0].url).toBe(newUrl)
-    expect(Editor.string(links[0])).toBe('updated link')
+    expect(Node.string(links[0])).toBe('updated link')
   })
 
   it('update link should normalize whitespace in url', async () => {

--- a/packages/basic-modules/__tests__/link/helper.test.ts
+++ b/packages/basic-modules/__tests__/link/helper.test.ts
@@ -271,6 +271,27 @@ describe('link module helper', () => {
     expect(linkElem.url).toBe(newUrl)
   })
 
+  it('updates link text and url together', async () => {
+    editor.select(startLocation)
+
+    const url = 'https://wangeditor-next.github.io/docs/'
+    const newUrl = 'https://wangeditor-next.github.io/docs/index.html'
+
+    await insertLink(editor, 'hello', url)
+    editor.select({
+      path: [0, 1, 0],
+      offset: 3,
+    })
+
+    await updateLink(editor, 'updated link', newUrl)
+
+    const links = editor.getElemsByTypePrefix('link')
+
+    expect(links).toHaveLength(1)
+    expect(links[0].url).toBe(newUrl)
+    expect(Editor.string(links[0])).toBe('updated link')
+  })
+
   it('update link should normalize whitespace in url', async () => {
     editor.select(startLocation)
 

--- a/packages/basic-modules/__tests__/link/menu/edit-link-menu.test.ts
+++ b/packages/basic-modules/__tests__/link/menu/edit-link-menu.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { waitFor } from '@testing-library/dom'
-import { Editor } from 'slate'
+import { Editor, Node } from 'slate'
 
 import createEditor from '../../../../../tests/utils/create-editor'
 import EditLink from '../../../src/modules/link/menu/EditLink'
@@ -70,7 +70,7 @@ describe('edit link menu', () => {
     expect(node.url).toBe(linkNode.url)
   })
 
-  it('get modal content elem', () => {
+  it('get modal content elem', async () => {
     const spy = vi.spyOn(editor, 'hidePanelOrModal')
 
     editor.select(startLocation)
@@ -79,6 +79,7 @@ describe('edit link menu', () => {
       path: [0, 1, 0],
       offset: 1,
     })
+    vi.spyOn(editor, 'restoreSelection').mockImplementation(() => {})
 
     const elem = menu.getModalContentElem(editor)
 
@@ -97,7 +98,9 @@ describe('edit link menu', () => {
 
     expect(elem.tagName).toBe('DIV')
     expect(spy).toHaveBeenCalled()
-    expect(Editor.string(editor.getElemsByTypePrefix('link')[0])).toBe('updated link')
+    await waitFor(() => {
+      expect(Node.string(editor.getElemsByTypePrefix('link')[0])).toBe('updated link')
+    })
   })
 
   it('focus input asynchronously', async () => {
@@ -108,7 +111,7 @@ describe('edit link menu', () => {
     const elem = menu.getModalContentElem(editor)
 
     document.body.appendChild(elem)
-    const inputSrc = elem.querySelector(`#${(menu as any).urlInputId}`) as HTMLInputElement
+    const inputSrc = elem.querySelector(`#${(menu as any).textInputId}`) as HTMLInputElement
 
     vi.spyOn(inputSrc, 'focus')
 

--- a/packages/basic-modules/__tests__/link/menu/edit-link-menu.test.ts
+++ b/packages/basic-modules/__tests__/link/menu/edit-link-menu.test.ts
@@ -72,21 +72,32 @@ describe('edit link menu', () => {
 
   it('get modal content elem', () => {
     const spy = vi.spyOn(editor, 'hidePanelOrModal')
-    const elem = menu.getModalContentElem(editor)
 
     editor.select(startLocation)
-    editor.insertText('test')
+    editor.insertNode(linkNode)
+    editor.select({
+      path: [0, 1, 0],
+      offset: 1,
+    })
+
+    const elem = menu.getModalContentElem(editor)
+
     document.body.appendChild(elem)
 
+    const textInputId = document.getElementById((menu as any).textInputId) as HTMLInputElement
     const urlInputId = document.getElementById((menu as any).urlInputId) as HTMLInputElement
     const button = document.getElementById((menu as any).buttonId) as HTMLButtonElement
 
+    expect(textInputId.value).toBe('xxx')
+    expect(urlInputId.value).toBe(linkNode.url)
+
+    textInputId.value = 'updated link'
     urlInputId.value = 'https://wangeditor-next.github.io/demo/'
-    editor.select(startLocation)
     button.click()
 
     expect(elem.tagName).toBe('DIV')
     expect(spy).toHaveBeenCalled()
+    expect(Editor.string(editor.getElemsByTypePrefix('link')[0])).toBe('updated link')
   })
 
   it('focus input asynchronously', async () => {

--- a/packages/basic-modules/src/modules/link/helper.ts
+++ b/packages/basic-modules/src/modules/link/helper.ts
@@ -4,7 +4,7 @@
  */
 
 import { DomEditor, IDomEditor } from '@wangeditor-next/core'
-import { Editor, Range, Transforms } from 'slate'
+import { Editor, Node, Range, Transforms } from 'slate'
 
 import { replaceSymbols } from '../../utils/util'
 import { LinkElement } from './custom-types'
@@ -195,10 +195,26 @@ export async function updateLink(editor: IDomEditor, text: string, url: string) 
 
   if (!parsedUrl) { return }
 
-  // 修改链接
-  const props: Partial<LinkElement> = { url: replaceSymbols(parsedUrl) }
+  const linkElem = DomEditor.getSelectedNodeByType(editor, 'link') as LinkElement | null
 
-  Transforms.setNodes(editor, props, {
-    match: n => DomEditor.checkNodeType(n, 'link'),
+  if (linkElem == null) { return }
+
+  const linkPath = DomEditor.findPath(editor, linkElem)
+  const parsedUrlWithSymbols = replaceSymbols(parsedUrl)
+
+  if (!text || text === Node.string(linkElem)) {
+    Transforms.setNodes(editor, { url: parsedUrlWithSymbols }, { at: linkPath })
+    return
+  }
+
+  const updatedLink: LinkElement = {
+    ...linkElem,
+    url: parsedUrlWithSymbols,
+    children: [{ text }],
+  }
+
+  Editor.withoutNormalizing(editor, () => {
+    Transforms.removeNodes(editor, { at: linkPath })
+    Transforms.insertNodes(editor, updatedLink, { at: linkPath })
   })
 }

--- a/packages/basic-modules/src/modules/link/menu/EditLink.ts
+++ b/packages/basic-modules/src/modules/link/menu/EditLink.ts
@@ -39,6 +39,8 @@ class EditLinkMenu implements IModalMenu {
 
   private $content: Dom7Array | null = null
 
+  private textInputId = genDomID()
+
   private urlInputId = genDomID()
 
   private buttonId = genDomID()
@@ -89,9 +91,11 @@ class EditLinkMenu implements IModalMenu {
   }
 
   getModalContentElem(editor: IDomEditor): DOMElement {
-    const { urlInputId, buttonId } = this
+    const { textInputId, urlInputId, buttonId } = this
 
     // 获取 input button elem
+    const [textContainerElem, inputTextElem] = genModalInputElems(t('link.text'), textInputId)
+    const $inputText = $(inputTextElem)
     const [urlContainerElem, inputUrlElem] = genModalInputElems(t('link.url'), urlInputId)
     const $inputUrl = $(inputUrlElem)
     const [buttonContainerElem] = genModalButtonElems(buttonId, t('common.ok'))
@@ -105,8 +109,7 @@ class EditLinkMenu implements IModalMenu {
         e.preventDefault()
         editor.restoreSelection() // 还原选区
 
-        const n = DomEditor.getSelectedNodeByType(editor, 'link')
-        const text = n ? Node.string(n) : ''
+        const text = $content.find(`#${textInputId}`).val()
         const url = $content.find(`#${urlInputId}`).val()
 
         updateLink(editor, text, url) // 修改链接
@@ -122,18 +125,22 @@ class EditLinkMenu implements IModalMenu {
 
     $content.empty() // 先清空内容
 
-    // append input and button
+    // append inputs and button
+    $content.append(textContainerElem)
     $content.append(urlContainerElem)
     $content.append(buttonContainerElem)
 
     // 设置 input val
+    const linkElem = this.getSelectedLinkElem(editor)
+    const text = linkElem ? Node.string(linkElem) : ''
     const url = this.getValue(editor)
 
+    $inputText.val(text)
     $inputUrl.val(url)
 
     // focus 一个 input（异步，此时 DOM 尚未渲染）
     setTimeout(() => {
-      $inputUrl.focus()
+      $inputText.focus()
     })
 
     return $content[0]

--- a/packages/plugin-link-card/README-en.md
+++ b/packages/plugin-link-card/README-en.md
@@ -43,6 +43,10 @@ const editorConfig: Partial<IEditorConfig> = {
         'convertToLinkCard' // add 'Convert to link-card' menu
       ],
     },
+    // hover menus when a link card is selected
+    'link-card': {
+      menuKeys: ['convertToLink'],
+    },
   },
 
   MENU_CONF: {
@@ -75,6 +79,8 @@ Then create editor and toolbar, you will use `editorConfig`.
 ### Render HTML
 
 You will get a link-card's HTML format like this
+
+When the source link has a `target`, `data-target` is also output and restored by Convert to Link.
 
 ```html
 <div data-w-e-type="link-card" data-w-e-is-void data-title="Baidu News" data-link="http://news.baidu.com/"

--- a/packages/plugin-link-card/README.md
+++ b/packages/plugin-link-card/README.md
@@ -42,6 +42,10 @@ const editorConfig: Partial<IEditorConfig> = {
         'convertToLinkCard' // 增加 '转为链接卡片'菜单
       ],
     },
+    // 选中链接卡片时，要弹出的菜单
+    'link-card': {
+      menuKeys: ['convertToLink'],
+    },
   },
 
   MENU_CONF: {
@@ -75,6 +79,8 @@ const editorConfig: Partial<IEditorConfig> = {
 ### 显示 HTML
 
 一个 link-card 节点产出的 HTML 格式如下
+
+如果原链接设置了 `target`，会额外输出并在“转为链接”时恢复 `data-target` 属性。
 
 ```html
 <div data-w-e-type="link-card" data-w-e-is-void data-title="百度新闻" data-link="http://news.baidu.com/"

--- a/packages/plugin-link-card/__tests__/elem-parse-html.test.ts
+++ b/packages/plugin-link-card/__tests__/elem-parse-html.test.ts
@@ -1,0 +1,37 @@
+import { $ } from 'dom7'
+
+import elemToHtmlConf from '../src/module/elem-to-html'
+import parseHtmlConf from '../src/module/parse-elem-html'
+
+describe('plugin-link-card elem html', () => {
+  it('preserves target through slate to html to slate', () => {
+    const elem = {
+      type: 'link-card',
+      title: 'wangEditor',
+      link: 'https://www.wangeditor.com/',
+      target: '_self',
+      iconImgSrc: 'https://www.wangeditor.com/icon.png',
+      children: [{ text: '' }],
+    }
+
+    const html = elemToHtmlConf.elemToHtml(elem, '')
+    const parsed = parseHtmlConf.parseElemHtml($(html)[0], [], {} as any)
+
+    expect(html).toContain('data-target="_self"')
+    expect(parsed).toEqual(elem)
+  })
+
+  it('keeps historical cards without target structurally unchanged', () => {
+    const html =
+      '<div data-w-e-type="link-card" data-w-e-is-void data-title="title" data-link="https://example.com" data-iconImgSrc=""></div>'
+    const parsed = parseHtmlConf.parseElemHtml($(html)[0], [], {} as any)
+
+    expect(parsed).toEqual({
+      type: 'link-card',
+      title: 'title',
+      link: 'https://example.com',
+      iconImgSrc: '',
+      children: [{ text: '' }],
+    })
+  })
+})

--- a/packages/plugin-link-card/__tests__/menu.test.ts
+++ b/packages/plugin-link-card/__tests__/menu.test.ts
@@ -1,0 +1,83 @@
+import { Editor, Transforms } from 'slate'
+
+import createEditor from '../../../tests/utils/create-editor'
+import ConvertToLink from '../src/module/menu/ConvertToLink'
+import ConvertToLinkCard from '../src/module/menu/ConvertToLinkCard'
+import withLinkCard from '../src/module/plugin'
+
+describe('plugin-link-card menus', () => {
+  it('converts a link into a link card without losing target', async () => {
+    const editor = withLinkCard(
+      createEditor({
+        config: {
+          MENU_CONF: {
+            convertToLinkCard: {
+              async getLinkCardInfo() {
+                return { title: 'wangEditor', iconImgSrc: '' }
+              },
+            },
+          },
+        },
+      })
+    )
+
+    editor.children = [
+      {
+        type: 'paragraph',
+        children: [
+          {
+            type: 'link',
+            url: 'https://www.wangeditor.com/',
+            target: '_self',
+            children: [{ text: 'wangEditor' }],
+          },
+        ],
+      },
+    ]
+    editor.select({ path: [0, 0, 0], offset: 1 })
+
+    const menu = new ConvertToLinkCard()
+
+    await menu.exec(editor, '')
+
+    const linkCard = editor.children[0] as any
+
+    expect(linkCard).toMatchObject({
+      type: 'link-card',
+      title: 'wangEditor',
+      link: 'https://www.wangeditor.com/',
+      target: '_self',
+    })
+  })
+
+  it('converts a selected link card into a paragraph containing a link', () => {
+    const editor = withLinkCard(createEditor())
+    const linkCard = {
+      type: 'link-card',
+      title: 'wangEditor',
+      link: 'https://www.wangeditor.com/',
+      target: '_self',
+      children: [{ text: '' }],
+    }
+
+    Transforms.insertNodes(editor, linkCard, { at: [0] })
+    Transforms.select(editor, [0])
+
+    const menu = new ConvertToLink()
+
+    expect(menu.isDisabled(editor)).toBe(false)
+    menu.exec(editor, '')
+
+    const paragraph = editor.children[0] as any
+    const link = paragraph.children[0]
+
+    expect(paragraph.type).toBe('paragraph')
+    expect(link).toEqual({
+      type: 'link',
+      url: 'https://www.wangeditor.com/',
+      target: '_self',
+      children: [{ text: 'wangEditor' }],
+    })
+    expect(Editor.string(link)).toBe('wangEditor')
+  })
+})

--- a/packages/plugin-link-card/__tests__/menu.test.ts
+++ b/packages/plugin-link-card/__tests__/menu.test.ts
@@ -1,4 +1,4 @@
-import { Editor, Transforms } from 'slate'
+import { Node, Transforms } from 'slate'
 
 import createEditor from '../../../tests/utils/create-editor'
 import ConvertToLink from '../src/module/menu/ConvertToLink'
@@ -21,6 +21,10 @@ describe('plugin-link-card menus', () => {
       })
     )
 
+    vi.spyOn(editor, 'getMenuConfig').mockReturnValue({
+      getLinkCardInfo: async () => ({ title: 'wangEditor', iconImgSrc: '' }),
+    } as any)
+
     editor.children = [
       {
         type: 'paragraph',
@@ -40,7 +44,7 @@ describe('plugin-link-card menus', () => {
 
     await menu.exec(editor, '')
 
-    const linkCard = editor.children[0] as any
+    const linkCard = editor.getElemsByTypePrefix('link-card')[0] as any
 
     expect(linkCard).toMatchObject({
       type: 'link-card',
@@ -69,15 +73,15 @@ describe('plugin-link-card menus', () => {
     menu.exec(editor, '')
 
     const paragraph = editor.children[0] as any
-    const link = paragraph.children[0]
+    const link = editor.getElemsByTypePrefix('link')[0]
 
     expect(paragraph.type).toBe('paragraph')
-    expect(link).toEqual({
+    expect(link).toMatchObject({
       type: 'link',
       url: 'https://www.wangeditor.com/',
       target: '_self',
       children: [{ text: 'wangEditor' }],
     })
-    expect(Editor.string(link)).toBe('wangEditor')
+    expect(Node.string(link)).toBe('wangEditor')
   })
 })

--- a/packages/plugin-link-card/src/module/custom-types.ts
+++ b/packages/plugin-link-card/src/module/custom-types.ts
@@ -12,6 +12,7 @@ export type LinkCardElement = {
   type: 'link-card'
   title: string
   link: string
+  target?: string
   iconImgSrc?: string
   children: EmptyText[] // void 元素必须有一个空 text
 }

--- a/packages/plugin-link-card/src/module/elem-to-html.ts
+++ b/packages/plugin-link-card/src/module/elem-to-html.ts
@@ -9,8 +9,9 @@ import { LinkCardElement } from './custom-types'
 
 // 生成 html 的函数
 function linkCardToHtml(elem: SlateElement, _childrenHtml: string): string {
-  const { title = '', link = '', iconImgSrc = '' } = elem as LinkCardElement
-  const html = `<div data-w-e-type="link-card" data-w-e-is-void data-title="${title}" data-link="${link}" data-iconImgSrc="${iconImgSrc}">
+  const { title = '', link = '', target, iconImgSrc = '' } = elem as LinkCardElement
+  const targetAttr = target ? ` data-target="${target}"` : ''
+  const html = `<div data-w-e-type="link-card" data-w-e-is-void data-title="${title}" data-link="${link}"${targetAttr} data-iconImgSrc="${iconImgSrc}">
     <div class="info-container">
       <div class="title-container"><p>${title}</p></div>
       <div class="link-container"><span>${link}</span></div>

--- a/packages/plugin-link-card/src/module/index.ts
+++ b/packages/plugin-link-card/src/module/index.ts
@@ -8,7 +8,7 @@ import './local' // 多语言
 import { IModuleConf } from '@wangeditor-next/editor'
 
 import elemToHtmlConf from './elem-to-html'
-import { convertToLinkCardMenuConf } from './menu/index'
+import { convertToLinkCardMenuConf, convertToLinkMenuConf } from './menu/index'
 import parseHtmlConf from './parse-elem-html'
 import withLinkCard from './plugin'
 import renderElemConf from './render-elem'
@@ -18,7 +18,7 @@ const module: Partial<IModuleConf> = {
   renderElems: [renderElemConf],
   elemsToHtml: [elemToHtmlConf],
   parseElemsHtml: [parseHtmlConf],
-  menus: [convertToLinkCardMenuConf],
+  menus: [convertToLinkCardMenuConf, convertToLinkMenuConf],
 }
 
 export default module

--- a/packages/plugin-link-card/src/module/local.ts
+++ b/packages/plugin-link-card/src/module/local.ts
@@ -8,6 +8,7 @@ import { i18nAddResources } from '@wangeditor-next/editor'
 i18nAddResources('en', {
   linkCard: {
     toCard: 'To Card',
+    toLink: 'To Link',
     // delete: 'Delete',
   },
 })
@@ -15,6 +16,7 @@ i18nAddResources('en', {
 i18nAddResources('zh-CN', {
   linkCard: {
     toCard: '转为卡片',
+    toLink: '转为链接',
     // delete: '删除',
   },
 })

--- a/packages/plugin-link-card/src/module/menu/ConvertToLink.ts
+++ b/packages/plugin-link-card/src/module/menu/ConvertToLink.ts
@@ -8,7 +8,6 @@ import {
   IButtonMenu,
   IDomEditor,
   SlateEditor,
-  SlateNode,
   SlateTransforms,
   t,
 } from '@wangeditor-next/editor'
@@ -54,7 +53,18 @@ class ConvertToLink implements IButtonMenu {
       return
     }
 
-    const linkCardPath = DomEditor.findPath(editor, linkCardElem)
+    const [linkCardEntry] = SlateEditor.nodes(editor, {
+      at: editor.selection!,
+      match: node => DomEditor.checkNodeType(node, 'link-card'),
+      mode: 'lowest',
+      universal: true,
+    })
+
+    if (linkCardEntry == null) {
+      return
+    }
+
+    const linkCardPath = linkCardEntry[1]
     const { link: url, title, target } = linkCardElem
     const linkElem: LinkElement = {
       type: 'link',
@@ -69,10 +79,21 @@ class ConvertToLink implements IButtonMenu {
       SlateTransforms.insertNodes(editor, paragraph, { at: linkCardPath })
     })
 
-    SlateTransforms.select(editor, {
-      anchor: { path: [...linkCardPath, 0, 0], offset: 0 },
-      focus: { path: [...linkCardPath, 0, 0], offset: SlateNode.string(linkElem).length },
+    const [linkEntry] = SlateEditor.nodes(editor, {
+      at: [],
+      match: node => node === linkElem,
+      mode: 'all',
+      universal: true,
     })
+
+    if (linkEntry != null) {
+      const linkPath = linkEntry[1]
+
+      SlateTransforms.select(editor, {
+        anchor: SlateEditor.start(editor, linkPath),
+        focus: SlateEditor.end(editor, linkPath),
+      })
+    }
   }
 }
 

--- a/packages/plugin-link-card/src/module/menu/ConvertToLink.ts
+++ b/packages/plugin-link-card/src/module/menu/ConvertToLink.ts
@@ -1,0 +1,79 @@
+/**
+ * @description convert link-card elem to link
+ * @author wangfupeng
+ */
+
+import {
+  DomEditor,
+  IButtonMenu,
+  IDomEditor,
+  SlateEditor,
+  SlateNode,
+  SlateTransforms,
+  t,
+} from '@wangeditor-next/editor'
+
+import { LinkCardElement, LinkElement } from '../custom-types'
+
+class ConvertToLink implements IButtonMenu {
+  readonly title = t('linkCard.toLink')
+
+  readonly iconSvg = ''
+
+  readonly tag = 'button'
+
+  private getSelectedLinkCardElem(editor: IDomEditor): LinkCardElement | null {
+    const node = DomEditor.getSelectedNodeByType(editor, 'link-card')
+
+    if (node == null) {
+      return null
+    }
+    return node as LinkCardElement
+  }
+
+  getValue(_editor: IDomEditor): string | boolean {
+    return ''
+  }
+
+  isActive(_editor: IDomEditor): boolean {
+    return false
+  }
+
+  isDisabled(editor: IDomEditor): boolean {
+    return editor.selection == null || this.getSelectedLinkCardElem(editor) == null
+  }
+
+  exec(editor: IDomEditor, _value: string | boolean) {
+    if (this.isDisabled(editor)) {
+      return
+    }
+
+    const linkCardElem = this.getSelectedLinkCardElem(editor)
+
+    if (linkCardElem == null) {
+      return
+    }
+
+    const linkCardPath = DomEditor.findPath(editor, linkCardElem)
+    const { link: url, title, target } = linkCardElem
+    const linkElem: LinkElement = {
+      type: 'link',
+      url,
+      ...(target ? { target } : {}),
+      children: [{ text: title || url }],
+    }
+    const paragraph = { type: 'paragraph', children: [linkElem] }
+
+    SlateEditor.withoutNormalizing(editor, () => {
+      SlateTransforms.removeNodes(editor, { at: linkCardPath })
+      SlateTransforms.insertNodes(editor, paragraph, { at: linkCardPath })
+    })
+
+    SlateTransforms.select(editor, {
+      anchor: { path: [...linkCardPath, 0, 0], offset: 0 },
+      focus: { path: [...linkCardPath, 0, 0], offset: SlateNode.string(linkElem).length },
+    })
+  }
+}
+
+export default ConvertToLink

--- a/packages/plugin-link-card/src/module/menu/ConvertToLinkCard.ts
+++ b/packages/plugin-link-card/src/module/menu/ConvertToLinkCard.ts
@@ -62,7 +62,18 @@ class ConvertToLinkCard implements IButtonMenu {
 
     const { url, target } = linkElem
     const text = SlateNode.string(linkElem)
-    const linkPathRef = SlateEditor.pathRef(editor, DomEditor.findPath(editor, linkElem))
+    const [linkEntry] = SlateEditor.nodes(editor, {
+      at: editor.selection!,
+      match: node => DomEditor.checkNodeType(node, 'link'),
+      mode: 'lowest',
+      universal: true,
+    })
+
+    if (linkEntry == null) {
+      return
+    }
+
+    const linkPathRef = SlateEditor.pathRef(editor, linkEntry[1])
 
     try {
       const { title, iconImgSrc } = await getLinkCardInfo(text, url) // 异步生成 link-card 信息

--- a/packages/plugin-link-card/src/module/menu/ConvertToLinkCard.ts
+++ b/packages/plugin-link-card/src/module/menu/ConvertToLinkCard.ts
@@ -6,6 +6,7 @@
 import {
   DomEditor,
   IButtonMenu, IDomEditor,
+  SlateEditor,
   SlateNode,
   SlateTransforms,
   t,
@@ -59,13 +60,15 @@ class ConvertToLinkCard implements IButtonMenu {
 
     if (typeof getLinkCardInfo !== 'function') { return }
 
-    const { url } = linkElem
+    const { url, target } = linkElem
     const text = SlateNode.string(linkElem)
+    const linkPathRef = SlateEditor.pathRef(editor, DomEditor.findPath(editor, linkElem))
 
     try {
       const { title, iconImgSrc } = await getLinkCardInfo(text, url) // 异步生成 link-card 信息
+      const linkPath = linkPathRef.current
 
-      const linkPath = DomEditor.findPath(editor, linkElem)
+      if (linkPath == null) { return }
 
       SlateTransforms.removeNodes(editor, { at: linkPath })
       SlateTransforms.splitNodes(editor, { always: true })
@@ -74,6 +77,7 @@ class ConvertToLinkCard implements IButtonMenu {
         type: 'link-card',
         link: url,
         title,
+        ...(target ? { target } : {}),
         iconImgSrc,
         children: [{ text: '' }],
       }
@@ -81,6 +85,8 @@ class ConvertToLinkCard implements IButtonMenu {
       SlateTransforms.insertNodes(editor, linkCard)
     } catch (err) {
       console.error('Convert to link-cart error', err)
+    } finally {
+      linkPathRef.unref()
     }
   }
 }

--- a/packages/plugin-link-card/src/module/menu/index.ts
+++ b/packages/plugin-link-card/src/module/menu/index.ts
@@ -4,6 +4,7 @@
  */
 
 import { genConvertToLinkCardConfig } from './config'
+import ConvertToLink from './ConvertToLink'
 import ConvertToLinkCard from './ConvertToLinkCard'
 
 export const convertToLinkCardMenuConf = {
@@ -15,4 +16,11 @@ export const convertToLinkCardMenuConf = {
   // 默认的菜单菜单配置，将存储在 editorConfig.MENU_CONF[key] 中
   // 创建编辑器时，可通过 editorConfig.MENU_CONF[key] = {...} 来修改
   config: genConvertToLinkCardConfig(),
+}
+
+export const convertToLinkMenuConf = {
+  key: 'convertToLink',
+  factory() {
+    return new ConvertToLink()
+  },
 }

--- a/packages/plugin-link-card/src/module/parse-elem-html.ts
+++ b/packages/plugin-link-card/src/module/parse-elem-html.ts
@@ -15,12 +15,14 @@ function parseHtml(
 ): SlateElement {
   const link = elem.getAttribute('data-link') || ''
   const title = elem.getAttribute('data-title') || ''
+  const target = elem.getAttribute('data-target') || undefined
   const iconImgSrc = elem.getAttribute('data-iconImgSrc') || ''
 
   return {
     type: 'link-card',
     link,
     title,
+    ...(target ? { target } : {}),
     iconImgSrc,
     children: [{ text: '' }], // void node 必须有一个空白 text
   } as LinkCardElement


### PR DESCRIPTION
## Summary
- add opt-in link-card to link conversion and hoverbar configuration
- allow editing link text and URL together
- preserve link targets through conversion and HTML serialization

## Verification
- git diff --check
- scoped ESLint
- esbuild syntax transpilation

## Test limitations
- scoped Vitest remained stalled during runner startup in the local environment
- direct TypeScript checks were blocked by existing @uppy/utils and Vite/Rollup declaration resolution errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to convert link cards back into standard links.
  * Link-card conversions preserve link targets and display text.
  * Link editing now supports updating both link text and URL.
* **Bug Fixes**
  * Fixed link updates affecting unintended links.
  * Preserved link targets during HTML conversion and round trips.
* **Documentation**
  * Added configuration and conversion guidance for link cards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->