### PR TITLE
feat(table): support media blocks in rich cells

### DIFF
--- a/.changeset/table-cells-handle-media.md
+++ b/.changeset/table-cells-handle-media.md
@@ -1,0 +1,7 @@
+---
+'@wangeditor-next/table-module': minor
+'@wangeditor-next/basic-modules': patch
+'@wangeditor-next/video-module': patch
+---
+
+Allow table cells to preserve and accept video and code-block content while rejecting unsupported custom blocks and nested tables.

--- a/packages/basic-modules/__tests__/code-block/code-block-menu.test.ts
+++ b/packages/basic-modules/__tests__/code-block/code-block-menu.test.ts
@@ -75,7 +75,10 @@ describe('code-block menu', () => {
     Transforms.setNodes(editor, { type: 'header1' } as Partial<Element>)
     expect(menu.isDisabled(editor)).toBeTruthy() // 非 p pre ，则禁用
 
-    editor.insertNode({ type: 'pre', children: [{ type: 'code', children: [{ text: 'var' }], language: 'javascript' }] })
+    editor.insertNode({
+      type: 'pre',
+      children: [{ type: 'code', children: [{ text: 'var' }], language: 'javascript' }],
+    })
     expect(menu.isDisabled(editor)).toBeFalsy()
     // Transforms.removeNodes(editor, { mode: 'highest' }) // 移除 pre/code
   })
@@ -109,5 +112,40 @@ describe('code-block menu', () => {
     const codeLis = editor1.getElemsByTypePrefix('code')
 
     expect(codeLis.length).toBe(0)
+  })
+
+  it('exec - converts a block inside a table cell without moving it outside the table', () => {
+    const editor1 = createEditor({
+      html: '<table><tbody><tr><td><p>cell code</p></td></tr></tbody></table>',
+    })
+    const cell = () => (editor1.children[0] as any).children[0].children[0]
+
+    editor1.select({
+      path: [0, 0, 0, 0, 0],
+      offset: 4,
+    })
+
+    menu.exec(editor1, 'javascript')
+
+    expect(cell().children.map((node: any) => node.type)).toEqual(['pre', 'paragraph'])
+    expect(editor1.children.map((node: any) => node.type)).toContain('table')
+    expect(editor1.getHtml()).toContain(
+      '<pre><code class="language-javascript">cell code</code></pre>'
+    )
+
+    const editor2 = createEditor({ html: editor1.getHtml() })
+    const reparsedCell = () => (editor2.children[0] as any).children[0].children[0]
+
+    editor2.select({
+      path: [0, 0, 0, 0, 0, 0],
+      offset: 4,
+    })
+    menu.exec(editor2, '')
+
+    expect(reparsedCell().children.map((node: any) => node.type)).toEqual([
+      'paragraph',
+      'paragraph',
+    ])
+    expect(editor2.getHtml()).toContain('<p>cell code</p>')
   })
 })

--- a/packages/basic-modules/src/modules/code-block/menu/CodeBlockMenu.ts
+++ b/packages/basic-modules/src/modules/code-block/menu/CodeBlockMenu.ts
@@ -3,17 +3,17 @@
  * @author wangfupeng
  */
 
-import {
-  DomEditor, IButtonMenu, IDomEditor, t,
-} from '@wangeditor-next/core'
-import {
-  Editor, Element, Node, Transforms,
-} from 'slate'
+import { DomEditor, IButtonMenu, IDomEditor, t } from '@wangeditor-next/core'
+import { Editor, Element, Node, Path, Transforms } from 'slate'
 
 import { CODE_BLOCK_SVG } from '../../../constants/icon-svg'
 import { CodeElement } from '../custom-types'
 
