### PR TITLE
fix(plugin-formula): 修复失焦后编辑公式报错

### DIFF
--- a/.changeset/calm-formulas-edit.md
+++ b/.changeset/calm-formulas-edit.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/plugin-formula': patch
+---
+
+fix(plugin-formula): preserve formula editing after focus is restored

--- a/packages/plugin-formula/__tests__/module.test.ts
+++ b/packages/plugin-formula/__tests__/module.test.ts
@@ -1,7 +1,15 @@
-import { DomEditor } from '@wangeditor-next/editor'
+import {
+  Boot,
+  createEditor,
+  DomEditor,
+  SlateEditor,
+  SlateTransforms,
+} from '@wangeditor-next/editor'
 import { afterEach, vi } from 'vitest'
 
 import module from '../src'
+
+Boot.registerModule(module)
 
 afterEach(() => {
   vi.restoreAllMocks()
@@ -29,5 +37,46 @@ describe('plugin-formula module', () => {
 
     expect(vnode.data.style.maxWidth).toBe('100%')
     expect(vnode.data.style.overflowX).toBe('auto')
+  })
+
+  it('updates a formula after the editor loses focus while its modal is open', async () => {
+    const container = document.createElement('div')
+
+    document.body.appendChild(container)
+    const editor = createEditor({
+      selector: container,
+      html: '<p><span data-w-e-type="formula" data-w-e-is-void data-w-e-is-inline data-value="x"></span></p>',
+      mode: 'simple',
+    })
+
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    const [, formulaPath] = [...SlateEditor.nodes(editor, {
+      at: [],
+      match: node => 'type' in node && node.type === 'formula',
+      universal: true,
+    })][0] as any
+
+    SlateTransforms.select(editor, {
+      anchor: { path: [...formulaPath, 0], offset: 0 },
+      focus: { path: [...formulaPath, 0], offset: 0 },
+    })
+    editor.onChange()
+
+    const menu = (module.menus?.find(item => item.key === 'editFormula') as any).factory()
+    const content = menu.getModalContentElem(editor)
+    const textarea = content.querySelector('textarea') as HTMLTextAreaElement
+
+    textarea.value = 'y'
+
+    editor.blur()
+    expect(editor.selection).toBeNull()
+    expect(() => (content.querySelector('button') as HTMLButtonElement).click()).not.toThrow()
+
+    const updatedFormula = (editor.children[0] as any).children
+      .find((node: any) => node.type === 'formula')
+
+    expect(updatedFormula.value).toBe('y')
+    editor.destroy()
   })
 })

--- a/packages/plugin-formula/src/module/menu/EditFormula.ts
+++ b/packages/plugin-formula/src/module/menu/EditFormula.ts
@@ -4,12 +4,14 @@
  */
 
 import {
-  DomEditor,
   genModalButtonElems,
   genModalTextareaElems,
   IDomEditor,
   IModalMenu,
+  SlateEditor,
+  SlateElement,
   SlateNode,
+  SlatePath,
   SlateRange,
   SlateTransforms,
   t,
@@ -45,10 +47,24 @@ class EditFormulaMenu implements IModalMenu {
   private readonly buttonId = genDomID()
 
   private getSelectedElem(editor: IDomEditor): FormulaElement | null {
-    const node = DomEditor.getSelectedNodeByType(editor, 'formula')
+    const entry = this.getSelectedFormulaEntry(editor)
 
-    if (node == null) { return null }
-    return node as FormulaElement
+    if (entry == null) { return null }
+    return entry[0]
+  }
+
+  private getSelectedFormulaEntry(editor: IDomEditor): [FormulaElement, SlatePath] | null {
+    const { selection } = editor
+
+    if (selection == null) { return null }
+
+    const entry = SlateEditor.above(editor, {
+      at: selection,
+      match: node => SlateElement.isElement(node) && node.type === 'formula',
+    })
+
+    if (entry == null) { return null }
+    return entry as [FormulaElement, SlatePath]
   }
 
   /**
@@ -150,11 +166,11 @@ class EditFormulaMenu implements IModalMenu {
 
     if (this.isDisabled(editor)) { return }
 
-    const selectedElem = this.getSelectedElem(editor)
+    const selectedEntry = this.getSelectedFormulaEntry(editor)
 
-    if (selectedElem == null) { return }
+    if (selectedEntry == null) { return }
 
-    const path = DomEditor.findPath(editor, selectedElem)
+    const [, path] = selectedEntry
     const props: Partial<FormulaElement> = { value }
 
     SlateTransforms.setNodes(editor, props, { at: path })


### PR DESCRIPTION
## 变更说明\n\n修复公式编辑弹窗打开后编辑器失焦，点击确定时因 Slate 节点映射失效而抛出 Unable to find the path for Slate node 的问题。更新公式时改为从当前选区解析节点路径并直接写入。\n\n## 验证\n\n- plugin-formula Vitest：3/3 通过\n- plugin-formula TypeScript 检查通过\n- ESLint 与 git diff --check 通过\n- 浏览器复现流程通过，公式可从 x 更新为 y 且无错误日志\n\nFixes #1004

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed formula editing after the editor loses and regains focus.
  * Updated formula selection and editing to reliably target the selected formula, preventing errors when applying changes from the edit dialog.

* **Tests**
  * Added coverage for editing a formula after the editor is blurred.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->