### PR TITLE
fix(table): remove empty paragraph before video

### DIFF
--- a/.changeset/calm-videos-delete.md
+++ b/.changeset/calm-videos-delete.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/table-module': patch
+---
+
+Allow backspace to remove an empty paragraph immediately before a block void node in a table cell.

--- a/packages/table-module/__tests__/plugin.test.ts
+++ b/packages/table-module/__tests__/plugin.test.ts
@@ -291,6 +291,55 @@ describe('TableModule module', () => {
       expect(originalForward).not.toHaveBeenCalled()
     })
 
+    test('use withTable plugin when deleteBackward should remove an empty paragraph before a void block', () => {
+      const editor = createEditor({
+        content: [
+          {
+            type: 'table',
+            width: 'auto',
+            children: [
+              {
+                type: 'table-row',
+                children: [
+                  {
+                    type: 'table-cell',
+                    children: [
+                      { type: 'paragraph', children: [{ text: '' }] },
+                      {
+                        type: 'video',
+                        src: 'https://example.com/table.mp4',
+                        poster: '',
+                        width: '320',
+                        height: '180',
+                        children: [{ text: '' }],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            columnWidths: [100],
+          },
+          { type: 'paragraph', children: [{ text: '' }] },
+        ],
+      })
+
+      editor.selection = {
+        anchor: { path: [0, 0, 0, 0, 0], offset: 0 },
+        focus: { path: [0, 0, 0, 0, 0], offset: 0 },
+      }
+
+      editor.deleteBackward('character')
+
+      const cell = slate.Node.get(editor, [0, 0, 0]) as slate.Element
+
+      expect(cell.children.map((node: any) => node.type)).toEqual(['video'])
+      expect(editor.selection).toEqual({
+        anchor: { path: [0, 0, 0, 0, 0], offset: 0 },
+        focus: { path: [0, 0, 0, 0, 0], offset: 0 },
+      })
+    })
+
     test('use withTable plugin when handleTab should move to next cell or append a paragraph after the table', () => {
       const editor = createEditor({
         content: [

--- a/packages/table-module/src/module/plugin.ts
+++ b/packages/table-module/src/module/plugin.ts
@@ -73,6 +73,51 @@ function parseSupportedSlateFragment(
 }
 
 // table cell 内部的删除处理
+function deleteEmptyParagraphBeforeVoid(newEditor: IDomEditor): boolean {
+  const { selection } = newEditor
+
+  if (selection == null || !Point.equals(selection.anchor, selection.focus)) {
+    return false
+  }
+
+  const [cellEntry] = Editor.nodes(newEditor, {
+    at: selection,
+    match: n => DomEditor.checkNodeType(n, 'table-cell'),
+  })
+
+  if (cellEntry == null) {
+    return false
+  }
+
+  const [cellNode, cellPath] = cellEntry
+  const cellStart = Editor.start(newEditor, cellPath)
+
+  if (!Point.equals(selection.anchor, cellStart) || !SlateElement.isElement(cellNode)) {
+    return false
+  }
+
+  const [firstChild, nextChild] = cellNode.children
+
+  if (
+    !SlateElement.isElement(firstChild) ||
+    firstChild.type !== 'paragraph' ||
+    Node.string(firstChild) !== '' ||
+    !SlateElement.isElement(nextChild) ||
+    newEditor.isInline(nextChild) ||
+    !newEditor.isVoid(nextChild)
+  ) {
+    return false
+  }
+
+  const nextChildPath = cellPath.concat(1)
+
+  // Keep selection on the following void block while the leading paragraph is removed.
+  Transforms.select(newEditor, Editor.start(newEditor, nextChildPath))
+  Transforms.removeNodes(newEditor, { at: cellPath.concat(0) })
+  Transforms.select(newEditor, Editor.start(newEditor, cellPath.concat(0)))
+  return true
+}
+
 function deleteHandler(newEditor: IDomEditor): boolean {
   const { selection } = newEditor
 
@@ -272,6 +317,10 @@ function withTable<T extends IDomEditor>(editor: T): T {
 
   // 重写 delete - cell 内删除，只删除文字，不删除 node
   newEditor.deleteBackward = unit => {
+    if (deleteEmptyParagraphBeforeVoid(newEditor)) {
+      return
+    }
+
     const res = deleteHandler(newEditor)
 
     if (res) {

--- a/tests/e2e/framework-regression.spec.ts
+++ b/tests/e2e/framework-regression.spec.ts
@@ -2014,6 +2014,68 @@ test.describe('Framework parity regression', () => {
       expect(pageErrors).toEqual([])
     })
 
+    test(`${target.name}: backspace should remove an empty paragraph before table video`, async ({
+      page,
+    }) => {
+      const pageErrors: string[] = []
+
+      page.on('pageerror', err => {
+        pageErrors.push(err?.stack || err?.message || String(err))
+      })
+
+      await openTarget(page, target)
+
+      await page.evaluate(() => {
+        const globalWindow = window as any
+        const editor =
+          globalWindow.wangEditorExampleBridge?.editor ||
+          globalWindow.vue2Editor ||
+          globalWindow.vue3Editor ||
+          globalWindow.reactEditor
+
+        if (!editor) {
+          throw new Error('editor not ready')
+        }
+
+        editor.setHtml(
+          '<table><tbody><tr><td><p><br></p><figure data-w-e-type="video" data-w-e-is-void><video controls="true" width="320" height="180"><source src="https://example.com/table-cell.mp4" type="video/mp4"/></video></figure></td></tr></tbody></table><p>after</p>'
+        )
+      })
+
+      const video = page.locator('[data-testid="editor-textarea"] table figure').first()
+
+      await video.click({ force: true })
+      await page.keyboard.press('ArrowLeft')
+      await page.keyboard.press('Backspace')
+      await page.waitForTimeout(120)
+
+      const state = await page.evaluate(() => {
+        const globalWindow = window as any
+        const editor =
+          globalWindow.wangEditorExampleBridge?.editor ||
+          globalWindow.vue2Editor ||
+          globalWindow.vue3Editor ||
+          globalWindow.reactEditor
+        const table = editor?.children?.find((node: any) => node?.type === 'table')
+        const cell = table?.children?.[0]?.children?.[0]
+
+        return {
+          cellTypes: cell?.children?.map((node: any) => node?.type) || [],
+          html: editor?.getHtml?.() || '',
+          selection: editor?.selection || null,
+        }
+      })
+
+      expect(state.cellTypes).toEqual(['video'])
+      expect(state.html).toContain('data-w-e-type="video"')
+      expect(state.html).not.toContain('<p><br></p>')
+      expect(state.selection).toEqual({
+        anchor: { path: [0, 0, 0, 0, 0], offset: 0 },
+        focus: { path: [0, 0, 0, 0, 0], offset: 0 },
+      })
+      expect(pageErrors).toEqual([])
+    })
+
     test(`${target.name}: table multi-cell bold should affect only selected cells`, async ({
       page,
     }) => {


### PR DESCRIPTION
## Summary

- Allow Backspace to remove a leading empty paragraph before a block void node in a table cell.
- Preserve the existing protection against deleting a table cell at its only content boundary.
- Add unit and cross-framework Playwright regression coverage for video nodes.

## Validation

- `pnpm exec vitest run packages/table-module/__tests__/plugin.test.ts packages/table-module/__tests__/rich-content.test.ts --maxWorkers=1 --minWorkers=1` (25 passed)
- `pnpm exec playwright test tests/e2e/framework-regression.spec.ts --grep "backspace should remove an empty paragraph before table video" --project=chromium --workers=1` (4 passed)
- `pnpm turbo build --filter=@wangeditor-next/editor-for-vue2 --filter=@wangeditor-next/plugin-ctrl-enter --filter=@wangeditor-next/plugin-markdown` (11 successful)
- Affected-file ESLint and `git diff --check` passed

Related to #963 and #1001.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Backspace now correctly removes an empty paragraph immediately before a video or other block element inside a table cell.
  - The video remains in place, and the cursor stays at the beginning of the cell after deletion.

- **Tests**
  - Added coverage for this behavior across table editing and framework regression scenarios.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->