### PR TITLE
fix(release): isolate link-card package versioning

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -16,7 +16,6 @@
       "@wangeditor-next/plugin-ctrl-enter",
       "@wangeditor-next/plugin-float-image",
       "@wangeditor-next/plugin-formula",
-      "@wangeditor-next/plugin-link-card",
       "@wangeditor-next/plugin-markdown",
       "@wangeditor-next/plugin-mention",
       "@wangeditor-next/table-module",
@@ -25,6 +24,9 @@
       "@wangeditor-next/yjs",
       "@wangeditor-next/yjs-for-react",
       "@wangeditor-next/yjs-for-vue"
+    ],
+    [
+      "@wangeditor-next/plugin-link-card"
     ]
   ],
   "linked": [],

--- a/docs/publish.md
+++ b/docs/publish.md
@@ -30,17 +30,17 @@ Release 与 `Repair Release Provenance` 都只能使用 GitHub Environment
 
 ## 版本关联策略
 
-所有 `packages/*` 下、名称为 `@wangeditor-next/*` 的公开运行时包属于同一个 Changesets
-`fixed` 组。这包含 `core`、`editor`、Vue 2/Vue 3/React 适配器、内置模块、可选插件和
-Yjs 包。一个用户可见的变更只需要在直接受影响的包写 changeset；Changesets 会把整个组
-提升到同一个产品版本，并在一次 release PR 中发布。
+所有 `packages/*` 下、名称为 `@wangeditor-next/*` 的公开运行时包都属于 Changesets 的
+`fixed` 组。`core`、`editor`、Vue 2/Vue 3/React 适配器、内置模块和 Yjs 包属于主同步组；
+`plugin-link-card` 单独成组，使它的功能变更不会抬高其他包的版本。一个用户可见的变更只
+需要在直接受影响的包写 changeset；Changesets 会在一次 release PR 中按组提升版本并发布。
 
 当前 `6.1.0` 已经发布，不能变更其 npm 包或 immutable source tag。它仅包含包同步，迁入后的
-首次共同发布使用 `6.1.1`：`editor`、`core` 和全部官方包都会是 `6.1.1`。之后每次发布都遵守相同规则。
+首次共同发布使用 `6.1.1`：`editor`、`core` 和主同步组中的官方包都会是 `6.1.1`。之后每次发布都遵守按组同步的规则。
 
 `pnpm check:release-group` 会校验新增公开包不会漏出该组。新增公开运行时包时必须同时：
 
-1. 放入 `.changeset/config.json` 的固定组。
+1. 放入 `.changeset/config.json` 的合适固定组；若不应与主产品同步升级，则单独成组。
 2. 添加 workspace 依赖、构建和框架集成测试。
 3. 确认其 package source tag 能由本仓库 release workflow 创建。
 

--- a/scripts/check-release-package-group.js
+++ b/scripts/check-release-package-group.js
@@ -53,8 +53,8 @@ const fixedSet = new Set(fixedPackages)
 const expectedSet = new Set(publicRuntimePackages)
 const errors = []
 
-if (fixedGroups.length !== 1) {
-  errors.push('Changesets must define exactly one fixed group for public runtime packages')
+if (fixedGroups.length === 0) {
+  errors.push('Changesets must define at least one fixed group for public runtime packages')
 }
 
 if (fixedSet.size !== fixedPackages.length) {
@@ -64,12 +64,25 @@ if (fixedSet.size !== fixedPackages.length) {
 const missing = publicRuntimePackages.filter(name => !fixedSet.has(name))
 const unexpected = fixedPackages.filter(name => !expectedSet.has(name))
 
+const packageGroupCounts = new Map()
+for (const packageName of fixedPackages) {
+  packageGroupCounts.set(packageName, (packageGroupCounts.get(packageName) || 0) + 1)
+}
+
+const duplicateGroups = [...packageGroupCounts]
+  .filter(([, count]) => count > 1)
+  .map(([name]) => name)
+
 if (missing.length > 0) {
   errors.push(`Public runtime packages missing from the fixed group: ${missing.join(', ')}`)
 }
 
 if (unexpected.length > 0) {
   errors.push(`Non-runtime packages in the fixed group: ${unexpected.join(', ')}`)
+}
+
+if (duplicateGroups.length > 0) {
+  errors.push(`Public runtime packages must belong to only one fixed group: ${duplicateGroups.join(', ')}`)
 }
 
 for (const { packageName, dependencyType, name, range } of internalDependencyRanges) {

--- a/scripts/check-release-package-group.js
+++ b/scripts/check-release-package-group.js
@@ -65,6 +65,7 @@ const missing = publicRuntimePackages.filter(name => !fixedSet.has(name))
 const unexpected = fixedPackages.filter(name => !expectedSet.has(name))
 
 const packageGroupCounts = new Map()
+
 for (const packageName of fixedPackages) {
   packageGroupCounts.set(packageName, (packageGroupCounts.get(packageName) || 0) + 1)
 }


### PR DESCRIPTION
## Summary\n\n- Keep the main runtime packages in the synchronized fixed group.\n- Isolate @wangeditor-next/plugin-link-card in its own fixed group so its feature releases do not bump unrelated packages.\n- Update release-group validation and publishing documentation.\n\n## Verification\n\n- node scripts/check-release-package-group.js\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Management**
  * Link card plugin releases are now versioned independently from the main editor packages.
  * Release validation now supports multiple coordinated package groups and prevents packages from appearing in more than one group.
* **Documentation**
  * Updated versioning guidance to explain synchronized package groups and requirements for adding new public runtime packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->