### PR TITLE
fix(image): make linked table images clickable

### DIFF
--- a/.changeset/bright-images-link.md
+++ b/.changeset/bright-images-link.md
@@ -1,0 +1,5 @@
+---
+'@wangeditor-next/basic-modules': patch
+---
+
+Render and export linked images as semantic anchors while preserving image-node round trips, including images inside table cells.

--- a/packages/basic-modules/__tests__/image/elem-to-html.test.ts
+++ b/packages/basic-modules/__tests__/image/elem-to-html.test.ts
@@ -22,7 +22,7 @@ describe('image to html', () => {
     const html = imageToHtmlConf.elemToHtml(elem, '')
 
     expect(html).toBe(
-      `<img src="${src}" alt="logo" data-href="${href}" width="" height="" style="width: 100;height: 80;"/>`,
+      `<a href="${href}" target="_blank"><img src="${src}" alt="logo" data-href="${href}" width="" height="" style="width: 100;height: 80;"/></a>`
     )
   })
 
@@ -45,7 +45,7 @@ describe('image to html', () => {
     const html = imageToHtmlConf.elemToHtml(elem, '', mockEditor)
 
     expect(html).toBe(
-      `<img src="${src}" alt="logo" data-href="${href}" width="100px" height="80px" data-w-e-style-width="100px" data-w-e-style-height="80px"/>`,
+      `<a href="${href}" target="_blank"><img src="${src}" alt="logo" data-href="${href}" width="100px" height="80px" data-w-e-style-width="100px" data-w-e-style-height="80px"/></a>`
     )
     expect(html).not.toContain('style=')
   })

--- a/packages/basic-modules/__tests__/image/render-elem.test.ts
+++ b/packages/basic-modules/__tests__/image/render-elem.test.ts
@@ -47,9 +47,12 @@ describe('image render elem', () => {
 
     const imageVnode = containerVnode.children[0] as any
 
-    expect(imageVnode.sel).toBe('img')
-    expect(imageVnode.data.src).toBe(src)
-    expect(imageVnode.data['data-href']).toBe(href)
+    expect(imageVnode.sel).toBe('a')
+    expect(imageVnode.data.href).toBe(href)
+    expect(imageVnode.data.target).toBe('_blank')
+    expect(imageVnode.children[0].sel).toBe('img')
+    expect(imageVnode.children[0].data.src).toBe(src)
+    expect(imageVnode.children[0].data['data-href']).toBe(href)
   })
 
   it('render image - selected image', () => {

--- a/packages/basic-modules/__tests__/link/parse-html.test.ts
+++ b/packages/basic-modules/__tests__/link/parse-html.test.ts
@@ -58,6 +58,27 @@ describe('link - parse html', () => {
     })
   })
 