-interface CodeSelectLangItem { text: string; value: string; selected?: boolean }
+interface CodeSelectLangItem {
+  text: string
+  value: string
+  selected?: boolean
+}
 
 class CodeBlockMenu implements IButtonMenu {
   readonly title = t('codeBlock.title')
@@ -25,13 +25,41 @@ class CodeBlockMenu implements IButtonMenu {
   private getSelectCodeElem(editor: IDomEditor): CodeElement | null {
     const codeNode = DomEditor.getSelectedNodeByType(editor, 'code')
 
-    if (codeNode == null) { return null }
+    if (codeNode == null) {
+      return null
+    }
     const preNode = DomEditor.getParentNode(editor, codeNode)
 
-    if (preNode == null) { return null }
-    if (DomEditor.getNodeType(preNode) !== 'pre') { return null }
+    if (preNode == null) {
+      return null
+    }
+    if (DomEditor.getNodeType(preNode) !== 'pre') {
+      return null
+    }
 
     return codeNode as CodeElement
+  }
+
+  private getSelectedTableCellBlock(editor: IDomEditor): [Element, Path] | null {
+    if (DomEditor.getSelectedNodeByType(editor, 'table-cell') == null) {
+      return null
+    }
+
+    const entry = Editor.above(editor, {
+      match: node => {
+        if (!Element.isElement(node)) {
+          return false
+        }
+
+        return node.type === 'paragraph' || node.type === 'pre'
+      },
+    })
+
+    if (entry == null) {
+      return null
+    }
+
+    return entry as [Element, Path]
   }
 
   /**
@@ -59,13 +87,17 @@ class CodeBlockMenu implements IButtonMenu {
   isDisabled(editor: IDomEditor): boolean {
     const { selection } = editor
 
-    if (selection == null) { return true }
+    if (selection == null) {
+      return true
+    }
 
     const selectedElems = DomEditor.getSelectedElems(editor)
 
     const hasVoid = selectedElems.some(elem => editor.isVoid(elem))
 
-    if (hasVoid) { return true }
+    if (hasVoid) {
+      return true
+    }
 
     const isMatch = selectedElems.some(elem => {
       const type = DomEditor.getNodeType(elem)
@@ -76,7 +108,9 @@ class CodeBlockMenu implements IButtonMenu {
       return false
     })
 
-    if (isMatch) { return false } // 匹配到，则 enable
+    if (isMatch) {
+      return false
+    } // 匹配到，则 enable
     return true // 否则 disable
   }
 
@@ -95,10 +129,25 @@ class CodeBlockMenu implements IButtonMenu {
   private changeToPlainText(editor: IDomEditor) {
     const elem = this.getSelectCodeElem(editor)
 
-    if (elem == null) { return }
+    if (elem == null) {
+      return
+    }
 
     // 获取 code 文本
     const str = Node.string(elem)
+
+    const tableCellBlock = this.getSelectedTableCellBlock(editor)
+
+    if (tableCellBlock) {
+      const [, path] = tableCellBlock
+      const pList = str.split('\n').map(s => {
+        return { type: 'paragraph', children: [{ text: s }] }
+      })
+
+      Transforms.removeNodes(editor, { at: path })
+      Transforms.insertNodes(editor, pList, { at: path })
+      return
+    }
 
     // 删除当前最高层级的节点，即 pre 节点
     Transforms.removeNodes(editor, { mode: 'highest' })
@@ -112,6 +161,26 @@ class CodeBlockMenu implements IButtonMenu {
   }
 
   private changeToCodeBlock(editor: IDomEditor, language: string) {
+    const tableCellBlock = this.getSelectedTableCellBlock(editor)
+
+    if (tableCellBlock) {
+      const [block, path] = tableCellBlock
+      const newPreNode = {
+        type: 'pre',
+        children: [
+          {
+            type: 'code',
+            language,
+            children: [{ text: Node.string(block) }],
+          },
+        ],
+      }
+
+      Transforms.removeNodes(editor, { at: path })
+      Transforms.insertNodes(editor, newPreNode, { at: path })
+      return
+    }
+
     // 汇总选中的最高层级节点的字符串
     const strArr: string[] = []
     const nodeEntries = Editor.nodes(editor, {
@@ -122,7 +191,9 @@ class CodeBlockMenu implements IButtonMenu {
     for (const nodeEntry of nodeEntries) {
       const [n] = nodeEntry
 
-      if (n) { strArr.push(Node.string(n)) }
+      if (n) {
+        strArr.push(Node.string(n))
+      }
     }
 
     // 删除选中的最高层级的节点

--- a/packages/table-module/__tests__/rich-content.test.ts
+++ b/packages/table-module/__tests__/rich-content.test.ts
@@ -11,6 +11,18 @@ const RICH_CELL_HTML = [
   '<p><br></p>',
 ].join('')
 
+const MEDIA_CELL_HTML = [
+  '<table><tbody><tr><td>',
+  '<p>正文</p>',
+  '<figure data-w-e-type="video" data-w-e-is-void>',
+  '<video poster="poster.png" controls="true" width="640" height="360">',
+  '<source src="https://example.com/demo.mp4" type="video/mp4"/>',
+  '</video></figure>',
+  '<pre><code>const answer = 42</code></pre>',
+  '</td></tr></tbody></table>',
+  '<p><br></p>',
+].join('')
+
 function getFirstCell(editor: ReturnType<typeof createEditor>) {
   return (editor.children[0] as any).children[0].children[0]
 }
@@ -23,12 +35,7 @@ describe('table rich cell content', () => {
   it('preserves paragraph and list blocks from HTML to Slate to HTML', () => {
     const editor = createEditor({ html: RICH_CELL_HTML })
 
-    expect(getCellBlockTypes(editor)).toEqual([
-      'paragraph',
-      'paragraph',
-      'list-item',
-      'list-item',
-    ])
+    expect(getCellBlockTypes(editor)).toEqual(['paragraph', 'paragraph', 'list-item', 'list-item'])
     expect(Node.string(getFirstCell(editor))).toContain('第一段')
 
     const output = editor.getHtml()
@@ -89,6 +96,44 @@ describe('table rich cell content', () => {
     ])
   })
 
+  it('preserves video and code blocks through table-cell HTML round-trip', () => {
+    const editor = createEditor({ html: MEDIA_CELL_HTML })
+    const cell = getFirstCell(editor)
+
+    expect(cell.children.map((child: any) => child.type)).toEqual(['paragraph', 'video', 'pre'])
+    expect(editor.getHtml()).toContain('data-w-e-type="video"')
+    expect(editor.getHtml()).toContain('<pre><code>const answer = 42</code></pre>')
+
+    editor.setHtml(editor.getHtml())
+
+    expect(getCellBlockTypes(editor)).toEqual(['paragraph', 'video', 'pre'])
+    expect(editor.getHtml()).toContain('https://example.com/demo.mp4')
+  })
+
+  it('allows inserting a video node as a block inside a table cell', () => {
+    const editor = createEditor({
+      html: '<table><tbody><tr><td><p>A</p></td></tr></tbody></table>',
+    })
+    const video = {
+      type: 'video',
+      src: 'https://example.com/insert.mp4',
+      poster: '',
+      width: 'auto',
+      height: 'auto',
+      align: 'center',
+      children: [{ text: '' }],
+    }
+
+    editor.selection = {
+      anchor: { path: [0, 0, 0, 0, 0], offset: 1 },
+      focus: { path: [0, 0, 0, 0, 0], offset: 1 },
+    }
+    editor.insertNode(video as any)
+
+    expect(getCellBlockTypes(editor)).toContain('video')
+    expect(editor.getHtml()).toContain('https://example.com/insert.mp4')
+  })
+
   it('canonicalizes legacy text-only cells before paths are created', () => {
     const legacyContent: any[] = [
       {
@@ -115,7 +160,9 @@ describe('table rich cell content', () => {
   })
 
   it('preserves pasted paragraph and list blocks inside a cell', () => {
-    const editor = createEditor({ html: '<table><tbody><tr><td><p>A</p></td></tr></tbody></table>' })
+    const editor = createEditor({
+      html: '<table><tbody><tr><td><p>A</p></td></tr></tbody></table>',
+    })
 
     editor.selection = {
       anchor: { path: [0, 0, 0, 0, 0], offset: 1 },
@@ -123,8 +170,12 @@ describe('table rich cell content', () => {
     }
     editor.insertData({
       getData(type: string) {
-        if (type === 'text/html') {return '<p>第二段</p><ul><li>粘贴列表</li></ul>'}
-        if (type === 'text/plain') {return '第二段\n粘贴列表'}
+        if (type === 'text/html') {
+          return '<p>第二段</p><ul><li>粘贴列表</li></ul>'
+        }
+        if (type === 'text/plain') {
+          return '第二段\n粘贴列表'
+        }
         return ''
       },
     } as DataTransfer)
@@ -139,20 +190,54 @@ describe('table rich cell content', () => {
     expect(editor.getHtml()).toContain('<ul><li>粘贴列表</li></ul>')
   })
 
-  it('rejects unsupported nested nodes from internal Slate fragments', () => {
+  it('preserves supported media blocks from internal Slate fragments', () => {
+    const editor = createEditor({
+      html: '<table><tbody><tr><td><p>A</p></td></tr></tbody></table>',
+    })
+    const supportedFragment = [
+      {
+        type: 'video',
+        src: 'https://example.com/pasted.mp4',
+        children: [{ text: '' }],
+      },
+      {
+        type: 'pre',
+        children: [{ type: 'code', language: '', children: [{ text: 'pasted code' }] }],
+      },
+    ]
+    const encodedFragment = window.btoa(encodeURIComponent(JSON.stringify(supportedFragment)))
+
+    editor.selection = {
+      anchor: { path: [0, 0, 0, 0, 0], offset: 1 },
+      focus: { path: [0, 0, 0, 0, 0], offset: 1 },
+    }
+    editor.insertData({
+      getData(type: string) {
+        if (type === 'application/x-slate-fragment') {
+          return encodedFragment
+        }
+        if (type === 'text/plain') {
+          return 'fallback'
+        }
+        return ''
+      },
+    } as DataTransfer)
+
+    const cell = getFirstCell(editor)
+
+    expect(cell.children.map((child: any) => child.type)).toEqual(['paragraph', 'video', 'pre'])
+    expect(Node.string(cell)).toContain('pasted code')
+    expect(editor.getHtml()).toContain('https://example.com/pasted.mp4')
+  })
+
+  it('rejects unsupported custom blocks from internal Slate fragments', () => {
     const editor = createEditor({
       html: '<table><tbody><tr><td><p>A</p></td></tr></tbody></table>',
     })
     const unsupportedFragment = [
       {
-        type: 'paragraph',
-        children: [
-          {
-            type: 'video',
-            src: 'https://example.com/video.mp4',
-            children: [{ text: '' }],
-          },
-        ],
+        type: 'custom-block',
+        children: [{ text: 'unsupported' }],
       },
     ]
     const encodedFragment = window.btoa(encodeURIComponent(JSON.stringify(unsupportedFragment)))
@@ -163,17 +248,16 @@ describe('table rich cell content', () => {
     }
     editor.insertData({
       getData(type: string) {
-        if (type === 'application/x-slate-fragment') {return encodedFragment}
-        if (type === 'text/plain') {return 'fallback'}
+        if (type === 'application/x-slate-fragment') {
+          return encodedFragment
+        }
+        if (type === 'text/plain') {
+          return 'fallback'
+        }
         return ''
       },
     } as DataTransfer)
 
-    const cell = getFirstCell(editor)
-
-    expect(Node.string(cell)).toBe('Afallback')
-    expect(cell.children).toEqual([
-      { type: 'paragraph', children: [{ text: 'Afallback' }] },
-    ])
+    expect(Node.string(getFirstCell(editor))).toBe('Afallback')
   })
 })

--- a/packages/table-module/src/module/helpers.ts
+++ b/packages/table-module/src/module/helpers.ts
@@ -4,14 +4,12 @@
  */
 
 import { DomEditor, IDomEditor } from '@wangeditor-next/core'
-import {
-  Descendant, Element as SlateElement, Text, Transforms,
-} from 'slate'
+import { Descendant, Element as SlateElement, Text, Transforms } from 'slate'
 
 import { TableCellElement, TableElement } from './custom-types'
 
 export function createEmptyTableCell(
-  properties: Omit<Partial<TableCellElement>, 'type' | 'children'> = {},
+  properties: Omit<Partial<TableCellElement>, 'type' | 'children'> = {}
 ): TableCellElement {
   return {
     type: 'table-cell',
@@ -38,7 +36,9 @@ export function normalizeTableCellChildren(children: Descendant[]): Descendant[]
   let textRun: Descendant[] = []
 
   const flushTextRun = () => {
-    if (textRun.length === 0) { return }
+    if (textRun.length === 0) {
+      return
+    }
 
     normalized.push({ type: 'paragraph', children: textRun })
     textRun = []
@@ -56,6 +56,50 @@ export function normalizeTableCellChildren(children: Descendant[]): Descendant[]
   flushTextRun()
 
   return normalized.length > 0 ? normalized : createEmptyTableCell().children
+}
+
+function hasSupportedInlineChildren(editor: IDomEditor, node: SlateElement): boolean {
+  return node.children.every(child => {
+    if (Text.isText(child)) {
+      return true
+    }
+
+    return (
+      SlateElement.isElement(child) &&
+      editor.isInline(child) &&
+      hasSupportedInlineChildren(editor, child)
+    )
+  })
+}
+
+/**
+ * Return whether a block node is safe to keep directly under a table cell.
+ * The list is intentionally explicit so arbitrary custom blocks cannot bypass
+ * table selection and keyboard invariants by being pasted into a cell.
+ */
+export function isSupportedTableCellBlock(editor: IDomEditor, node: Descendant): boolean {
+  if (!SlateElement.isElement(node)) {
+    return false
+  }
+
+  if (node.type === 'paragraph' || node.type === 'list-item') {
+    return hasSupportedInlineChildren(editor, node)
+  }
+
+  if (node.type === 'pre') {
+    return (
+      node.children.length === 1 &&
+      SlateElement.isElement(node.children[0]) &&
+      node.children[0].type === 'code' &&
+      node.children[0].children.every(Text.isText)
+    )
+  }
+
+  if (node.type === 'video') {
+    return editor.isVoid(node) && node.children.every(Text.isText)
+  }
+
+  return false
 }
 
 export function normalizeTableContent(content: Descendant[]): Descendant[] {
@@ -90,7 +134,7 @@ export function normalizeTableContent(content: Descendant[]): Descendant[] {
 export function setTableNodeProps(
   editor: IDomEditor,
   tableNode: SlateElement,
-  props: Partial<TableElement>,
+  props: Partial<TableElement>
 ) {
   try {
     const tablePath = DomEditor.findPath(editor, tableNode)
@@ -108,7 +152,9 @@ export function setTableNodeProps(
 export function getFirstRowCells(tableNode: TableElement): TableCellElement[] {
   const rows = tableNode.children || [] // 所有行
 
-  if (rows.length === 0) { return [] }
+  if (rows.length === 0) {
+    return []
+  }
   const firstRow = rows[0] || {} // 第一行
   const cells = firstRow.children || [] // 第一行所有 cell
 
@@ -133,10 +179,14 @@ export function isTableWithHeader(tableNode: TableElement): boolean {
 export function isCellInFirstRow(editor: IDomEditor, cellNode: TableCellElement): boolean {
   const rowNode = DomEditor.getParentNode(editor, cellNode)
 
-  if (rowNode == null) { return false }
+  if (rowNode == null) {
+    return false
+  }
   const tableNode = DomEditor.getParentNode(editor, rowNode)
 
-  if (tableNode == null) { return false }
+  if (tableNode == null) {
+    return false
+  }
 
   const firstRowCells = getFirstRowCells(tableNode as TableElement)
 

--- a/packages/table-module/src/module/parse-elem-html.ts
+++ b/packages/table-module/src/module/parse-elem-html.ts
@@ -8,7 +8,7 @@ import { Descendant, Text } from 'slate'
 
 import $, { DOMElement, getStyleValue, getTagName } from '../utils/dom'
 import { TableCellElement, TableElement, TableRowElement } from './custom-types'
-import { normalizeTableCellChildren } from './helpers'
+import { isSupportedTableCellBlock, normalizeTableCellChildren } from './helpers'
 
 const DEFAULT_PERCENT_TABLE_WIDTH = 600
 
@@ -25,7 +25,7 @@ function parsePixelSize(value: string | null | undefined, fallback = 0): number 
 function parseCssPixelSize(
   value: string | null | undefined,
   fallback = 0,
-  percentageBase = 0,
+  percentageBase = 0
 ): number {
   const rawValue = (value || '').trim().toLowerCase()
   const parsedValue = parseFloat(rawValue)
@@ -48,9 +48,11 @@ function parseCssPixelSize(
 
 function getColgroupWidths(
   colgroupElements: HTMLCollection | null,
-  percentageBase: number,
+  percentageBase: number
 ): number[] {
-  if (!colgroupElements || colgroupElements.length === 0) { return [] }
+  if (!colgroupElements || colgroupElements.length === 0) {
+    return []
+  }
 
   const columnWidths: number[] = []
 
@@ -59,10 +61,12 @@ function getColgroupWidths(
     const width = parseCssPixelSize(
       col.getAttribute('width') || getStyleValue($(col), 'width'),
       90,
-      percentageBase,
+      percentageBase
     )
 
-    if (Number.isNaN(width)) { return }
+    if (Number.isNaN(width)) {
+      return
+    }
 
     for (let i = 0; i < span; i += 1) {
       columnWidths.push(width)
@@ -87,17 +91,19 @@ function getTableWidthPixelBase($table: ReturnType<typeof $>): number {
 function parseCellHtml(
   elem: DOMElement,
   children: Descendant[],
-  editor: IDomEditor,
+  editor: IDomEditor
 ): TableCellElement {
   const $elem = $(elem)
   const cellText = $elem.text().replace(/\s+/gm, ' ').trim()
 
   children = children.filter(child => {
-    if (DomEditor.getNodeType(child) === 'paragraph') { return true }
-    if (DomEditor.getNodeType(child) === 'list-item') { return true }
-    if (Text.isText(child)) { return true }
-    if (editor.isInline(child)) { return true }
-    return false
+    if (Text.isText(child)) {
+      return true
+    }
+    if (editor.isInline(child)) {
+      return true
+    }
+    return isSupportedTableCellBlock(editor, child)
   })
 
   // 无 children ，则用纯文本
@@ -132,7 +138,7 @@ export const parseCellHtmlConf = {
 function parseRowHtml(
   elem: DOMElement,
   children: Descendant[],
-  _editor: IDomEditor,
+  _editor: IDomEditor
 ): TableRowElement {
   const $elem = $(elem)
   const tableCellChildren: TableCellElement[] = []
@@ -154,9 +160,8 @@ function parseRowHtml(
   }
 
   // 解析行高度（style / class-mode data attr / legacy attr）
-  const rowHeightRaw = getStyleValue($elem, 'height')
-    || $elem.attr('data-w-e-row-height')
-    || $elem.attr('height')
+  const rowHeightRaw =
+    getStyleValue($elem, 'height') || $elem.attr('data-w-e-row-height') || $elem.attr('height')
   const height = parsePixelSize(rowHeightRaw) || undefined
 
   return {
@@ -174,7 +179,7 @@ export const parseRowHtmlConf = {
 function parseTableHtml(
   elem: DOMElement,
   children: Descendant[],
-  _editor: IDomEditor,
+  _editor: IDomEditor
 ): TableElement {
   const $elem = $(elem)
   const caption = ($elem.find('caption').text() || '').replace(/\s+/gm, ' ').trim() || undefined
@@ -184,18 +189,22 @@ function parseTableHtml(
 
   const styleWidth = getStyleValue($elem, 'width')
   const widthAttr = $elem.attr('width') || ''
-  const isClassModeTable = $elem.hasClass('w-e-table-layout-fixed') || !!$elem.attr('data-w-e-table-height')
+  const isClassModeTable =
+    $elem.hasClass('w-e-table-layout-fixed') || !!$elem.attr('data-w-e-table-height')
 
-  if (styleWidth === '100%') { tableWidth = '100%' }
-  if ($elem.attr('width') === '100%') { tableWidth = '100%' } // 兼容 v4 格式
+  if (styleWidth === '100%') {
+    tableWidth = '100%'
+  }
+  if ($elem.attr('width') === '100%') {
+    tableWidth = '100%'
+  } // 兼容 v4 格式
   if (isClassModeTable && widthAttr && widthAttr !== 'auto' && widthAttr !== '100%') {
     tableWidth = widthAttr
   }
 
   // 计算高度
-  const tableHeightRaw = getStyleValue($elem, 'height')
-    || $elem.attr('data-w-e-table-height')
-    || $elem.attr('height')
+  const tableHeightRaw =
+    getStyleValue($elem, 'height') || $elem.attr('data-w-e-table-height') || $elem.attr('height')
   const height = parsePixelSize(tableHeightRaw)
 
   const tableELement: TableElement = {

--- a/packages/table-module/src/module/plugin.ts
+++ b/packages/table-module/src/module/plugin.ts
@@ -16,39 +16,38 @@ import {
   Transforms,
 } from 'slate'
 
-import { normalizeTableContent } from './helpers'
+import { isSupportedTableCellBlock, normalizeTableContent } from './helpers'
 import { TableCursor } from './table-cursor'
 import { EDITOR_TO_SELECTION } from './weak-maps'
 import { withSelection } from './with-selection'
 
 const CELL_BREAK = '\n'
 
-function hasSupportedInlineChildren(editor: IDomEditor, node: SlateElement): boolean {
-  return node.children.every(child => {
-    if (Text.isText(child)) { return true }
-
-    return SlateElement.isElement(child)
-      && editor.isInline(child)
-      && hasSupportedInlineChildren(editor, child)
-  })
-}
-
 function isSupportedCellFragment(editor: IDomEditor, fragment: Descendant[]): boolean {
-  return fragment.length > 0 && fragment.every(node => {
-    if (Text.isText(node)) { return true }
-    return SlateElement.isElement(node)
-      && ['paragraph', 'list-item'].includes(node.type)
-      && hasSupportedInlineChildren(editor, node)
-  })
+  return (
+    fragment.length > 0 &&
+    fragment.every(node => {
+      if (Text.isText(node)) {
+        return true
+      }
+      return isSupportedTableCellBlock(editor, node)
+    })
+  )
 }
 
 function parseSupportedCellBlockHtml(editor: IDomEditor, html: string): Descendant[] | null {
-  if (!html || !/<(p|ol|ul|li)\b/i.test(html)) { return null }
+  if (!html || !/<(p|ol|ul|li|pre|figure)\b/i.test(html)) {
+    return null
+  }
 
   const container = document.createElement('div')
 
   container.innerHTML = html
-  if (container.querySelector('table, pre, img, video, audio, iframe')) { return null }
+  // Keep the established image paste path, which handles uploads and
+  // browser-specific image payloads outside the block-fragment parser.
+  if (container.querySelector('table, img')) {
+    return null
+  }
 
   const fragment = htmlToContent(editor, html)
 
@@ -57,9 +56,11 @@ function parseSupportedCellBlockHtml(editor: IDomEditor, html: string): Descenda
 
 function parseSupportedSlateFragment(
   editor: IDomEditor,
-  encodedFragment: string,
+  encodedFragment: string
 ): Descendant[] | null {
-  if (!encodedFragment) { return null }
+  if (!encodedFragment) {
+    return null
+  }
 
   try {
     const decoded = decodeURIComponent(window.atob(encodedFragment))
@@ -75,7 +76,9 @@ function parseSupportedSlateFragment(
 function deleteHandler(newEditor: IDomEditor): boolean {
   const { selection } = newEditor
 
-  if (selection == null) { return false }
+  if (selection == null) {
+    return false
+  }
 
   const [cellNodeEntry] = Editor.nodes(newEditor, {
     match: n => DomEditor.checkNodeType(n, 'table-cell'),
@@ -98,10 +101,16 @@ function deleteHandler(newEditor: IDomEditor): boolean {
  * @param newEditor
  * @returns 是否在内部处理了删除
  */
-function deleteCellBreak(newEditor: IDomEditor, unit: Parameters<IDomEditor['deleteBackward']>[0], direction: 'forward' | 'backward'): boolean {
+function deleteCellBreak(
+  newEditor: IDomEditor,
+  unit: Parameters<IDomEditor['deleteBackward']>[0],
+  direction: 'forward' | 'backward'
+): boolean {
   const { selection } = newEditor
 
-  if (selection == null || unit === 'line') { return false }
+  if (selection == null || unit === 'line') {
+    return false
+  }
 
   // 判断目标位置是否在同一个 cell 内，不在同一个 cell 内不处理
   const [cellNodeEntry] = Editor.nodes(newEditor, {
@@ -119,26 +128,32 @@ function deleteCellBreak(newEditor: IDomEditor, unit: Parameters<IDomEditor['del
     targetPoint = Editor.after(newEditor, selection)
   }
 
-  if (targetPoint == null) { return false }
+  if (targetPoint == null) {
+    return false
+  }
   const aboveCell = Editor.above(newEditor, {
     at: targetPoint,
     match: n => DomEditor.checkNodeType(n, 'table-cell'),
   })
 
-  if (aboveCell == null || cellNodeEntry == null || !Path.equals(aboveCell[1], cellNodeEntry[1])) { return false }
+  if (aboveCell == null || cellNodeEntry == null || !Path.equals(aboveCell[1], cellNodeEntry[1])) {
+    return false
+  }
   const targetNode = Editor.node(newEditor, targetPoint)
 
-  if (!Text.isText(targetNode[0]) || targetNode[0].text.length < CELL_BREAK.length) { return false }
+  if (!Text.isText(targetNode[0]) || targetNode[0].text.length < CELL_BREAK.length) {
+    return false
+  }
 
   // 处理光标在换行符首/尾的情况,|表示光标  |\n   \n|
-  const startOffset = direction === 'backward'
-    ? targetPoint.offset - CELL_BREAK.length
-    : targetPoint.offset
-  const endOffset = direction === 'backward'
-    ? targetPoint.offset
-    : targetPoint.offset + CELL_BREAK.length
+  const startOffset =
+    direction === 'backward' ? targetPoint.offset - CELL_BREAK.length : targetPoint.offset
+  const endOffset =
+    direction === 'backward' ? targetPoint.offset : targetPoint.offset + CELL_BREAK.length
 
-  if (startOffset < 0) { return false }
+  if (startOffset < 0) {
+    return false
+  }
 
   const nodeText = Node.string(targetNode[0])
   const isBreak = nodeText.slice(startOffset, endOffset) === CELL_BREAK
@@ -189,7 +204,12 @@ function isProtectedNode(editor: IDomEditor): boolean {
   // 检查是否是受保护的节点类型
   const protectedTypes = [
     'paragraph',
-    'header1', 'header2', 'header3', 'header4', 'header5', 'header6',
+    'header1',
+    'header2',
+    'header3',
+    'header4',
+    'header5',
+    'header6',
     'blockquote',
     'list-item',
     'todo',
@@ -254,9 +274,13 @@ function withTable<T extends IDomEditor>(editor: T): T {
   newEditor.deleteBackward = unit => {
     const res = deleteHandler(newEditor)
 
-    if (res) { return } // 命中 table cell ，自己处理删除
+    if (res) {
+      return
+    } // 命中 table cell ，自己处理删除
 
-    if (deleteCellBreak(newEditor, unit, 'backward')) { return } // 命中了 cell 内删除换行符，自行处理删除
+    if (deleteCellBreak(newEditor, unit, 'backward')) {
+      return
+    } // 命中了 cell 内删除换行符，自行处理删除
 
     // 防止从 table 后面的 p 删除时，删除最后一个 cell - issues/4221
     const { selection } = newEditor
@@ -299,10 +323,12 @@ function withTable<T extends IDomEditor>(editor: T): T {
       if (currentCell && tableEntry) {
         const [, currentCellPath] = currentCell
         const [, tablePath] = tableEntry
-        const cells = Array.from(Editor.nodes(editor, {
-          at: tablePath,
-          match: n => DomEditor.checkNodeType(n, 'table-cell') && !(n as any).hidden,
-        }))
+        const cells = Array.from(
+          Editor.nodes(editor, {
+            at: tablePath,
+            match: n => DomEditor.checkNodeType(n, 'table-cell') && !(n as any).hidden,
+          })
+        )
         const index = cells.findIndex(([, path]) => Path.equals(path, currentCellPath))
         const next = index >= 0 ? cells[index + 1] : undefined
 
@@ -341,9 +367,13 @@ function withTable<T extends IDomEditor>(editor: T): T {
   newEditor.deleteForward = unit => {
     const res = deleteHandler(newEditor)
 
-    if (res) { return }
+    if (res) {
+      return
+    }
 
-    if (deleteCellBreak(newEditor, unit, 'forward')) { return }
+    if (deleteCellBreak(newEditor, unit, 'forward')) {
+      return
+    }
 
     // 防止从 table 前面的 p 删除时，删除第一个 cell
     const { selection } = newEditor
@@ -375,6 +405,11 @@ function withTable<T extends IDomEditor>(editor: T): T {
     const type = DomEditor.getNodeType(node)
 
     if (type !== 'table') {
+      if (type === 'table-cell' && SlateElement.isElement(node) && node.children.length === 0) {
+        Transforms.insertNodes(newEditor, DomEditor.genEmptyParagraph(), { at: path.concat(0) })
+        return
+      }
+
       // 未命中 table ，执行默认的 normalizeNode
       return normalizeNode([node, path])
     }
@@ -400,8 +435,9 @@ function withTable<T extends IDomEditor>(editor: T): T {
 
     const fragment = data.getData('application/x-slate-fragment')
     const html = data.getData('text/html')
-    const structuredFragment = parseSupportedSlateFragment(newEditor, fragment)
-      || parseSupportedCellBlockHtml(newEditor, html)
+    const structuredFragment =
+      parseSupportedSlateFragment(newEditor, fragment) ||
+      parseSupportedCellBlockHtml(newEditor, html)
 
     if (structuredFragment) {
       Transforms.insertFragment(newEditor, structuredFragment)
@@ -431,7 +467,7 @@ function withTable<T extends IDomEditor>(editor: T): T {
 
     const cell = DomEditor.getSelectedNodeByType(newEditor, 'table-cell')
 
-    if (cell == null) {
+    if (cell == null || !SlateElement.isElement(cell)) {
       selectAll()
       return
     }
@@ -445,9 +481,13 @@ function withTable<T extends IDomEditor>(editor: T): T {
     }
 
     const text = Node.string(cell)
-    const textLength = text.length
+    const hasOnlyEmptyParagraph =
+      cell.children.length === 1 &&
+      SlateElement.isElement(cell.children[0]) &&
+      cell.children[0].type === 'paragraph' &&
+      text.length === 0
 
-    if (textLength === 0) {
+    if (hasOnlyEmptyParagraph) {
       selectAll()
       return
     }
@@ -484,7 +524,9 @@ function withTable<T extends IDomEditor>(editor: T): T {
 
       selectedCellPaths.forEach(cellPath => {
         // 在复杂操作后 path 可能失效，跳过即可
-        if (!Node.has(newEditor, cellPath)) { return }
+        if (!Node.has(newEditor, cellPath)) {
+          return
+        }
 
         const start = Editor.start(newEditor, cellPath)
         const end = Editor.end(newEditor, cellPath)

--- a/packages/video-module/__tests__/helpler.test.ts
+++ b/packages/video-module/__tests__/helpler.test.ts
@@ -1,3 +1,4 @@
+import { DomEditor } from '@wangeditor-next/core'
 import * as uploadCore from '@wangeditor-next/core/upload'
 import nock from 'nock'
 import * as slate from 'slate'
@@ -68,8 +69,31 @@ describe('Video module helper', () => {
           type: 'video',
           align: 'center',
         }),
-        { mode: 'highest' },
+        { mode: 'highest' }
       )
+    })
+
+    test('it should insert a video inside a table cell', async () => {
+      const editor = createEditor({
+        html: '<table><tbody><tr><td><p>before</p></td></tr></tbody></table>',
+      })
+
+      editor.selection = {
+        anchor: { path: [0, 0, 0, 0, 0], offset: 6 },
+        focus: { path: [0, 0, 0, 0, 0], offset: 6 },
+      }
+
+      expect(DomEditor.getSelectedNodeByType(editor, 'table-cell')).not.toBeNull()
+
+      // The preceding helper test spies on Slate insertion without restoring it.
+      vi.restoreAllMocks()
+      await insertVideo(editor, 'https://example.com/table.mp4')
+      await flushPromises()
+
+      const cell = (editor.children[0] as any).children[0].children[0]
+
+      expect(cell.children.map((node: any) => node.type)).toEqual(['paragraph', 'video'])
+      expect(editor.getHtml()).toContain('https://example.com/table.mp4')
     })
 
     test('it should invoke onInsertedVideo callback if pass the option when create editor', async () => {
@@ -147,22 +171,27 @@ describe('Video module helper', () => {
         config: expect.objectContaining({ uploadAdapter }),
         editor,
       })
-      expect(addFiles).toHaveBeenCalledWith([expect.objectContaining({
-        name: 'adapter.mp4',
-        data: file,
-      })])
+      expect(addFiles).toHaveBeenCalledWith([
+        expect.objectContaining({
+          name: 'adapter.mp4',
+          data: file,
+        }),
+      ])
       expect(upload).toHaveBeenCalledTimes(1)
     })
 
     test('it should invoke onSuccess callback if give the option when create editor', async () => {
       const fn = vi.fn()
 
-      vi.spyOn(uploadCore, 'createUploader').mockImplementation((options: any) => ({
-        addFiles: vi.fn(),
-        upload: vi.fn(async () => {
-          options.onSuccess({ name: 'foo.jpg' }, { errno: 0, data: { url: 'test.mp4' } })
-        }),
-      }) as any)
+      vi.spyOn(uploadCore, 'createUploader').mockImplementation(
+        (options: any) =>
+          ({
+            addFiles: vi.fn(),
+            upload: vi.fn(async () => {
+              options.onSuccess({ name: 'foo.jpg' }, { errno: 0, data: { url: 'test.mp4' } })
+            }),
+          }) as any
+      )
 
       const editor = createEditor({
         config: {
@@ -183,12 +212,15 @@ describe('Video module helper', () => {
     test('it should invoke onProgress callback and show progress bar if uploading', async () => {
       const mockOnProgress = vi.fn()
 
-      vi.spyOn(uploadCore, 'createUploader').mockImplementation((options: any) => ({
-        addFiles: vi.fn(),
-        upload: vi.fn(async () => {
-          options.onProgress(66)
-        }),
-      }) as any)
+      vi.spyOn(uploadCore, 'createUploader').mockImplementation(
+        (options: any) =>
+          ({
+            addFiles: vi.fn(),
+            upload: vi.fn(async () => {
+              options.onProgress(66)
+            }),
+          }) as any
+      )
 
       const editor = createEditor({
         config: {
@@ -243,12 +275,15 @@ describe('Video module helper', () => {
     test('it should invoke onFail callback if upload result with error', async () => {
       const fn = vi.fn()
 
-      vi.spyOn(uploadCore, 'createUploader').mockImplementation((options: any) => ({
-        addFiles: vi.fn(),
-        upload: vi.fn(async () => {
-          options.onSuccess({ name: 'foo.jpg' }, { errno: 1, message: 'failed' })
-        }),
-      }) as any)
+      vi.spyOn(uploadCore, 'createUploader').mockImplementation(
+        (options: any) =>
+          ({
+            addFiles: vi.fn(),
+            upload: vi.fn(async () => {
+              options.onSuccess({ name: 'foo.jpg' }, { errno: 1, message: 'failed' })
+            }),
+          }) as any
+      )
 
       const editor = createEditor({
         config: {
@@ -269,12 +304,15 @@ describe('Video module helper', () => {
     test('it should invoke customInsert callback if upload successfully', async () => {
       const fn = vi.fn()
 
-      vi.spyOn(uploadCore, 'createUploader').mockImplementation((options: any) => ({
-        addFiles: vi.fn(),
-        upload: vi.fn(async () => {
-          options.onSuccess({ name: 'foo.jpg' }, { errno: 0, data: { url: 'test.mp4' } })
-        }),
-      }) as any)
+      vi.spyOn(uploadCore, 'createUploader').mockImplementation(
+        (options: any) =>
+          ({
+            addFiles: vi.fn(),
+            upload: vi.fn(async () => {
+              options.onSuccess({ name: 'foo.jpg' }, { errno: 0, data: { url: 'test.mp4' } })
+            }),
+          }) as any
+      )
 
       const editor = createEditor({
         config: {

--- a/packages/video-module/src/module/helper/insert-video.ts
+++ b/packages/video-module/src/module/helper/insert-video.ts
@@ -20,9 +20,11 @@ export default async function (
   src: string,
   poster = '',
   width = '',
-  height = '',
+  height = ''
 ) {
-  if (!src) { return }
+  if (!src) {
+    return
+  }
 
   // 还原选区
   editor.restoreSelection()
@@ -61,12 +63,22 @@ export default async function (
     },
   }
 
+  const isInsideTableCell = DomEditor.getSelectedNodeByType(editor, 'table-cell') != null
+
   // 插入视频
   // 不使用此方式会比正常的选区选取先执行
   Promise.resolve().then(() => {
-    if (DomEditor.isSelectedEmptyParagraph(editor)) {
+    // A table cell owns its block children. Removing the empty paragraph or
+    // inserting with `mode: highest` would move the video outside the cell.
+    if (!isInsideTableCell && DomEditor.isSelectedEmptyParagraph(editor)) {
       Transforms.removeNodes(editor, { mode: 'highest' })
     }
+
+    if (isInsideTableCell) {
+      Transforms.insertNodes(editor, video)
+      return
+    }
+
     Transforms.insertNodes(editor, video, { mode: 'highest' })
   })
 

--- a/tests/e2e/framework-regression.spec.ts
+++ b/tests/e2e/framework-regression.spec.ts
@@ -31,12 +31,15 @@ const targets: Target[] = [
 
 const WRAPPER_READY_TIMEOUT = process.env.CI ? 180_000 : 60_000
 
-const getEditable = (page: Page) => page.locator('[data-testid="editor-textarea"] [contenteditable="true"]')
+const getEditable = (page: Page) =>
+  page.locator('[data-testid="editor-textarea"] [contenteditable="true"]')
 
-const getToolbarMenu = (page: Page, menuKey: string) => page.locator(`[data-testid="editor-toolbar"] [data-menu-key="${menuKey}"]`)
+const getToolbarMenu = (page: Page, menuKey: string) =>
+  page.locator(`[data-testid="editor-toolbar"] [data-menu-key="${menuKey}"]`)
 
 async function openTarget(page: Page, target: Target) {
-  const isExternalWrapper = !target.needCreate && /^http:\/\/127\.0\.0\.1:31\d{2}\//.test(target.url)
+  const isExternalWrapper =
+    !target.needCreate && /^http:\/\/127\.0\.0\.1:31\d{2}\//.test(target.url)
 
   await page.goto(target.url, {
     // Vite wrapper demos may spend noticeable time on first module transform in CI.
@@ -65,12 +68,18 @@ async function clearEditor(page: Page) {
 async function ensureMenuEnabled(page: Page, menuKey: string) {
   const menu = getToolbarMenu(page, menuKey).first()
   const tryEnable = async (attempt: number): Promise<void> => {
-    if (attempt >= 10) { return }
+    if (attempt >= 10) {
+      return
+    }
     const className = await menu.getAttribute('class')
 
-    if (!className?.includes('disabled')) { return }
+    if (!className?.includes('disabled')) {
+      return
+    }
 
-    const textNode = page.locator('[data-testid="editor-textarea"] [data-slate-node="text"]:visible').first()
+    const textNode = page
+      .locator('[data-testid="editor-textarea"] [data-slate-node="text"]:visible')
+      .first()
     const textNodeCount = await textNode.count()
 
     if (textNodeCount > 0) {
@@ -106,18 +115,20 @@ async function create2x2Table(page: Page) {
 }
 
 async function create2x2TableByApi(page: Page) {
-  await page.evaluate(({ widthMode }) => {
-    const globalWindow = window as any
-    const editor = globalWindow.wangEditorExampleBridge?.editor
-      || globalWindow.vue2Editor
-      || globalWindow.vue3Editor
-      || globalWindow.reactEditor
+  await page.evaluate(
+    ({ widthMode }) => {
+      const globalWindow = window as any
+      const editor =
+        globalWindow.wangEditorExampleBridge?.editor ||
+        globalWindow.vue2Editor ||
+        globalWindow.vue3Editor ||
+        globalWindow.reactEditor
 
-    if (!editor) {
-      throw new Error('editor not ready')
-    }
+      if (!editor) {
+        throw new Error('editor not ready')
+      }
 
-    editor.setHtml(`
+      editor.setHtml(`
       <table style="width: ${widthMode}; table-layout: fixed;">
         <colgroup>
           <col width="120">
@@ -129,16 +140,22 @@ async function create2x2TableByApi(page: Page) {
         </tbody>
       </table>
     `)
-  }, { widthMode: 'auto' })
+    },
+    { widthMode: 'auto' }
+  )
   await page.waitForTimeout(220)
 }
 
 async function getLastTableWidths(page: Page): Promise<number[]> {
   return page.evaluate(() => {
-    const tables = Array.from(document.querySelectorAll('[data-testid="editor-textarea"] table.table'))
+    const tables = Array.from(
+      document.querySelectorAll('[data-testid="editor-textarea"] table.table')
+    )
     const lastTable = tables[tables.length - 1]
 
-    if (!lastTable) { return [] }
+    if (!lastTable) {
+      return []
+    }
     return Array.from(lastTable.querySelectorAll('col')).map(col => {
       return Number(col.getAttribute('width') || 0)
     })
@@ -150,7 +167,9 @@ async function dragLastTableFirstBorder(page: Page, deltaX: number): Promise<boo
   const table = page.locator('[data-testid="editor-textarea"] table.table').last()
   const tableRect = await table.boundingBox()
 
-  if (!tableRect || widths.length === 0) { return false }
+  if (!tableRect || widths.length === 0) {
+    return false
+  }
 
   await page.mouse.move(tableRect.x + widths[0], tableRect.y + 20)
   await page.waitForTimeout(140)
@@ -163,13 +182,18 @@ async function dragLastTableFirstBorder(page: Page, deltaX: number): Promise<boo
     .locator('.resizer-line-hotzone')
   const hotzoneRect = await hotzone.boundingBox()
 
-  if (!hotzoneRect) { return false }
+  if (!hotzoneRect) {
+    return false
+  }
 
-  await page.mouse.move(hotzoneRect.x + hotzoneRect.width / 2, hotzoneRect.y + hotzoneRect.height / 2)
+  await page.mouse.move(
+    hotzoneRect.x + hotzoneRect.width / 2,
+    hotzoneRect.y + hotzoneRect.height / 2
+  )
   await page.mouse.down()
   await page.mouse.move(
     hotzoneRect.x + hotzoneRect.width / 2 + deltaX,
-    hotzoneRect.y + hotzoneRect.height / 2,
+    hotzoneRect.y + hotzoneRect.height / 2
   )
   await page.mouse.up()
   await page.waitForTimeout(240)
@@ -178,93 +202,115 @@ async function dragLastTableFirstBorder(page: Page, deltaX: number): Promise<boo
 }
 
 async function dispatchSyntheticFirstColumnResize(page: Page, deltaX: number): Promise<boolean> {
-  return page.evaluate(({ delta }) => {
-    const globalWindow = window as any
-    const editor = globalWindow.wangEditorExampleBridge?.editor
-      || globalWindow.vue2Editor
-      || globalWindow.vue3Editor
-      || globalWindow.reactEditor
-    const table = document.querySelector('[data-testid="editor-textarea"] table.table') as HTMLElement | null
-    const hotzone = document.querySelector(
-      '[data-testid="editor-textarea"] .column-resizer .column-resizer-item:first-child .resizer-line-hotzone',
-    ) as HTMLElement | null
+  return page.evaluate(
+    ({ delta }) => {
+      const globalWindow = window as any
+      const editor =
+        globalWindow.wangEditorExampleBridge?.editor ||
+        globalWindow.vue2Editor ||
+        globalWindow.vue3Editor ||
+        globalWindow.reactEditor
+      const table = document.querySelector(
+        '[data-testid="editor-textarea"] table.table'
+      ) as HTMLElement | null
+      const hotzone = document.querySelector(
+        '[data-testid="editor-textarea"] .column-resizer .column-resizer-item:first-child .resizer-line-hotzone'
+      ) as HTMLElement | null
 
-    if (!editor || !table || !hotzone) { return false }
+      if (!editor || !table || !hotzone) {
+        return false
+      }
 
-    const tableNode = (editor.children || []).find((node: any) => node?.type === 'table')
+      const tableNode = (editor.children || []).find((node: any) => node?.type === 'table')
 
-    if (!tableNode) { return false }
+      if (!tableNode) {
+        return false
+      }
 
-    const firstCol = table.querySelector('col')
-    const firstWidth = Number(firstCol?.getAttribute('width') || 0)
-    const tableRect = table.getBoundingClientRect()
-    const startX = Math.round(tableRect.left + Math.max(firstWidth, 80))
-    const startY = Math.round(tableRect.top + 10)
+      const firstCol = table.querySelector('col')
+      const firstWidth = Number(firstCol?.getAttribute('width') || 0)
+      const tableRect = table.getBoundingClientRect()
+      const startX = Math.round(tableRect.left + Math.max(firstWidth, 80))
+      const startY = Math.round(tableRect.top + 10)
 
-    tableNode.resizingIndex = 0
-    tableNode.isHoverCellBorder = true
-    tableNode.scrollWidth = Math.max(Math.round(tableRect.width), 1)
+      tableNode.resizingIndex = 0
+      tableNode.isHoverCellBorder = true
+      tableNode.scrollWidth = Math.max(Math.round(tableRect.width), 1)
 
-    hotzone.dispatchEvent(new MouseEvent('mousedown', {
-      bubbles: true,
-      clientX: startX,
-      clientY: startY,
-    }))
-    window.dispatchEvent(new MouseEvent('mousemove', {
-      bubbles: true,
-      clientX: startX + delta,
-      clientY: startY,
-    }))
-    window.dispatchEvent(new MouseEvent('mouseup', {
-      bubbles: true,
-      clientX: startX + delta,
-      clientY: startY,
-    }))
+      hotzone.dispatchEvent(
+        new MouseEvent('mousedown', {
+          bubbles: true,
+          clientX: startX,
+          clientY: startY,
+        })
+      )
+      window.dispatchEvent(
+        new MouseEvent('mousemove', {
+          bubbles: true,
+          clientX: startX + delta,
+          clientY: startY,
+        })
+      )
+      window.dispatchEvent(
+        new MouseEvent('mouseup', {
+          bubbles: true,
+          clientX: startX + delta,
+          clientY: startY,
+        })
+      )
 
-    return true
-  }, { delta: deltaX })
+      return true
+    },
+    { delta: deltaX }
+  )
 }
 
 async function setTextareaWidthAndMeasureLastTable(
   page: Page,
-  widthPx: number,
+  widthPx: number
 ): Promise<{ containerWidth: number; tableWidth: number; tableStyleWidth: string }> {
-  return page.evaluate(({ width }) => {
-    const textarea = document.querySelector('[data-testid="editor-textarea"]') as HTMLElement | null
+  return page.evaluate(
+    ({ width }) => {
+      const textarea = document.querySelector(
+        '[data-testid="editor-textarea"]'
+      ) as HTMLElement | null
 
-    if (!textarea) {
-      throw new Error('editor textarea not found')
-    }
+      if (!textarea) {
+        throw new Error('editor textarea not found')
+      }
 
-    textarea.style.width = `${width}px`
-    textarea.style.maxWidth = `${width}px`
-    textarea.style.transition = 'none'
+      textarea.style.width = `${width}px`
+      textarea.style.maxWidth = `${width}px`
+      textarea.style.transition = 'none'
 
-    const tables = Array.from(textarea.querySelectorAll('table.table')) as HTMLElement[]
-    const table = tables[tables.length - 1] || null
+      const tables = Array.from(textarea.querySelectorAll('table.table')) as HTMLElement[]
+      const table = tables[tables.length - 1] || null
 
-    if (!table) {
-      throw new Error('table not found')
-    }
+      if (!table) {
+        throw new Error('table not found')
+      }
 
-    const containerRect = textarea.getBoundingClientRect()
-    const tableRect = table.getBoundingClientRect()
+      const containerRect = textarea.getBoundingClientRect()
+      const tableRect = table.getBoundingClientRect()
 
-    return {
-      containerWidth: containerRect.width,
-      tableWidth: tableRect.width,
-      tableStyleWidth: table.style.width || '',
-    }
-  }, { width: widthPx })
+      return {
+        containerWidth: containerRect.width,
+        tableWidth: tableRect.width,
+        tableStyleWidth: table.style.width || '',
+      }
+    },
+    { width: widthPx }
+  )
 }
 
 async function getFirstTableWidthMode(page: Page): Promise<string> {
   return page.evaluate(() => {
     const globalWindow = window as any
-    const editor = globalWindow.wangEditorExampleBridge?.editor
-      || globalWindow.vue2Editor
-      || globalWindow.vue3Editor
-      || globalWindow.reactEditor
+    const editor =
+      globalWindow.wangEditorExampleBridge?.editor ||
+      globalWindow.vue2Editor ||
+      globalWindow.vue3Editor ||
+      globalWindow.reactEditor
 
     if (!editor) {
       throw new Error('editor not ready')
@@ -277,18 +323,20 @@ async function getFirstTableWidthMode(page: Page): Promise<string> {
 }
 
 async function setSelectedTableWidthMode(page: Page, width: '100%' | 'auto') {
-  await page.evaluate(({ nextWidth }) => {
-    const globalWindow = window as any
-    const editor = globalWindow.wangEditorExampleBridge?.editor
-      || globalWindow.vue2Editor
-      || globalWindow.vue3Editor
-      || globalWindow.reactEditor
+  await page.evaluate(
+    ({ nextWidth }) => {
+      const globalWindow = window as any
+      const editor =
+        globalWindow.wangEditorExampleBridge?.editor ||
+        globalWindow.vue2Editor ||
+        globalWindow.vue3Editor ||
+        globalWindow.reactEditor
 
-    if (!editor) {
-      throw new Error('editor not ready')
-    }
+      if (!editor) {
+        throw new Error('editor not ready')
+      }
 
-    editor.setHtml(`
+      editor.setHtml(`
       <table style="width: ${nextWidth}; table-layout: fixed;">
         <colgroup>
           <col width="120">
@@ -300,7 +348,9 @@ async function setSelectedTableWidthMode(page: Page, width: '100%' | 'auto') {
         </tbody>
       </table>
     `)
-  }, { nextWidth: width })
+    },
+    { nextWidth: width }
+  )
   await page.waitForTimeout(220)
 }
 
@@ -337,7 +387,9 @@ test.describe('Framework parity regression', () => {
     expect(pageErrors).toEqual([])
   })
 
-  test('react-wrapper: regression #907 Editor style should apply to the actual editor root', async ({ page }) => {
+  test('react-wrapper: regression #907 Editor style should apply to the actual editor root', async ({
+    page,
+  }) => {
     const pageErrors: string[] = []
 
     page.on('pageerror', err => {
@@ -347,7 +399,9 @@ test.describe('Framework parity regression', () => {
     await openTarget(page, targets.find(target => target.name === 'react-wrapper')!)
 
     const snapshot = await page.evaluate(() => {
-      const host = document.querySelector('[data-testid="editor-textarea"] [data-w-e-textarea="true"]')
+      const host = document.querySelector(
+        '[data-testid="editor-textarea"] [data-w-e-textarea="true"]'
+      )
       const textContainer = host?.querySelector('.w-e-text-container')
       const scroll = host?.querySelector('.w-e-scroll')
 
@@ -381,10 +435,12 @@ test.describe('Framework parity regression', () => {
     expect(pageErrors).toEqual([])
   })
 
-  test('vue3-wrapper: regression #919 production build should keep image hoverbar and paste order', async ({ page }) => {
+  test('vue3-wrapper: regression #919 production build should keep image hoverbar and paste order', async ({
+    page,
+  }) => {
     test.skip(
       process.env.PLAYWRIGHT_WRAPPER_PREVIEW !== '1',
-      'regression #919 requires wrapper production preview',
+      'regression #919 requires wrapper production preview'
     )
 
     const pageErrors: string[] = []
@@ -405,7 +461,7 @@ test.describe('Framework parity regression', () => {
 
       editor.clear()
       editor.dangerouslyInsertHtml(
-        '<p><img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" alt="tiny" /></p>',
+        '<p><img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" alt="tiny" /></p>'
       )
     })
     await page.locator('[data-testid="editor-textarea"] img').first().click({ force: true })
@@ -416,29 +472,30 @@ test.describe('Framework parity regression', () => {
         const style = window.getComputedStyle(el)
         const rect = el.getBoundingClientRect()
 
-        return style.display !== 'none'
-          && style.visibility !== 'hidden'
-          && rect.width > 0
-          && rect.height > 0
+        return (
+          style.display !== 'none' &&
+          style.visibility !== 'hidden' &&
+          rect.width > 0 &&
+          rect.height > 0
+        )
       })
 
       return {
         selectedImage: !!document.querySelector('.w-e-selected-image-container'),
         hoverbarVisible: !!visibleHoverbar,
         menuKeys: visibleHoverbar
-          ? Array.from(visibleHoverbar.querySelectorAll('[data-menu-key]')).map(el => el.getAttribute('data-menu-key'))
+          ? Array.from(visibleHoverbar.querySelectorAll('[data-menu-key]')).map(el =>
+              el.getAttribute('data-menu-key')
+            )
           : [],
       }
     })
 
     expect(imageState.selectedImage).toBe(true)
     expect(imageState.hoverbarVisible).toBe(true)
-    expect(imageState.menuKeys).toEqual(expect.arrayContaining([
-      'imageWidth30',
-      'editorImageSizeMenu',
-      'editImage',
-      'deleteImage',
-    ]))
+    expect(imageState.menuKeys).toEqual(
+      expect.arrayContaining(['imageWidth30', 'editorImageSizeMenu', 'editImage', 'deleteImage'])
+    )
 
     await openTarget(page, targets.find(target => target.name === 'vue3-wrapper')!)
 
@@ -451,38 +508,37 @@ test.describe('Framework parity regression', () => {
         </div>
       </body></html>`
 
-    const pasteState = await page.evaluate(({ html }) => {
-      const globalWindow = window as any
-      const editor = globalWindow.vue3Editor
+    const pasteState = await page.evaluate(
+      ({ html }) => {
+        const globalWindow = window as any
+        const editor = globalWindow.vue3Editor
 
-      if (!editor) {
-        throw new Error('vue3 editor not ready')
-      }
+        if (!editor) {
+          throw new Error('vue3 editor not ready')
+        }
 
-      editor.clear()
-      editor.focus()
+        editor.clear()
+        editor.focus()
 
-      const transfer = new DataTransfer()
+        const transfer = new DataTransfer()
 
-      transfer.setData('text/html', html)
-      transfer.setData('text/plain', '测试标题\n第一段内容\n第二段内容')
-      editor.insertData(transfer)
+        transfer.setData('text/html', html)
+        transfer.setData('text/plain', '测试标题\n第一段内容\n第二段内容')
+        editor.insertData(transfer)
 
-      return {
-        text: editor.getText(),
-        children: editor.children.map((node: any) => {
-          return Array.isArray(node.children)
-            ? node.children.map((child: any) => child.text || '').join('')
-            : ''
-        }),
-      }
-    }, { html: wordLikeHtml })
+        return {
+          text: editor.getText(),
+          children: editor.children.map((node: any) => {
+            return Array.isArray(node.children)
+              ? node.children.map((child: any) => child.text || '').join('')
+              : ''
+          }),
+        }
+      },
+      { html: wordLikeHtml }
+    )
 
-    expect(pasteState.children).toEqual([
-      '测试标题',
-      '第一段内容',
-      '第二段内容',
-    ])
+    expect(pasteState.children).toEqual(['测试标题', '第一段内容', '第二段内容'])
     expect(pasteState.text).toBe('测试标题\n第一段内容\n第二段内容')
     expect(pageErrors).toEqual([])
   })
@@ -501,7 +557,9 @@ test.describe('Framework parity regression', () => {
       await page.keyboard.press('Control+A')
 
       await page.evaluate(() => {
-        const el = document.querySelector('[data-testid="editor-textarea"] [contenteditable="true"]')
+        const el = document.querySelector(
+          '[data-testid="editor-textarea"] [contenteditable="true"]'
+        )
 
         if (!el) {
           throw new Error('editable not found')
@@ -510,17 +568,21 @@ test.describe('Framework parity regression', () => {
         const fire = (event: Event) => el.dispatchEvent(event)
 
         fire(new CompositionEvent('compositionstart', { data: '' }))
-        fire(new InputEvent('beforeinput', {
-          inputType: 'insertCompositionText',
-          data: 'ni',
-          bubbles: true,
-          cancelable: true,
-        }))
-        fire(new InputEvent('input', {
-          inputType: 'insertCompositionText',
-          data: 'ni',
-          bubbles: true,
-        }))
+        fire(
+          new InputEvent('beforeinput', {
+            inputType: 'insertCompositionText',
+            data: 'ni',
+            bubbles: true,
+            cancelable: true,
+          })
+        )
+        fire(
+          new InputEvent('input', {
+            inputType: 'insertCompositionText',
+            data: 'ni',
+            bubbles: true,
+          })
+        )
         fire(new CompositionEvent('compositionupdate', { data: 'ni' }))
         fire(new CompositionEvent('compositionend', { data: '你' }))
       })
@@ -530,7 +592,9 @@ test.describe('Framework parity regression', () => {
       expect(pageErrors).toEqual([])
     })
 
-    test(`${target.name}: regression #564 malformed span+p html should not throw`, async ({ page }) => {
+    test(`${target.name}: regression #564 malformed span+p html should not throw`, async ({
+      page,
+    }) => {
       const pageErrors: string[] = []
 
       page.on('pageerror', err => {
@@ -539,36 +603,41 @@ test.describe('Framework parity regression', () => {
 
       await openTarget(page, target)
 
-      const malformedHtml = '<p><span style="color: rgb(0, 0, 0); font-size: medium; font-family: -webkit-standard;">这是一</span><span style="color: rgb(0, 0, 0); font-size: medium; font-family: -webkit-standard;"><p><br></p></span><span style="color: rgb(0, 0, 0); font-size: medium; font-family: -webkit-standard;">这是二</span><span style="color: rgb(0, 0, 0); font-size: medium; font-family: -webkit-standard;"><p><br></p></span><span style="color: rgb(0, 0, 0); font-size: medium; font-family: -webkit-standard;">这是三</span><span style="color: rgb(0, 0, 0); font-size: medium; font-family: -webkit-standard;"><p><br></p></span><span style="color: rgb(0, 0, 0); font-size: medium; font-family: -webkit-standard;"><p><br></p></span><span style="color: rgb(0, 0, 0); font-size: medium; font-family: -webkit-standard;">这是四</span></p>'
+      const malformedHtml =
+        '<p><span style="color: rgb(0, 0, 0); font-size: medium; font-family: -webkit-standard;">这是一</span><span style="color: rgb(0, 0, 0); font-size: medium; font-family: -webkit-standard;"><p><br></p></span><span style="color: rgb(0, 0, 0); font-size: medium; font-family: -webkit-standard;">这是二</span><span style="color: rgb(0, 0, 0); font-size: medium; font-family: -webkit-standard;"><p><br></p></span><span style="color: rgb(0, 0, 0); font-size: medium; font-family: -webkit-standard;">这是三</span><span style="color: rgb(0, 0, 0); font-size: medium; font-family: -webkit-standard;"><p><br></p></span><span style="color: rgb(0, 0, 0); font-size: medium; font-family: -webkit-standard;"><p><br></p></span><span style="color: rgb(0, 0, 0); font-size: medium; font-family: -webkit-standard;">这是四</span></p>'
 
-      const snapshot = await page.evaluate(({ html }) => {
-        const globalWindow = window as any
-        const editor = globalWindow.wangEditorExampleBridge?.editor
-          || globalWindow.vue2Editor
-          || globalWindow.vue3Editor
-          || globalWindow.reactEditor
+      const snapshot = await page.evaluate(
+        ({ html }) => {
+          const globalWindow = window as any
+          const editor =
+            globalWindow.wangEditorExampleBridge?.editor ||
+            globalWindow.vue2Editor ||
+            globalWindow.vue3Editor ||
+            globalWindow.reactEditor
 
-        if (!editor) {
-          throw new Error('editor not ready')
-        }
+          if (!editor) {
+            throw new Error('editor not ready')
+          }
 
-        editor.setHtml(html)
-        const output = editor.getHtml()
-        const hasInlineNestedParagraph = /<span[^>]*>\s*<p/i.test(output)
-        const root = document.querySelector('[data-testid="editor-textarea"]')
-        const nestedParagraphInSpanCount = root?.querySelectorAll('span p').length ?? 0
+          editor.setHtml(html)
+          const output = editor.getHtml()
+          const hasInlineNestedParagraph = /<span[^>]*>\s*<p/i.test(output)
+          const root = document.querySelector('[data-testid="editor-textarea"]')
+          const nestedParagraphInSpanCount = root?.querySelectorAll('span p').length ?? 0
 
-        editor.focus()
-        editor.insertText('1')
-        editor.deleteBackward('character')
+          editor.focus()
+          editor.insertText('1')
+          editor.deleteBackward('character')
 
-        return {
-          output,
-          outputAfterEdit: editor.getHtml(),
-          hasInlineNestedParagraph,
-          nestedParagraphInSpanCount,
-        }
-      }, { html: malformedHtml })
+          return {
+            output,
+            outputAfterEdit: editor.getHtml(),
+            hasInlineNestedParagraph,
+            nestedParagraphInSpanCount,
+          }
+        },
+        { html: malformedHtml }
+      )
 
       expect(snapshot.hasInlineNestedParagraph).toBe(false)
       expect(snapshot.nestedParagraphInSpanCount).toBe(0)
@@ -576,7 +645,9 @@ test.describe('Framework parity regression', () => {
       expect(pageErrors).toEqual([])
     })
 
-    test(`${target.name}: regression #339 setHtml should keep emsp in styled span`, async ({ page }) => {
+    test(`${target.name}: regression #339 setHtml should keep emsp in styled span`, async ({
+      page,
+    }) => {
       const pageErrors: string[] = []
 
       page.on('pageerror', err => {
@@ -587,10 +658,11 @@ test.describe('Framework parity regression', () => {
 
       const snapshot = await page.evaluate(() => {
         const globalWindow = window as any
-        const editor = globalWindow.wangEditorExampleBridge?.editor
-          || globalWindow.vue2Editor
-          || globalWindow.vue3Editor
-          || globalWindow.reactEditor
+        const editor =
+          globalWindow.wangEditorExampleBridge?.editor ||
+          globalWindow.vue2Editor ||
+          globalWindow.vue3Editor ||
+          globalWindow.reactEditor
 
         if (!editor) {
           throw new Error('editor not ready')
@@ -616,7 +688,9 @@ test.describe('Framework parity regression', () => {
       expect(pageErrors).toEqual([])
     })
 
-    test(`${target.name}: regression #441 ordered list selection text should match visual range`, async ({ page }) => {
+    test(`${target.name}: regression #441 ordered list selection text should match visual range`, async ({
+      page,
+    }) => {
       const pageErrors: string[] = []
 
       page.on('pageerror', err => {
@@ -628,7 +702,7 @@ test.describe('Framework parity regression', () => {
 
       const listMenuSupport = await page.evaluate(() => {
         const menuKeys = Array.from(
-          document.querySelectorAll('[data-testid="editor-toolbar"] [data-menu-key]'),
+          document.querySelectorAll('[data-testid="editor-toolbar"] [data-menu-key]')
         ).map(el => el.getAttribute('data-menu-key') || '')
 
         return {
@@ -647,7 +721,7 @@ test.describe('Framework parity regression', () => {
 
       test.skip(
         !orderedListMenuKey,
-        `${target.name} demo toolbar does not expose ordered-list menu`,
+        `${target.name} demo toolbar does not expose ordered-list menu`
       )
 
       const orderedListMenu = await ensureMenuEnabled(page, orderedListMenuKey)
@@ -658,18 +732,21 @@ test.describe('Framework parity regression', () => {
       await page.keyboard.type('child-item')
       await page.evaluate(() => {
         const globalWindow = window as any
-        const editor = globalWindow.wangEditorExampleBridge?.editor
-          || globalWindow.vue2Editor
-          || globalWindow.vue3Editor
-          || globalWindow.reactEditor
+        const editor =
+          globalWindow.wangEditorExampleBridge?.editor ||
+          globalWindow.vue2Editor ||
+          globalWindow.vue3Editor ||
+          globalWindow.reactEditor
 
         if (!editor) {
           throw new Error('editor not ready')
         }
 
-        const secondListItemIndex = (editor.children || []).findIndex((node: any, index: number) => {
-          return index > 0 && node?.type === 'list-item'
-        })
+        const secondListItemIndex = (editor.children || []).findIndex(
+          (node: any, index: number) => {
+            return index > 0 && node?.type === 'list-item'
+          }
+        )
 
         if (secondListItemIndex < 0) {
           throw new Error('second list item not found')
@@ -684,22 +761,34 @@ test.describe('Framework parity regression', () => {
       await page.waitForTimeout(200)
 
       const didSelectPrefix = await page.evaluate(() => {
-        const textArea = document.querySelector('[data-testid="editor-textarea"]') as HTMLElement | null
-        const textNodes = Array.from(textArea?.querySelectorAll('[data-slate-string]') || []) as HTMLElement[]
+        const textArea = document.querySelector(
+          '[data-testid="editor-textarea"]'
+        ) as HTMLElement | null
+        const textNodes = Array.from(
+          textArea?.querySelectorAll('[data-slate-string]') || []
+        ) as HTMLElement[]
         const parentText = textNodes.find(el => (el.textContent || '').trim() === 'parent-item')
 
-        if (!parentText) { return false }
+        if (!parentText) {
+          return false
+        }
 
         const row = parentText.closest('div[style*="display: flex"]') as HTMLElement | null
 
-        if (!row) { return false }
+        if (!row) {
+          return false
+        }
         const prefixNode = row.querySelector('[data-w-e-reserve]') as HTMLElement | null
 
-        if (!prefixNode || !prefixNode.firstChild) { return false }
+        if (!prefixNode || !prefixNode.firstChild) {
+          return false
+        }
 
         const selection = window.getSelection()
 
-        if (!selection) { return false }
+        if (!selection) {
+          return false
+        }
 
         const range = document.createRange()
 
@@ -717,10 +806,11 @@ test.describe('Framework parity regression', () => {
 
       const snapshot = await page.evaluate(() => {
         const globalWindow = window as any
-        const editor = globalWindow.wangEditorExampleBridge?.editor
-          || globalWindow.vue2Editor
-          || globalWindow.vue3Editor
-          || globalWindow.reactEditor
+        const editor =
+          globalWindow.wangEditorExampleBridge?.editor ||
+          globalWindow.vue2Editor ||
+          globalWindow.vue3Editor ||
+          globalWindow.reactEditor
 
         if (!editor) {
           throw new Error('editor not ready')
@@ -743,17 +833,18 @@ test.describe('Framework parity regression', () => {
         }
       })
 
-      expect(snapshot.levels.some(item => item.level === 1 && item.text.includes('child-item'))).toBe(true)
       expect(
-        snapshot.editorSelectionText.length,
-        JSON.stringify(snapshot),
-      ).toBeGreaterThan(0)
+        snapshot.levels.some(item => item.level === 1 && item.text.includes('child-item'))
+      ).toBe(true)
+      expect(snapshot.editorSelectionText.length, JSON.stringify(snapshot)).toBeGreaterThan(0)
       expect(snapshot.domSelectionText).toBe('1.')
       expect(snapshot.editorSelectionText.replace(/\s+/g, '')).toBe('parent-item')
       expect(pageErrors).toEqual([])
     })
 
-    test(`${target.name}: regression #610 image insertion should keep active font marks`, async ({ page }) => {
+    test(`${target.name}: regression #610 image insertion should keep active font marks`, async ({
+      page,
+    }) => {
       const pageErrors: string[] = []
 
       page.on('pageerror', err => {
@@ -765,7 +856,7 @@ test.describe('Framework parity regression', () => {
 
       const imageMenuSupport = await page.evaluate(() => {
         const menuKeys = Array.from(
-          document.querySelectorAll('[data-testid="editor-toolbar"] [data-menu-key]'),
+          document.querySelectorAll('[data-testid="editor-toolbar"] [data-menu-key]')
         ).map(el => el.getAttribute('data-menu-key') || '')
 
         return {
@@ -776,15 +867,16 @@ test.describe('Framework parity regression', () => {
 
       test.skip(
         !imageMenuSupport.hasGroupImage && !imageMenuSupport.hasInsertImage,
-        `${target.name} demo toolbar does not expose image insertion menus`,
+        `${target.name} demo toolbar does not expose image insertion menus`
       )
 
       await page.evaluate(() => {
         const globalWindow = window as any
-        const editor = globalWindow.wangEditorExampleBridge?.editor
-          || globalWindow.vue2Editor
-          || globalWindow.vue3Editor
-          || globalWindow.reactEditor
+        const editor =
+          globalWindow.wangEditorExampleBridge?.editor ||
+          globalWindow.vue2Editor ||
+          globalWindow.vue3Editor ||
+          globalWindow.reactEditor
 
         if (!editor) {
           throw new Error('editor not ready')
@@ -814,7 +906,10 @@ test.describe('Framework parity regression', () => {
       const modal = page.locator('.w-e-modal:visible').last()
 
       await expect(modal).toBeVisible()
-      await modal.locator('input[type="text"]').first().fill('https://example.com/regression-610.png')
+      await modal
+        .locator('input[type="text"]')
+        .first()
+        .fill('https://example.com/regression-610.png')
       await modal.locator('.button-container button').first().click()
       await page.waitForTimeout(220)
 
@@ -824,10 +919,11 @@ test.describe('Framework parity regression', () => {
 
       const markState = await page.evaluate(() => {
         const globalWindow = window as any
-        const editor = globalWindow.wangEditorExampleBridge?.editor
-          || globalWindow.vue2Editor
-          || globalWindow.vue3Editor
-          || globalWindow.reactEditor
+        const editor =
+          globalWindow.wangEditorExampleBridge?.editor ||
+          globalWindow.vue2Editor ||
+          globalWindow.vue3Editor ||
+          globalWindow.reactEditor
 
         if (!editor) {
           throw new Error('editor not ready')
@@ -841,7 +937,9 @@ test.describe('Framework parity regression', () => {
             if (Array.isArray(node?.children)) {
               const found = findTextNode(node.children, targetText)
 
-              if (found) { return found }
+              if (found) {
+                return found
+              }
             }
           }
           return null
@@ -864,7 +962,9 @@ test.describe('Framework parity regression', () => {
       expect(pageErrors).toEqual([])
     })
 
-    test(`${target.name}: regression #704 list item should allow inserting image and video`, async ({ page }) => {
+    test(`${target.name}: regression #704 list item should allow inserting image and video`, async ({
+      page,
+    }) => {
       const pageErrors: string[] = []
 
       page.on('pageerror', err => {
@@ -876,7 +976,7 @@ test.describe('Framework parity regression', () => {
 
       const menuSupport = await page.evaluate(() => {
         const menuKeys = Array.from(
-          document.querySelectorAll('[data-testid="editor-toolbar"] [data-menu-key]'),
+          document.querySelectorAll('[data-testid="editor-toolbar"] [data-menu-key]')
         ).map(el => el.getAttribute('data-menu-key') || '')
 
         return {
@@ -889,18 +989,19 @@ test.describe('Framework parity regression', () => {
       })
 
       test.skip(
-        !menuSupport.hasBulletedList
-          || (!menuSupport.hasGroupImage && !menuSupport.hasInsertImage)
-          || (!menuSupport.hasGroupVideo && !menuSupport.hasInsertVideo),
-        `${target.name} demo toolbar does not expose required list/image/video menus`,
+        !menuSupport.hasBulletedList ||
+          (!menuSupport.hasGroupImage && !menuSupport.hasInsertImage) ||
+          (!menuSupport.hasGroupVideo && !menuSupport.hasInsertVideo),
+        `${target.name} demo toolbar does not expose required list/image/video menus`
       )
 
       await page.evaluate(() => {
         const globalWindow = window as any
-        const editor = globalWindow.wangEditorExampleBridge?.editor
-          || globalWindow.vue2Editor
-          || globalWindow.vue3Editor
-          || globalWindow.reactEditor
+        const editor =
+          globalWindow.wangEditorExampleBridge?.editor ||
+          globalWindow.vue2Editor ||
+          globalWindow.vue3Editor ||
+          globalWindow.reactEditor
 
         if (!editor) {
           throw new Error('editor not ready')
@@ -914,7 +1015,7 @@ test.describe('Framework parity regression', () => {
           throw new Error('list-item node not found')
         }
 
-        const listTextNode = listIndex >= 0 ? (editor.children[listIndex]?.children?.[0] || {}) : {}
+        const listTextNode = listIndex >= 0 ? editor.children[listIndex]?.children?.[0] || {} : {}
         const textLength = String(listTextNode.text || '').length
         const offset = Math.min(Math.max(textLength, 1), 4)
 
@@ -941,16 +1042,20 @@ test.describe('Framework parity regression', () => {
       const imageModal = page.locator('.w-e-modal:visible').last()
 
       await expect(imageModal).toBeVisible()
-      await imageModal.locator('input[type="text"]').first().fill('https://example.com/regression-704.png')
+      await imageModal
+        .locator('input[type="text"]')
+        .first()
+        .fill('https://example.com/regression-704.png')
       await imageModal.locator('.button-container button').first().click()
       await page.waitForTimeout(200)
 
       await page.evaluate(() => {
         const globalWindow = window as any
-        const editor = globalWindow.wangEditorExampleBridge?.editor
-          || globalWindow.vue2Editor
-          || globalWindow.vue3Editor
-          || globalWindow.reactEditor
+        const editor =
+          globalWindow.wangEditorExampleBridge?.editor ||
+          globalWindow.vue2Editor ||
+          globalWindow.vue3Editor ||
+          globalWindow.reactEditor
 
         if (!editor) {
           throw new Error('editor not ready')
@@ -962,7 +1067,7 @@ test.describe('Framework parity regression', () => {
           throw new Error('list-item node not found after image insertion')
         }
 
-        const listTextNode = listIndex >= 0 ? (editor.children[listIndex]?.children?.[0] || {}) : {}
+        const listTextNode = listIndex >= 0 ? editor.children[listIndex]?.children?.[0] || {} : {}
         const textLength = String(listTextNode.text || '').length
         const offset = Math.min(Math.max(textLength, 1), 4)
 
@@ -989,22 +1094,28 @@ test.describe('Framework parity regression', () => {
       const videoModal = page.locator('.w-e-modal:visible').last()
 
       await expect(videoModal).toBeVisible()
-      await videoModal.locator('input[type="text"]').first().fill('https://example.com/regression-704.mp4')
+      await videoModal
+        .locator('input[type="text"]')
+        .first()
+        .fill('https://example.com/regression-704.mp4')
       await videoModal.locator('.button-container button').first().click()
       await page.waitForTimeout(260)
 
       const snapshot = await page.evaluate(() => {
         const globalWindow = window as any
-        const editor = globalWindow.wangEditorExampleBridge?.editor
-          || globalWindow.vue2Editor
-          || globalWindow.vue3Editor
-          || globalWindow.reactEditor
+        const editor =
+          globalWindow.wangEditorExampleBridge?.editor ||
+          globalWindow.vue2Editor ||
+          globalWindow.vue3Editor ||
+          globalWindow.reactEditor
 
         if (!editor) {
           throw new Error('editor not ready')
         }
 
-        const listItemCount = (editor.children || []).filter((node: any) => node?.type === 'list-item').length
+        const listItemCount = (editor.children || []).filter(
+          (node: any) => node?.type === 'list-item'
+        ).length
 
         return {
           imageCount: (editor.getElemsByTypePrefix?.('image') || []).length,
@@ -1054,7 +1165,9 @@ test.describe('Framework parity regression', () => {
       expect(pageErrors).toEqual([])
     })
 
-    test(`${target.name}: regression #848 tableFullWidth should stay responsive after container resize`, async ({ page }) => {
+    test(`${target.name}: regression #848 tableFullWidth should stay responsive after container resize`, async ({
+      page,
+    }) => {
       const pageErrors: string[] = []
 
       page.on('pageerror', err => {
@@ -1082,10 +1195,11 @@ test.describe('Framework parity regression', () => {
 
       const widthMode = await page.evaluate(() => {
         const globalWindow = window as any
-        const editor = globalWindow.wangEditorExampleBridge?.editor
-          || globalWindow.vue2Editor
-          || globalWindow.vue3Editor
-          || globalWindow.reactEditor
+        const editor =
+          globalWindow.wangEditorExampleBridge?.editor ||
+          globalWindow.vue2Editor ||
+          globalWindow.vue3Editor ||
+          globalWindow.reactEditor
 
         if (!editor) {
           throw new Error('editor not ready')
@@ -1122,7 +1236,9 @@ test.describe('Framework parity regression', () => {
       expect(pageErrors).toEqual([])
     })
 
-    test(`${target.name}: regression #893 tableFullWidth should toggle back and allow effective resize`, async ({ page }) => {
+    test(`${target.name}: regression #893 tableFullWidth should toggle back and allow effective resize`, async ({
+      page,
+    }) => {
       const pageErrors: string[] = []
 
       page.on('pageerror', err => {
@@ -1165,7 +1281,9 @@ test.describe('Framework parity regression', () => {
       expect(pageErrors).toEqual([])
     })
 
-    test(`${target.name}: regression #923 table without height should allow column resize`, async ({ page }) => {
+    test(`${target.name}: regression #923 table without height should allow column resize`, async ({
+      page,
+    }) => {
       const pageErrors: string[] = []
 
       page.on('pageerror', err => {
@@ -1177,7 +1295,9 @@ test.describe('Framework parity regression', () => {
       await create2x2TableByApi(page)
 
       await page.evaluate(() => {
-        const table = document.querySelector('[data-testid="editor-textarea"] table.table') as HTMLTableElement | null
+        const table = document.querySelector(
+          '[data-testid="editor-textarea"] table.table'
+        ) as HTMLTableElement | null
 
         if (!table) {
           throw new Error('table not ready')
@@ -1187,10 +1307,11 @@ test.describe('Framework parity regression', () => {
         table.style.height = ''
 
         const globalWindow = window as any
-        const editor = globalWindow.wangEditorExampleBridge?.editor
-          || globalWindow.vue2Editor
-          || globalWindow.vue3Editor
-          || globalWindow.reactEditor
+        const editor =
+          globalWindow.wangEditorExampleBridge?.editor ||
+          globalWindow.vue2Editor ||
+          globalWindow.vue3Editor ||
+          globalWindow.reactEditor
         const tableNode = (editor?.children || []).find((node: any) => node?.type === 'table')
 
         if (!tableNode) {
@@ -1221,7 +1342,9 @@ test.describe('Framework parity regression', () => {
       expect(pageErrors).toEqual([])
     })
 
-    test(`${target.name}: regression #505 fast drag should keep effective resize`, async ({ page }) => {
+    test(`${target.name}: regression #505 fast drag should keep effective resize`, async ({
+      page,
+    }) => {
       const pageErrors: string[] = []
 
       page.on('pageerror', err => {
@@ -1255,36 +1378,46 @@ test.describe('Framework parity regression', () => {
 
       const fastDragApplied = await page.evaluate(() => {
         const hotzoneEl = document.querySelector(
-          '[data-testid="editor-textarea"] .column-resizer .column-resizer-item:first-child .resizer-line-hotzone',
+          '[data-testid="editor-textarea"] .column-resizer .column-resizer-item:first-child .resizer-line-hotzone'
         ) as HTMLElement | null
 
-        if (!hotzoneEl) { return false }
+        if (!hotzoneEl) {
+          return false
+        }
 
         const rect = hotzoneEl.getBoundingClientRect()
         const x = Math.round(rect.left + rect.width / 2)
         const y = Math.round(rect.top + rect.height / 2)
 
-        hotzoneEl.dispatchEvent(new MouseEvent('mousedown', {
-          bubbles: true,
-          clientX: x,
-          clientY: y,
-        }))
+        hotzoneEl.dispatchEvent(
+          new MouseEvent('mousedown', {
+            bubbles: true,
+            clientX: x,
+            clientY: y,
+          })
+        )
         // Trigger a no-op movement first so the next movement is throttled trailing.
-        window.dispatchEvent(new MouseEvent('mousemove', {
-          bubbles: true,
-          clientX: x,
-          clientY: y,
-        }))
-        window.dispatchEvent(new MouseEvent('mousemove', {
-          bubbles: true,
-          clientX: x + 120,
-          clientY: y,
-        }))
-        window.dispatchEvent(new MouseEvent('mouseup', {
-          bubbles: true,
-          clientX: x + 120,
-          clientY: y,
-        }))
+        window.dispatchEvent(
+          new MouseEvent('mousemove', {
+            bubbles: true,
+            clientX: x,
+            clientY: y,
+          })
+        )
+        window.dispatchEvent(
+          new MouseEvent('mousemove', {
+            bubbles: true,
+            clientX: x + 120,
+            clientY: y,
+          })
+        )
+        window.dispatchEvent(
+          new MouseEvent('mouseup', {
+            bubbles: true,
+            clientX: x + 120,
+            clientY: y,
+          })
+        )
 
         return true
       })
@@ -1300,7 +1433,9 @@ test.describe('Framework parity regression', () => {
       expect(pageErrors).toEqual([])
     })
 
-    test(`${target.name}: setHtml in-table focus should keep single table and stable output`, async ({ page }) => {
+    test(`${target.name}: setHtml in-table focus should keep single table and stable output`, async ({
+      page,
+    }) => {
       const pageErrors: string[] = []
 
       page.on('pageerror', err => {
@@ -1332,70 +1467,83 @@ test.describe('Framework parity regression', () => {
         <p><br></p>
       `
 
-      await page.evaluate(({ html }) => {
-        const globalWindow = window as any
-        const editor = globalWindow.wangEditorExampleBridge?.editor
-          || globalWindow.vue2Editor
-          || globalWindow.vue3Editor
-          || globalWindow.reactEditor
+      await page.evaluate(
+        ({ html }) => {
+          const globalWindow = window as any
+          const editor =
+            globalWindow.wangEditorExampleBridge?.editor ||
+            globalWindow.vue2Editor ||
+            globalWindow.vue3Editor ||
+            globalWindow.reactEditor
 
-        if (!editor) {
-          throw new Error('editor not ready')
-        }
+          if (!editor) {
+            throw new Error('editor not ready')
+          }
 
-        const normalizeHtml = (value: string) => value.replace(/\s+/g, ' ').trim()
+          const normalizeHtml = (value: string) => value.replace(/\s+/g, ' ').trim()
 
-        editor.setHtml(html)
-        const afterFirstSet = normalizeHtml(editor.getHtml())
+          editor.setHtml(html)
+          const afterFirstSet = normalizeHtml(editor.getHtml())
 
-        editor.setHtml(html)
-        const afterSecondSet = normalizeHtml(editor.getHtml())
+          editor.setHtml(html)
+          const afterSecondSet = normalizeHtml(editor.getHtml())
 
-        globalWindow.setHtmlStableFlag = afterFirstSet === afterSecondSet
-        globalWindow.setHtmlTableCountAfterFirst = (afterFirstSet.match(/<table/gi) || []).length
-        globalWindow.setHtmlTableCountAfterSecond = (afterSecondSet.match(/<table/gi) || []).length
+          globalWindow.setHtmlStableFlag = afterFirstSet === afterSecondSet
+          globalWindow.setHtmlTableCountAfterFirst = (afterFirstSet.match(/<table/gi) || []).length
+          globalWindow.setHtmlTableCountAfterSecond = (
+            afterSecondSet.match(/<table/gi) || []
+          ).length
 
-        const tableIndex = editor.children.findIndex((node: any) => node?.type === 'table')
+          const tableIndex = editor.children.findIndex((node: any) => node?.type === 'table')
 
-        if (tableIndex < 0) {
-          throw new Error('table node not found')
-        }
+          if (tableIndex < 0) {
+            throw new Error('table node not found')
+          }
 
-        editor.select({
-          anchor: { path: [tableIndex, 0, 0, 0, 0], offset: 0 },
-          focus: { path: [tableIndex, 0, 0, 0, 0], offset: 1 },
-        })
-      }, { html: firstHtml })
+          editor.select({
+            anchor: { path: [tableIndex, 0, 0, 0, 0], offset: 0 },
+            focus: { path: [tableIndex, 0, 0, 0, 0], offset: 1 },
+          })
+        },
+        { html: firstHtml }
+      )
 
       await page.waitForTimeout(120)
 
-      await page.evaluate(({ html }) => {
-        const globalWindow = window as any
-        const editor = globalWindow.wangEditorExampleBridge?.editor
-          || globalWindow.vue2Editor
-          || globalWindow.vue3Editor
-          || globalWindow.reactEditor
+      await page.evaluate(
+        ({ html }) => {
+          const globalWindow = window as any
+          const editor =
+            globalWindow.wangEditorExampleBridge?.editor ||
+            globalWindow.vue2Editor ||
+            globalWindow.vue3Editor ||
+            globalWindow.reactEditor
 
-        if (!editor) {
-          throw new Error('editor not ready')
-        }
+          if (!editor) {
+            throw new Error('editor not ready')
+          }
 
-        editor.setHtml(html)
-      }, { html: secondHtml })
+          editor.setHtml(html)
+        },
+        { html: secondHtml }
+      )
 
       await page.waitForTimeout(160)
 
       const snapshot = await page.evaluate(() => {
         const globalWindow = window as any
-        const editor = globalWindow.wangEditorExampleBridge?.editor
-          || globalWindow.vue2Editor
-          || globalWindow.vue3Editor
-          || globalWindow.reactEditor
+        const editor =
+          globalWindow.wangEditorExampleBridge?.editor ||
+          globalWindow.vue2Editor ||
+          globalWindow.vue3Editor ||
+          globalWindow.reactEditor
         const root = document.querySelector('[data-testid="editor-textarea"]') as HTMLElement | null
         const tableElements = Array.from(root?.querySelectorAll('table') || [])
         const nestedTableElements = Array.from(root?.querySelectorAll('table table') || [])
         const firstCell = tableElements[0]?.querySelector('tr td, tr th') as HTMLElement | null
-        const modelTableCount = (editor?.children || []).filter((node: any) => node?.type === 'table').length
+        const modelTableCount = (editor?.children || []).filter(
+          (node: any) => node?.type === 'table'
+        ).length
         const currentHtml = editor?.getHtml?.() || ''
 
         return {
@@ -1423,7 +1571,9 @@ test.describe('Framework parity regression', () => {
       expect(pageErrors).toEqual([])
     })
 
-    test(`${target.name}: regression #608 mixed bold span should keep non-bold subrange`, async ({ page }) => {
+    test(`${target.name}: regression #608 mixed bold span should keep non-bold subrange`, async ({
+      page,
+    }) => {
       const pageErrors: string[] = []
 
       page.on('pageerror', err => {
@@ -1434,16 +1584,19 @@ test.describe('Framework parity regression', () => {
 
       await page.evaluate(async () => {
         const globalWindow = window as any
-        const editor = globalWindow.wangEditorExampleBridge?.editor
-          || globalWindow.vue2Editor
-          || globalWindow.vue3Editor
-          || globalWindow.reactEditor
+        const editor =
+          globalWindow.wangEditorExampleBridge?.editor ||
+          globalWindow.vue2Editor ||
+          globalWindow.vue3Editor ||
+          globalWindow.reactEditor
 
         if (!editor) {
           throw new Error('editor not ready')
         }
 
-        editor.setHtml('<p><span style="font-weight: 700;">前缀<span style="font-weight: 400;">中间</span>后缀</span></p><p><br></p>')
+        editor.setHtml(
+          '<p><span style="font-weight: 700;">前缀<span style="font-weight: 400;">中间</span>后缀</span></p><p><br></p>'
+        )
 
         await new Promise<void>(resolve => {
           setTimeout(() => resolve(), 80)
@@ -1451,17 +1604,20 @@ test.describe('Framework parity regression', () => {
       })
       const snapshot = await page.evaluate(() => {
         const globalWindow = window as any
-        const editor = globalWindow.wangEditorExampleBridge?.editor
-          || globalWindow.vue2Editor
-          || globalWindow.vue3Editor
-          || globalWindow.reactEditor
+        const editor =
+          globalWindow.wangEditorExampleBridge?.editor ||
+          globalWindow.vue2Editor ||
+          globalWindow.vue3Editor ||
+          globalWindow.reactEditor
 
         if (!editor) {
           throw new Error('editor not ready')
         }
 
         const richParagraph = (editor.children || []).find((node: any) => {
-          if (!node || node.type !== 'paragraph') { return false }
+          if (!node || node.type !== 'paragraph') {
+            return false
+          }
           const text = (node.children || [])
             .map((child: any) => String(child?.text || ''))
             .join('')
@@ -1493,7 +1649,9 @@ test.describe('Framework parity regression', () => {
       expect(pageErrors).toEqual([])
     })
 
-    test(`${target.name}: regression #621 heading default font-size should clear pasted inline size`, async ({ page }) => {
+    test(`${target.name}: regression #621 heading default font-size should clear pasted inline size`, async ({
+      page,
+    }) => {
       const pageErrors: string[] = []
 
       page.on('pageerror', err => {
@@ -1504,10 +1662,11 @@ test.describe('Framework parity regression', () => {
 
       await page.evaluate(async () => {
         const globalWindow = window as any
-        const editor = globalWindow.wangEditorExampleBridge?.editor
-          || globalWindow.vue2Editor
-          || globalWindow.vue3Editor
-          || globalWindow.reactEditor
+        const editor =
+          globalWindow.wangEditorExampleBridge?.editor ||
+          globalWindow.vue2Editor ||
+          globalWindow.vue3Editor ||
+          globalWindow.reactEditor
 
         if (!editor) {
           throw new Error('editor not ready')
@@ -1530,14 +1689,20 @@ test.describe('Framework parity regression', () => {
         const headingTextNode = editor.children?.[headingIndex]?.children?.[0] || {}
         const text = String(headingTextNode.text || '')
         const endOffset = Math.max(text.length, 1)
-        const editable = document.querySelector('[data-testid="editor-textarea"] [contenteditable="true"]')
-        const headingLeaf = editable?.querySelector('h2 [data-slate-string="true"]') as HTMLElement | null
+        const editable = document.querySelector(
+          '[data-testid="editor-textarea"] [contenteditable="true"]'
+        )
+        const headingLeaf = editable?.querySelector(
+          'h2 [data-slate-string="true"]'
+        ) as HTMLElement | null
 
         if (!headingLeaf) {
           throw new Error('heading leaf dom not found')
         }
 
-        globalWindow.issue621BeforeSize = Number.parseFloat(window.getComputedStyle(headingLeaf).fontSize || '0')
+        globalWindow.issue621BeforeSize = Number.parseFloat(
+          window.getComputedStyle(headingLeaf).fontSize || '0'
+        )
         globalWindow.issue621BeforeModelFontSize = String(headingTextNode.fontSize || '')
 
         editor.select({
@@ -1556,10 +1721,11 @@ test.describe('Framework parity regression', () => {
       } else {
         await page.evaluate(() => {
           const globalWindow = window as any
-          const editor = globalWindow.wangEditorExampleBridge?.editor
-            || globalWindow.vue2Editor
-            || globalWindow.vue3Editor
-            || globalWindow.reactEditor
+          const editor =
+            globalWindow.wangEditorExampleBridge?.editor ||
+            globalWindow.vue2Editor ||
+            globalWindow.vue3Editor ||
+            globalWindow.reactEditor
 
           if (!editor) {
             throw new Error('editor not ready')
@@ -1574,26 +1740,34 @@ test.describe('Framework parity regression', () => {
 
       const snapshot = await page.evaluate(() => {
         const globalWindow = window as any
-        const editor = globalWindow.wangEditorExampleBridge?.editor
-          || globalWindow.vue2Editor
-          || globalWindow.vue3Editor
-          || globalWindow.reactEditor
+        const editor =
+          globalWindow.wangEditorExampleBridge?.editor ||
+          globalWindow.vue2Editor ||
+          globalWindow.vue3Editor ||
+          globalWindow.reactEditor
 
         if (!editor) {
           throw new Error('editor not ready')
         }
 
         const headingIndex = editor.children.findIndex((node: any) => node?.type === 'header2')
-        const headingTextNode = headingIndex >= 0 ? (editor.children?.[headingIndex]?.children?.[0] || {}) : {}
-        const editable = document.querySelector('[data-testid="editor-textarea"] [contenteditable="true"]')
+        const headingTextNode =
+          headingIndex >= 0 ? editor.children?.[headingIndex]?.children?.[0] || {} : {}
+        const editable = document.querySelector(
+          '[data-testid="editor-textarea"] [contenteditable="true"]'
+        )
         const heading = editable?.querySelector('h2') as HTMLElement | null
-        const headingLeaf = editable?.querySelector('h2 [data-slate-string="true"]') as HTMLElement | null
+        const headingLeaf = editable?.querySelector(
+          'h2 [data-slate-string="true"]'
+        ) as HTMLElement | null
         const html = editor.getHtml?.() || ''
 
         return {
           beforeSize: Number(globalWindow.issue621BeforeSize || 0),
           beforeModelFontSize: String(globalWindow.issue621BeforeModelFontSize || ''),
-          afterSize: Number.parseFloat(headingLeaf ? window.getComputedStyle(headingLeaf).fontSize || '0' : '0'),
+          afterSize: Number.parseFloat(
+            headingLeaf ? window.getComputedStyle(headingLeaf).fontSize || '0' : '0'
+          ),
           leafStyle: headingLeaf?.getAttribute('style') || '',
           modelFontSize: String(headingTextNode.fontSize || ''),
           html,
@@ -1612,7 +1786,9 @@ test.describe('Framework parity regression', () => {
       expect(pageErrors).toEqual([])
     })
 
-    test(`${target.name}: rich table cells should support blocks, paste, Enter, and final Tab`, async ({ page }) => {
+    test(`${target.name}: rich table cells should support blocks, paste, Enter, and final Tab`, async ({
+      page,
+    }) => {
       const pageErrors: string[] = []
 
       page.on('pageerror', err => {
@@ -1623,10 +1799,11 @@ test.describe('Framework parity regression', () => {
 
       const initialState = await page.evaluate(() => {
         const globalWindow = window as any
-        const editor = globalWindow.wangEditorExampleBridge?.editor
-          || globalWindow.vue2Editor
-          || globalWindow.vue3Editor
-          || globalWindow.reactEditor
+        const editor =
+          globalWindow.wangEditorExampleBridge?.editor ||
+          globalWindow.vue2Editor ||
+          globalWindow.vue3Editor ||
+          globalWindow.reactEditor
 
         if (!editor) {
           throw new Error('editor not ready')
@@ -1663,14 +1840,16 @@ test.describe('Framework parity regression', () => {
 
       const afterEnterTypes = await page.evaluate(() => {
         const globalWindow = window as any
-        const editor = globalWindow.wangEditorExampleBridge?.editor
-          || globalWindow.vue2Editor
-          || globalWindow.vue3Editor
-          || globalWindow.reactEditor
+        const editor =
+          globalWindow.wangEditorExampleBridge?.editor ||
+          globalWindow.vue2Editor ||
+          globalWindow.vue3Editor ||
+          globalWindow.reactEditor
         const tableIndex = editor.children.findIndex((node: any) => node?.type === 'table')
 
-        return editor.children[tableIndex].children[0].children[0].children
-          .map((node: any) => node.type)
+        return editor.children[tableIndex].children[0].children[0].children.map(
+          (node: any) => node.type
+        )
       })
 
       expect(afterEnterTypes).toEqual(['paragraph', 'paragraph', 'list-item'])
@@ -1701,10 +1880,11 @@ test.describe('Framework parity regression', () => {
 
       const pasteState = await page.evaluate(() => {
         const globalWindow = window as any
-        const editor = globalWindow.wangEditorExampleBridge?.editor
-          || globalWindow.vue2Editor
-          || globalWindow.vue3Editor
-          || globalWindow.reactEditor
+        const editor =
+          globalWindow.wangEditorExampleBridge?.editor ||
+          globalWindow.vue2Editor ||
+          globalWindow.vue3Editor ||
+          globalWindow.reactEditor
 
         editor.setHtml(`
           <table><tbody><tr>
@@ -1755,10 +1935,11 @@ test.describe('Framework parity regression', () => {
 
       const selectionAfterTab = await page.evaluate(() => {
         const globalWindow = window as any
-        const editor = globalWindow.wangEditorExampleBridge?.editor
-          || globalWindow.vue2Editor
-          || globalWindow.vue3Editor
-          || globalWindow.reactEditor
+        const editor =
+          globalWindow.wangEditorExampleBridge?.editor ||
+          globalWindow.vue2Editor ||
+          globalWindow.vue3Editor ||
+          globalWindow.reactEditor
 
         return editor.selection
       })
@@ -1770,7 +1951,72 @@ test.describe('Framework parity regression', () => {
       expect(pageErrors).toEqual([])
     })
 
-    test(`${target.name}: table multi-cell bold should affect only selected cells`, async ({ page }) => {
+    test(`${target.name}: table cells should preserve video and code blocks`, async ({ page }) => {
+      const pageErrors: string[] = []
+
+      page.on('pageerror', err => {
+        pageErrors.push(err?.stack || err?.message || String(err))
+      })
+
+      await openTarget(page, target)
+
+      const state = await page.evaluate(() => {
+        const globalWindow = window as any
+        const editor =
+          globalWindow.wangEditorExampleBridge?.editor ||
+          globalWindow.vue2Editor ||
+          globalWindow.vue3Editor ||
+          globalWindow.reactEditor
+
+        if (!editor) {
+          throw new Error('editor not ready')
+        }
+
+        editor.setHtml(
+          '<table><tbody><tr><td><p>media</p><figure data-w-e-type="video" data-w-e-is-void><video controls="true" width="320" height="180"><source src="https://example.com/table-cell.mp4" type="video/mp4"/></video></figure><pre><code>const insideCell = true</code></pre></td></tr></tbody></table><p>after</p>'
+        )
+
+        const tableIndex = editor.children.findIndex((node: any) => node?.type === 'table')
+
+        editor.select({
+          anchor: { path: [tableIndex, 0, 0, 0, 0], offset: 0 },
+          focus: { path: [tableIndex, 0, 0, 0, 0], offset: 0 },
+        })
+
+        const cell = editor.children[tableIndex].children[0].children[0]
+        const html = editor.getHtml()
+
+        editor.setHtml(html)
+        editor.select({
+          anchor: { path: [tableIndex, 0, 0, 0, 0], offset: 0 },
+          focus: { path: [tableIndex, 0, 0, 0, 0], offset: 0 },
+        })
+
+        return {
+          blockTypes: cell.children.map((node: any) => node.type),
+          html,
+          reparsedTypes: editor.children[tableIndex].children[0].children[0].children.map(
+            (node: any) => node.type
+          ),
+        }
+      })
+
+      expect(state.blockTypes).toEqual(['paragraph', 'video', 'pre'])
+      expect(state.reparsedTypes).toEqual(['paragraph', 'video', 'pre'])
+      expect(state.html).toContain('data-w-e-type="video"')
+      expect(state.html).toContain('<pre><code>const insideCell = true</code></pre>')
+      await expect(
+        page.locator('[data-testid="editor-textarea"] table figure.w-e-video')
+      ).toHaveCount(1)
+      await expect(page.locator('[data-testid="editor-textarea"] table pre code')).toHaveText(
+        'const insideCell = true'
+      )
+      expect(pageErrors).toEqual([])
+    })
+
+    test(`${target.name}: table multi-cell bold should affect only selected cells`, async ({
+      page,
+    }) => {
       const pageErrors: string[] = []
 
       page.on('pageerror', err => {
@@ -1781,10 +2027,11 @@ test.describe('Framework parity regression', () => {
 
       await page.evaluate(() => {
         const globalWindow = window as any
-        const editor = globalWindow.wangEditorExampleBridge?.editor
-          || globalWindow.vue2Editor
-          || globalWindow.vue3Editor
-          || globalWindow.reactEditor
+        const editor =
+          globalWindow.wangEditorExampleBridge?.editor ||
+          globalWindow.vue2Editor ||
+          globalWindow.vue3Editor ||
+          globalWindow.reactEditor
 
         if (!editor) {
           throw new Error('editor not ready')
@@ -1816,10 +2063,11 @@ test.describe('Framework parity regression', () => {
 
       const selectionState = await page.evaluate(() => {
         const globalWindow = window as any
-        const editor = globalWindow.wangEditorExampleBridge?.editor
-          || globalWindow.vue2Editor
-          || globalWindow.vue3Editor
-          || globalWindow.reactEditor
+        const editor =
+          globalWindow.wangEditorExampleBridge?.editor ||
+          globalWindow.vue2Editor ||
+          globalWindow.vue3Editor ||
+          globalWindow.reactEditor
 
         if (!editor) {
           throw new Error('editor not ready')
@@ -1843,10 +2091,11 @@ test.describe('Framework parity regression', () => {
 
       const markState = await page.evaluate(() => {
         const globalWindow = window as any
-        const editor = globalWindow.wangEditorExampleBridge?.editor
-          || globalWindow.vue2Editor
-          || globalWindow.vue3Editor
-          || globalWindow.reactEditor
+        const editor =
+          globalWindow.wangEditorExampleBridge?.editor ||
+          globalWindow.vue2Editor ||
+          globalWindow.vue3Editor ||
+          globalWindow.reactEditor
 
         if (!editor) {
           throw new Error('editor not ready')
@@ -1859,8 +2108,10 @@ test.describe('Framework parity regression', () => {
         }
 
         const getCellTextNode = (row: number, col: number) => {
-          return editor.children?.[tableIndex]?.children?.[row]?.children?.[col]
-            ?.children?.[0]?.children?.[0] || {}
+          return (
+            editor.children?.[tableIndex]?.children?.[row]?.children?.[col]?.children?.[0]
+              ?.children?.[0] || {}
+          )
         }
 
         return {
@@ -1879,7 +2130,9 @@ test.describe('Framework parity regression', () => {
     })
   }
 
-  test('vue2-wrapper-markdown: regression #675 should skip markdown trigger during composition', async ({ page }) => {
+  test('vue2-wrapper-markdown: regression #675 should skip markdown trigger during composition', async ({
+    page,
+  }) => {
     const pageErrors: string[] = []
 
     page.on('pageerror', err => {
@@ -1941,7 +2194,9 @@ test.describe('Framework parity regression', () => {
     expect(pageErrors).toEqual([])
   })
 
-  test('vue3-wrapper: regression #388 enter-at-bottom should keep scroll pinned', async ({ page }) => {
+  test('vue3-wrapper: regression #388 enter-at-bottom should keep scroll pinned', async ({
+    page,
+  }) => {
     const pageErrors: string[] = []
 
     page.on('pageerror', err => {
@@ -2020,9 +2275,10 @@ test.describe('Framework parity regression', () => {
           caretTop = rangeRect.top
           caretBottom = rangeRect.bottom
         } else if (selection.anchorNode) {
-          const anchorElem = selection.anchorNode.nodeType === Node.TEXT_NODE
-            ? selection.anchorNode.parentElement
-            : selection.anchorNode as Element
+          const anchorElem =
+            selection.anchorNode.nodeType === Node.TEXT_NODE
+              ? selection.anchorNode.parentElement
+              : (selection.anchorNode as Element)
           const anchorRect = anchorElem?.getBoundingClientRect()
 
           if (anchorRect) {


### PR DESCRIPTION
## Summary

- Preserve `video` and `pre/code` blocks directly inside table cells.
- Keep supported paragraph and list blocks safe during table HTML parsing and paste.
- Insert videos and convert code blocks in-place when the selection is inside a table cell.
- Reject unsupported custom blocks and nested tables in structured cell fragments.
- Add package changesets and cross-framework regression coverage.

## Validation

- `@wangeditor-next/table-module`: 30 files, 274 tests passed
- `@wangeditor-next/basic-modules`: 22 tests passed
- `@wangeditor-next/video-module`: 15 tests passed
- Playwright Chromium: HTML core, Vue2, Vue3, and React media-cell tests: 4 passed
- Affected-file ESLint and Prettier checks passed
- `pnpm turbo build --filter=@wangeditor-next/editor`: 8 tasks successful

The local Playwright Chromium executable was installed before running the browser suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Table cells now preserve supported video and code-block content when editing or reloading content.
  * Videos can be inserted directly into table cells.
  * Code blocks inside table cells can be converted to and from paragraphs without leaving the cell.
  * Unsupported custom blocks and nested tables are rejected with a plain-text fallback.

* **Bug Fixes**
  * Empty table cells now remain valid and editable with an empty paragraph.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->