+  it('should restore an image link anchor to an image node', () => {
+    const $link = $('<a href="https://example.com/image" target="_blank"></a>')
+    const children = [
+      {
+        type: 'image',
+        src: 'https://example.com/image.png',
+        href: 'https://example.com/image',
+        children: [{ text: '' }],
+      },
+    ]
+
+    const res = parseHtmlConf.parseElemHtml($link[0], children, editor)
+
+    expect(res).toEqual({
+      type: 'image',
+      src: 'https://example.com/image.png',
+      href: 'https://example.com/image',
+      children: [{ text: '' }],
+    })
+  })
+
   it('should normalize href formatting whitespace from imported html', () => {
     const $link = $('<a href=" \nhttps://localhost/a b\t\r " target="_blank">hello</a>')
     const children = [{ text: 'hello' }]

--- a/packages/basic-modules/src/modules/image/elem-to-html.ts
+++ b/packages/basic-modules/src/modules/image/elem-to-html.ts
@@ -15,6 +15,8 @@ function imageToHtml(elemNode: Element, _childrenHtml: string, editor?: IDomEdit
   const { width: styleWidth = '', height: styleHeight = '' } = style
   const mode = getTextStyleMode(editor)
 
+  let imageHtml = ''
+
   if (mode === 'class') {
     // class 模式下不输出 inline style
     const exportedWidth = width || styleWidth
@@ -22,14 +24,16 @@ function imageToHtml(elemNode: Element, _childrenHtml: string, editor?: IDomEdit
     const widthData = styleWidth ? ` data-w-e-style-width="${styleWidth}"` : ''
     const heightData = styleHeight ? ` data-w-e-style-height="${styleHeight}"` : ''
 
-    return `<img src="${src}" alt="${alt}" data-href="${href}" width="${exportedWidth}" height="${exportedHeight}"${widthData}${heightData}/>`
+    imageHtml = `<img src="${src}" alt="${alt}" data-href="${href}" width="${exportedWidth}" height="${exportedHeight}"${widthData}${heightData}/>`
+  } else {
+    let styleStr = ''
+
+    if (styleWidth) { styleStr += `width: ${styleWidth};` }
+    if (styleHeight) { styleStr += `height: ${styleHeight};` }
+    imageHtml = `<img src="${src}" alt="${alt}" data-href="${href}" width="${width}" height="${height}" style="${styleStr}"/>`
   }
 
-  let styleStr = ''
-
-  if (styleWidth) { styleStr += `width: ${styleWidth};` }
-  if (styleHeight) { styleStr += `height: ${styleHeight};` }
-  return `<img src="${src}" alt="${alt}" data-href="${href}" width="${width}" height="${height}" style="${styleStr}"/>`
+  return href ? `<a href="${href}" target="_blank">${imageHtml}</a>` : imageHtml
 }
 
 export const imageToHtmlConf = {

--- a/packages/basic-modules/src/modules/image/render-elem.tsx
+++ b/packages/basic-modules/src/modules/image/render-elem.tsx
@@ -5,13 +5,12 @@
 
 import { DomEditor, IDomEditor } from '@wangeditor-next/core'
 import throttle from 'lodash.throttle'
-import { Element as SlateElement } from 'slate'
+import { Element as SlateElement, Transforms } from 'slate'
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { jsx, VNode } from 'snabbdom'
 
 import $, { Dom7Array } from '../../utils/dom'
 import { ImageElement } from './custom-types'
-import { updateImageSize } from './resize'
 
 interface IImageSize {
   width?: string
@@ -109,16 +108,16 @@ function renderResizeContainer(
     const newWidth = $container.width().toFixed(2)
     const newHeight = $container.height().toFixed(2)
 
-    const resizeUnit = editor.getConfig().imageResize?.resizeUnit
-    const resizedWidth = resizeUnit === '%' && maxWidth > 0
-      ? `${((Number(newWidth) / maxWidth) * 100).toFixed(2)}%`
-      : `${newWidth}px`
-    const resizedHeight = resizeUnit === '%' ? '' : `${newHeight}px`
-
-    if (!updateImageSize(editor, elemNode, resizedWidth, resizedHeight, 'drag')) {
-      $container.css('width', `${originalWith}px`)
-      $container.css('height', `${originalHeight}px`)
+    // 修改 node
+    const props: Partial<ImageElement> = {
+      style: {
+        ...(elemNode as ImageElement).style,
+        width: `${newWidth}px`,
+        height: `${newHeight}px`,
+      },
     }
+
+    Transforms.setNodes(editor, props, { at: DomEditor.findPath(editor, elemNode) })
 
     // 取消监听 mouseup
     $body.off('mouseup', onMouseup)
@@ -221,7 +220,14 @@ function renderImage(elemNode: SlateElement, children: VNode[] | null, editor: I
   if (height) { imageStyle.height = '100%' }
 
   // 【注意】void node 中，renderElem 不用处理 children 。core 会统一处理。
-  const vnode = <img style={imageStyle} src={src} alt={alt} data-href={href} />
+  const imageVnode = <img style={imageStyle} src={src} alt={alt} data-href={href} />
+  const vnode = href ? (
+    <a href={href} target="_blank">
+      {imageVnode}
+    </a>
+  ) : (
+    imageVnode
+  )
 
   const isDisabled = editor.isDisabled()
 

--- a/packages/basic-modules/src/modules/link/parse-elem-html.ts
+++ b/packages/basic-modules/src/modules/link/parse-elem-html.ts
@@ -4,24 +4,54 @@
  */
 
 import { IDomEditor } from '@wangeditor-next/core'
-import { Descendant, Text } from 'slate'
+import { Descendant, Element, Text } from 'slate'
 
 import $, { DOMElement } from '../../utils/dom'
+import { ImageElement } from '../image/custom-types'
 import { LinkElement } from './custom-types'
 import { normalizeLinkUrl } from './url'
 
-function parseHtml(elem: DOMElement, children: Descendant[], editor: IDomEditor): LinkElement {
+function parseHtml(
+  elem: DOMElement,
+  children: Descendant[],
+  editor: IDomEditor
+): LinkElement | ImageElement {
   const $elem = $(elem)
 
   children = children.filter(child => {
-    if (Text.isText(child)) { return true }
-    if (editor.isInline(child)) { return true }
+    if (Text.isText(child)) {
+      return true
+    }
+    if (editor.isInline(child)) {
+      return true
+    }
     return false
   })
 
   // 无 children ，则用纯文本
   if (children.length === 0) {
     children = [{ text: $elem.text().replace(/\s+/gm, ' ') }]
+  }
+
+  // Images store their link on the image node, so restore that shape when
+  // reading the semantic anchor emitted by the image serializer.
+  const imageChild = children[0]
+  const imageHref =
+    Element.isElement(imageChild) && imageChild.type === 'image'
+      ? (imageChild as { href?: string }).href || ''
+      : ''
+  const dataHref = $elem.find('img').attr('data-href') || ''
+
+  if (
+    children.length === 1 &&
+    Element.isElement(imageChild) &&
+    imageChild.type === 'image' &&
+    (imageHref || dataHref)
+  ) {
+    return {
+      ...(imageChild as ImageElement),
+      href: normalizeLinkUrl($elem.attr('href') || ''),
+    }
   }
 
   return {

--- a/tests/e2e/framework-regression.spec.ts
+++ b/tests/e2e/framework-regression.spec.ts
@@ -2014,6 +2014,57 @@ test.describe('Framework parity regression', () => {
       expect(pageErrors).toEqual([])
     })
 
+    test(`${target.name}: linked images in table cells should render as anchors`, async ({
+      page,
+    }) => {
+      const pageErrors: string[] = []
+
+      page.on('pageerror', err => {
+        pageErrors.push(err?.stack || err?.message || String(err))
+      })
+
+      await openTarget(page, target)
+
+      const state = await page.evaluate(() => {
+        const globalWindow = window as any
+        const editor =
+          globalWindow.wangEditorExampleBridge?.editor ||
+          globalWindow.vue2Editor ||
+          globalWindow.vue3Editor ||
+          globalWindow.reactEditor
+
+        if (!editor) {
+          throw new Error('editor not ready')
+        }
+
+        editor.setHtml(
+          '<table><tbody><tr><td><img src="https://example.com/table-cell.png" alt="table image" data-href="https://example.com/image-target" /></td></tr></tbody></table><p>after</p>'
+        )
+
+        const image = editor.getElemsByTypePrefix?.('image')?.[0]
+        const html = editor.getHtml()
+
+        editor.setHtml(html)
+
+        return {
+          imageHref: image?.href || '',
+          html,
+          reparsedImageHref: editor.getElemsByTypePrefix?.('image')?.[0]?.href || '',
+        }
+      })
+
+      const linkedImage = page.locator(
+        '[data-testid="editor-textarea"] table td a[href="https://example.com/image-target"] img'
+      )
+
+      await expect(linkedImage).toHaveCount(1)
+      await expect(linkedImage.locator('..')).toHaveAttribute('target', '_blank')
+      expect(state.imageHref).toBe('https://example.com/image-target')
+      expect(state.reparsedImageHref).toBe('https://example.com/image-target')
+      expect(state.html).toContain('<a href="https://example.com/image-target" target="_blank">')
+      expect(pageErrors).toEqual([])
+    })
+
     test(`${target.name}: backspace should remove an empty paragraph before table video`, async ({
       page,
     }) => {


### PR DESCRIPTION
## Summary

- render and export linked image nodes as semantic `<a href>` anchors
- restore image anchors to `image.href` when parsing, preserving legacy `data-href` documents
- add table-cell round-trip coverage and four-framework browser regression coverage

Fixes #1009

## Reproduction

On current master, a table-cell image configured with a link renders only `data-href` and has no clickable anchor. Chromium reproduction confirmed the missing anchor and no page errors.

## Compatibility

The Slate model remains an `image` void node. Existing `data-href` attributes remain on serialized images for compatibility; semantic anchors are flattened back to `image.href` on import.

## Validation

- `@wangeditor-next/basic-modules`: 91 files, 311 tests passed
- `@wangeditor-next/table-module`: 30 files, 275 tests passed
- Chromium framework regression: HTML core, Vue 2, Vue 3, React, 4/4 passed
- affected ESLint, incremental builds, and `git diff --check` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Linked images now render as clickable links that open in a new tab.
  - Linked-image data is preserved when content is exported, imported, or reloaded, including images in table cells.

- **Bug Fixes**
  - Improved handling of linked images during HTML parsing and rendering.
  - Image resizing now reliably preserves updated dimensions.

- **Tests**
  - Added coverage for linked images, HTML round trips, and linked images within tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->